### PR TITLE
Fix the issue of RecursionError when use fast tokenizer

### DIFF
--- a/workflows/chatbot/finetune_clm.py
+++ b/workflows/chatbot/finetune_clm.py
@@ -73,7 +73,7 @@ class ModelArguments:
         metadata={"help": "Where do you want to store the pretrained models downloaded from huggingface.co"},
     )
     use_fast_tokenizer: bool = field(
-        default=True,
+        default=False,
         metadata={"help": "Whether to use one of the fast tokenizer (backed by the tokenizers library) or not."},
     )
     model_revision: str = field(


### PR DESCRIPTION
## Type of Change
bug fix 


## Description

when use fast tokenizer, the code would stop in line400 with RecursionError of Python object, try not using it or turn to  replace AutoTokenizer with LlamaTokenizer could avoid the error.

