### PR TITLE
[Graph]Add AMX_BF16 and AMX_INT8 kernels (#1239)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,3 +27,4 @@
 
 /intel_extension_for_transformers/backends/neural_engine/Cmake* yu.luo@intel.com
 /intel_extension_for_transformers/backends/neural_engine/cmake/ yu.luo@intel.com
+/intel_extension_for_transformers/backends/neural_engine/graph/jblas yu.luo@intel.com

--- a/intel_extension_for_transformers/backends/neural_engine/graph/CMakeLists.txt
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/CMakeLists.txt
@@ -74,6 +74,14 @@ option(NE_PROFILING              "neural_engine: use Profiling"                 
 if (NE_PROFILING)
     add_compile_definitions(NE_PERF)
 endif()
+option(NE_GELU_VEC               "neural_engine: enable vec in gelu"                             ON)
+if (NE_GELU_VEC)
+    add_compile_definitions(NE_GELU_USE_VEC)
+endif()
+
+if(NE_BUILD_TESTS)
+    enable_testing()
+endif()
 
 if (MSVC)
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS NOMINMAX)

--- a/intel_extension_for_transformers/backends/neural_engine/graph/CMakePresets.json
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/CMakePresets.json
@@ -24,21 +24,6 @@
       "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" }
     },
     {
-      "name": "macos-debug",
-      "displayName": "macOS Debug",
-      "description": "Target a remote macOS system.",
-      "generator": "Ninja",
-      "binaryDir": "${sourceDir}/out/build/${presetName}",
-      "installDir": "${sourceDir}/out/install/${presetName}",
-      "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" },
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Darwin"
-      },
-      "vendor": { "microsoft.com/VisualStudioRemoteSettings/CMake/1.0": { "sourceDir": "$env{HOME}/.vs/$ms{projectDirName}" } }
-    },
-    {
       "name": "windows-base",
       "description": "Target Windows with the Visual Studio development environment.",
       "hidden": true,
@@ -71,24 +56,6 @@
       "displayName": "x64 Release",
       "description": "Target Windows (64-bit) with the Visual Studio development environment. (RelWithDebInfo)",
       "inherits": "x64-debug",
-      "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" }
-    },
-    {
-      "name": "x86-debug",
-      "displayName": "x86 Debug",
-      "description": "Target Windows (32-bit) with the Visual Studio development environment. (Debug)",
-      "inherits": "windows-base",
-      "architecture": {
-        "value": "x86",
-        "strategy": "external"
-      },
-      "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" }
-    },
-    {
-      "name": "x86-release",
-      "displayName": "x86 Release",
-      "description": "Target Windows (32-bit) with the Visual Studio development environment. (RelWithDebInfo)",
-      "inherits": "x86-debug",
       "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" }
     }
   ]

--- a/intel_extension_for_transformers/backends/neural_engine/graph/application/ChatGPTJ/pybind_gptj.cpp
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/application/ChatGPTJ/pybind_gptj.cpp
@@ -50,9 +50,10 @@ bool gptj_model_eval_ids(model_context* ctx, model_token* tokens, size_t n_eval,
 
 extern "C" {
 void* init_gptj(int seed, int n_predict, int n_batch, int top_k, float top_p, float temp, float repeat_penalty,
-                bool perplexity, int n_ctx, const char* model_file) {
+                bool perplexity, int n_ctx, const char* model_file, bool beam_search = false, int beam_size = 4,
+                int batch_size = 1, int n_threads = 56) {
   gpt_params params;
-  params.n_threads = N_threads;
+  params.n_threads = n_threads;
   params.seed = seed;
   params.name = MODEL_GPTJ;
   params.n_ctx = n_ctx;
@@ -65,6 +66,11 @@ void* init_gptj(int seed, int n_predict, int n_batch, int top_k, float top_p, fl
   params.temp = temp;
   params.repeat_penalty = repeat_penalty;
   params.perplexity = perplexity;
+  params.batch_size = batch_size;
+  params.beam_search = beam_search;
+  params.beam_size = beam_size;
+  // params.use_mmap = false;
+  // params.use_mlock= true;
   model_init_backend();
   model_context* ctx;
   g_ctx = &ctx;
@@ -77,53 +83,59 @@ void* init_gptj(int seed, int n_predict, int n_batch, int top_k, float top_p, fl
 }
 
 int32_t* eval_gptj_ids(void* ctx, int32_t* embd_inp_ptr, int ind_size, int n_predict, int top_k, float top_p,
-                       float temp, int n_batch) {
+                       float temp, int n_batch, int n_threads) {
   model_context* lctx = (model_context*)ctx;
   int n_past = 0;
 
   auto hparams = lctx->model.hparams;
-  std::vector<model_token> embd_inp(embd_inp_ptr, embd_inp_ptr + ind_size);
+
   n_predict = std::min(n_predict, (int)hparams.n_ctx - (int)ind_size);
   std::vector<model_token> res;
-  std::vector<model_token> embd;
+  bool do_beam_search = lctx->beam_search;
 
-  for (int i = embd.size(); i < embd_inp.size() + n_predict; i++) {
-    // predict
-    if (embd.size() > 0) {
-      if (!gptj_model_eval_ids(lctx, embd.data(), embd.size(), n_past, N_threads)) {
-        printf("Failed to predict\n");
-        return {};
-      }
-    }
-
-    auto logits = model_get_logits(lctx);
-    n_past += embd.size();
-    embd.clear();
-
-    if (i >= embd_inp.size()) {
-      const int n_vocab = hparams.n_vocab;
-      gpt_vocab::id id = 0;
-      id = model_sample_top_k_top_p(lctx, n_vocab, logits, top_k, top_p, temp);
-      // add it to the context
-      embd.push_back(id);
-      res.push_back(id);
-    } else {
-      // if here, it means we are still processing the input prompt
-      for (int k = i; k < embd_inp.size(); k++) {
-        embd.push_back(embd_inp[k]);
-        if (embd.size() > n_batch) {
-          break;
+  if (do_beam_search) {
+    res = beam_search(lctx->beam_size, n_predict, lctx, embd_inp_ptr, ind_size, n_threads);
+  } else {
+    std::vector<model_token> embd_inp(embd_inp_ptr, embd_inp_ptr + ind_size);
+    std::vector<model_token> embd;
+    for (int i = embd.size(); i < embd_inp.size() + n_predict; i++) {
+      // predict
+      if (embd.size() > 0) {
+        if (!gptj_model_eval_ids(lctx, embd.data(), embd.size(), n_past, n_threads)) {
+          printf("Failed to predict\n");
+          return {};
         }
       }
-      i += embd.size() - 1;
-    }
 
-    // end of text token
-    if (embd.back() == 50256) {
-      break;
+      auto logits = model_get_logits(lctx);
+      n_past += embd.size();
+      embd.clear();
+
+      if (i >= embd_inp.size()) {
+        const int n_vocab = hparams.n_vocab;
+        gpt_vocab::id id = 0;
+        id = model_sample_top_k_top_p(lctx, n_vocab, logits, top_k, top_p, temp);
+        // add it to the context
+        embd.push_back(id);
+        res.push_back(id);
+      } else {
+        // if here, it means we are still processing the input prompt
+        for (int k = i; k < embd_inp.size(); k++) {
+          embd.push_back(embd_inp[k]);
+          if (embd.size() > n_batch) {
+            break;
+          }
+        }
+        i += embd.size() - 1;
+      }
+
+      // end of text token
+      if (embd.back() == 50256) {
+        break;
+      }
     }
   }
-  int32_t* res_ptr = new int32_t[res.size()+1];
+  int32_t* res_ptr = new int32_t[res.size() + 1];
   res_ptr[0] = res.size();
   std::copy(res.begin(), res.end(), &res_ptr[1]);
   return res_ptr;
@@ -134,48 +146,59 @@ char* eval_gptj_char(void* ctx, const char* prom, int n_predict, int top_k, floa
   int n_past = 0;
 
   auto hparams = lctx->model.hparams;
-  std::vector<float> logits;
   std::vector<model_token> embd_inp = ::model_tokenize(lctx, std::string(prom), false);
   n_predict = std::min(n_predict, (int)hparams.n_ctx - (int)embd_inp.size());
   std::string res;
   std::vector<model_token> embd;
 
-  for (int i = embd.size(); i < embd_inp.size() + n_predict; i++) {
-    // predict
-    if (embd.size() > 0) {
-      if (!gptj_model_eval_ids(lctx, embd.data(), embd.size(), n_past, N_threads)) {
-        printf("Failed to predict\n");
-        return {};
-      }
-    }
-
-    auto logits = model_get_logits(lctx);
-    n_past += embd.size();
-    embd.clear();
-
-    if (i >= embd_inp.size()) {
-      const int n_vocab = hparams.n_vocab;
-      model_token id = 0;
-      id = model_sample_top_k_top_p(lctx, n_vocab, logits, top_k, top_p, temp);
-      // add it to the context
-      embd.push_back(id);
-    } else {
-      // if here, it means we are still processing the input prompt
-      for (int k = i; k < embd_inp.size(); k++) {
-        embd.push_back(embd_inp[k]);
-        if (embd.size() > n_batch) {
-          break;
-        }
-      }
-      i += embd.size() - 1;
+  bool do_beam_search = lctx->beam_search;
+  if (do_beam_search) {
+    embd = beam_search(lctx->beam_size, n_predict, lctx, embd_inp.data(), embd_inp.size(), N_threads);
+    for (auto id : embd_inp) {
+      res += model_token_to_str(lctx, id);
     }
     for (auto id : embd) {
       res += model_token_to_str(lctx, id);
     }
+  } else {
+    std::vector<float> logits;
+    for (int i = embd.size(); i < embd_inp.size() + n_predict; i++) {
+      // predict
+      if (embd.size() > 0) {
+        if (!gptj_model_eval_ids(lctx, embd.data(), embd.size(), n_past, N_threads)) {
+          printf("Failed to predict\n");
+          return {};
+        }
+      }
 
-    // end of text token
-    if (embd.back() == 50256) {
-      break;
+      auto logits = model_get_logits(lctx);
+      n_past += embd.size();
+      embd.clear();
+
+      if (i >= embd_inp.size()) {
+        const int n_vocab = hparams.n_vocab;
+        model_token id = 0;
+        id = model_sample_top_k_top_p(lctx, n_vocab, logits, top_k, top_p, temp);
+        // add it to the context
+        embd.push_back(id);
+      } else {
+        // if here, it means we are still processing the input prompt
+        for (int k = i; k < embd_inp.size(); k++) {
+          embd.push_back(embd_inp[k]);
+          if (embd.size() > n_batch) {
+            break;
+          }
+        }
+        i += embd.size() - 1;
+      }
+      for (auto id : embd) {
+        res += model_token_to_str(lctx, id);
+      }
+
+      // end of text token
+      if (embd.back() == 50256) {
+        break;
+      }
     }
   }
 
@@ -190,20 +213,99 @@ void exit_gptj(void* ctx) {
 }
 }
 
-int main() {
-  auto gptj_in_all = init_gptj(1234, 32, 32, 40, 1.0, 0.8, 1.02, false, 2048, "/home/hengyume/model/gptj-f32.bin");
-  auto res = eval_gptj_char(gptj_in_all, "she opened the door and saw", 32, 40, 1.0, 0.8, 32);
-  std::cout << res << std::endl;
-  auto res1 = eval_gptj_char(gptj_in_all,
-                             "Once upon a time, there existed a little girl, who liked to have adventures. She wanted "
-                             "to go to places and meet new people, and have fun",
-                             32, 40, 1.0, 0.8, 32);
-  std::cout << res1 << std::endl;
-  std::vector<int32_t> embd_inp = {7091, 4721, 262, 3420, 290, 2497};
-  auto res_ids = eval_gptj_ids(gptj_in_all, embd_inp.data(), embd_inp.size(), 32, 40, 1.0, 0.8, 32);
-  exit_gptj(gptj_in_all);
-  delete[] res;
-  delete[] res1;
-  delete[] res_ids;
+int main(int argc, char* argv[]) {
+  if (argc != 2) {
+    std::cout << "Usage: ./pybind_gptj <model_filename>\n";
+    return 1;
+  }
+
+  auto gptj_in_all_bs = init_gptj(1234, 32, 32, 40, 1.0, 0.8, 1.02, false, 2048, argv[1], true, 4, 1);
+  std::vector<void*> ctxs = {gptj_in_all_bs};
+  for (auto gptj_in_all : ctxs) {
+    auto res = eval_gptj_char(
+        gptj_in_all,
+        "2017: It is done, and submitted. You can play 'Survival of the Tastiest' on Android, and on the web. Playing "
+        "on the web works, but you have to simulate multiple touch for table moving and that can be a bit confusing. "
+        "There is a lot I'd like to talk about. I will go through every topic, insted of making the typical what went "
+        "right/wrong list. Concept Working over the theme was probably one of the hardest tasks which I had to face. "
+        "Originally, I had an idea of what kind of game I wanted to develop, gameplay wise - something with a lot of "
+        "enemies/actors, simple graphics, maybe set in space, controlled from a top-down view. I was confident that I "
+        "could fit any theme around it. In the end, the problem with a theme like 'Evolution' in a game is that "
+        "evolution is unassisted. It happens through several seemingly random mutations over time, with the most apt "
+        "permutation surviving. This genetic car simulator is, in my opinion, a great example of actual evolution of a "
+        "species facing a challenge. But is it a game? In a game, you need to control something to reach an objective. "
+        "That control goes against what evolution is supposed to be like. If you allow the user to pick how to evolve "
+        "something, it's not evolution anymore - it's the equivalent of intelligent design, the fable invented by "
+        "creationists to combat the idea of evolution. Being agnostic and a Pastafarian, that's not something that "
+        "rubbed me the right way. Hence, my biggest dillema when deciding what to create was not with what I wanted to "
+        "create, but with what I did not. I didn't want to create an 'intelligent design' simulator and wrongly call "
+        "it evolution. This is a problem, of course, every other contestant also had to face. And judging by the "
+        "entries submitted, not many managed to work around it. I'd say the only real solution was through the use of "
+        "artificial selection, somehow. So far, I haven't seen any entry using this at its core gameplay. Alas, this "
+        "is just a fun competition and after a while I decided not to be as strict with the game idea, and allowed "
+        "myself to pick whatever I thought would work out. My initial idea was to create something where humanity "
+        "tried to evolve to a next level, but had some kind of foe trying to stop them from doing so. I kind of had "
+        "this image of human souls flying in space towards a monolith or a space baby (all based in 2001: A Space "
+        "Odyssey of course) but I couldn't think of compelling (read: serious) mechanics for that. Borgs were my next "
+        "inspiration, as their whole hypothesis fit pretty well into the evolution theme. But how to make it work? Are "
+        "you the borg, or fighting the Borg? The third and final idea came to me through my girlfriend, who somehow "
+        "gave me the idea of making something about the evolution of Pasta. The more I thought about it the more it "
+        "sounded like it would work, so I decided to go with it. Conversations with my inspiring co-worker Roushey "
+        "(who also created the 'Mechanical Underdogs' signature logo for my intros) further matured the concept, as it "
+        "involved into the idea of having individual pieces of pasta flying around and trying to evolve until they "
+        "became all-powerful. A secondary idea here was that the game would work to explain how the Flying Spaghetti "
+        "Monster came to exist - by evolving from a normal dinner table. So the idea evolved more or less into this: "
+        "you are sitting a table. You have your own plate, with is your 'base'. There are 5 other guests at the table, "
+        "each with their own plate. Your plate can spawn little pieces of pasta. You do so by 'ordering' them through "
+        "a menu. Some pastas are better than others; some are faster, some are stronger. They have varying 'costs', "
+        "which are debited from your credits (you start with a number of credits). Once spawned, your pastas start "
+        "flying around. Their instinct is to fly to other plates, in order to conquer them (the objective of the game "
+        "is having your pasta conquer all the plates on the table). But they are really autonomous, so after being "
+        "spawned, you have no control over your pasta (think DotA or LoL creeps). Your pasta doesn't like other "
+        "people's pasta, so if they meet, they shoot sauce at each other until one dies. You get credits for other "
+        "pastas your own pasta kill. Once a pasta is in the vicinity of a plate, it starts conquering it for its team. "
+        "It takes around 10 seconds for a plate to be conquered; less if more pasta from the same team are around. If "
+        "pasta from other team are around, though, they get locked down in their attempt, unable to conquer the plate, "
+        "until one of them die (think Battlefield's standard 'Conquest' mode). You get points every second for every "
+        "plate you own. Over time, the concept also evolved to use an Italian bistro as its main scenario. Carlos, "
+        "Carlos' Bistro's founder and owner Setup No major changes were made from my work setup. I used FDT and "
+        "Starling creating an Adobe AIR (ActionScript) project, all tools or frameworks I already had some knowledge "
+        "with. One big change for me was that I livestreamed my work through a twitch.tv account. This was a new thing "
+        "for me. As recommended by Roushey, I used a program called XSplit and I got to say, it is pretty amazing. It "
+        "made the livestream pretty effortless and the features are awesome, even for the free version. It was great "
+        "to have some of my friends watch me, and then interact with them and random people through chat. It was also "
+        "good knowing that I was also recording a local version of the files, so I could make a timelapse video later. "
+        "Knowing the video was being recorded also made me a lot more self-conscious about my computer use, as if "
+        "someone was watching over my shoulder. It made me realize that sometimes I spend too much time in seemingly "
+        "inane tasks (I ended up wasting the longest time just to get some text alignment the way I wanted - it'll "
+        "probably drive someone crazy if they watch it) and that I do way too many typos where writing code. I pretty "
+        "much spend half of the time writing a line and the other half fixing the crazy characters in it. My own "
+        "stream was probably boring to watch since I was coding for the most time. But livestreaming is one of the "
+        "cool things to do as a spectator too. It was great seeing other people working - I had a few tabs opened on "
+        "my second monitor all the time. It's actually a bit sad, because if I could, I could have spent the whole "
+        "weekend just watching other people working! But I had to do my own work, so I'd only do it once in a while, "
+        "when resting for a bit. Design Although I wanted some simple, low-fi, high-contrast kind of design, I ended "
+        "up going with somewhat realistic (vector) art. I think it worked very well, fitting the mood of the game, but "
+        "I also went overboard. For example: to know the state of a plate (who owns it, who's conquering it and how "
+        "much time they have left before conquering it, which pasta units are in the queue, etc), you have to look at "
+        "the plate's bill. The problem I realized when doing some tests is that people never look at the bill! They "
+        "think it's some kind of prop, so they never actually read its details. Plus, if you're zoomed out too much, "
+        "you can't actually read it, so it's hard to know what's going on with the game until you zoom in to the area "
+        "of a specific plate. One other solution that didn't turn out to be as perfect as I thought was how to "
+        "indicate who a plate base belongs to. In the game, that's indicated by the plate's decoration - its color "
+        "denotes the team owner. But it's something that fits so well into the design that people never realized it, "
+        "until they were told about it. In the end, the idea of going with a full physical metaphor is one that should "
+        "be done with care. Things that are very important risk becoming background noise, unless the player knows its "
+        "importance. Originally, I wanted to avoid any kind of heads-up display in my game. In the end, I ended up "
+        "adding it at the bottom to indicate your credits and bases owned, as well as the hideous "
+        "out-of-place-and-still-not-obvious 'Call Waiter' button. But in hindsight, I should have gone with a simple "
+        "HUD from the start, especially one that indicated each team's colors and general state of the game without "
+        "the need for zooming in and out. Development Development went fast.",
+        10, 40, 1.0, 0.8, 2048);
+    std::cout << res << std::endl;
+    exit_gptj(gptj_in_all);
+    delete[] res;
+    // delete[] res_ids;
+  }
   return 0;
 }

--- a/intel_extension_for_transformers/backends/neural_engine/graph/application/ChatGPTJ/quant_gptj.cpp
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/application/ChatGPTJ/quant_gptj.cpp
@@ -33,9 +33,9 @@ class gptj_quant_layer : public quant_layer_base {
   virtual quant_params_internal get_layer_config(std::string layername, std::vector<int64_t> ne,
                                                  ne_type type) override {
     bool quantize = layername.rfind("weight") == layername.size() - 6;  // ends with 'weight'?
-    if (layername == "transformer.wte.weight") {
+    if (layername == "transformer.wte.weight" || layername == "lm_head.weight") {
       // special layer process, can be loaded by config file
-      return quant_params_internal();  // return q4_0 to cover the usage of getrow
+      return quant_params_internal{quant_bits::count};  // skip for head and tail layers
     }
     quantize &= (ne.size() == 2);
     if (quantize) {

--- a/intel_extension_for_transformers/backends/neural_engine/graph/application/common.cpp
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/application/common.cpp
@@ -786,21 +786,13 @@ size_t jblas_quantize(const float* f32ptr, void* dstpr, const quant_params param
     if (params.compute_type == "int8") {
       using GemmKernel = jblas::wrapper::gemm_default::weight_comp::avx512_vnni::GemmKernelDynamicQuantS4KBlock;
       static GemmKernel kernel;
-      if (cd->AVX512F()) {
-        packedw =
-            kernel.getWeightPtr()->compressWeightTranspose<JblasAVX512F>(n, k, f32ptr, k, params.block_size, type);
-      } else {
-        packedw = kernel.getWeightPtr()->compressWeightTranspose<JblasNoSIMD>(n, k, f32ptr, k, params.block_size, type);
-      }
+      assert(cd->AVX512F());
+      packedw = kernel.getWeightPtr()->compressWeightTranspose(n, k, f32ptr, k, params.block_size, type);
     } else if (params.compute_type == "fp32") {
       using GemmKernel = jblas::wrapper::gemm_default::weight_comp::avx512f::GemmKernelS4KBlock;
       static GemmKernel kernel;
-      if (cd->AVX512F()) {
-        packedw =
-            kernel.getWeightPtr()->compressWeightTranspose<JblasAVX512F>(n, k, f32ptr, k, params.block_size, type);
-      } else {
-        packedw = kernel.getWeightPtr()->compressWeightTranspose<JblasNoSIMD>(n, k, f32ptr, k, params.block_size, type);
-      }
+      assert(cd->AVX512F());
+      packedw = kernel.getWeightPtr()->compressWeightTranspose(n, k, f32ptr, k, params.block_size, type);
     }
   } else if (params.bits == 8) {
     // TODO add 8bit quantization

--- a/intel_extension_for_transformers/backends/neural_engine/graph/core/CMakeLists.txt
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/core/CMakeLists.txt
@@ -26,3 +26,32 @@ if(NOT WIN32)
   target_link_libraries(ne_layers PUBLIC rt)
 endif()
 
+add_compile_definitions(NE_USE_RN_BF16FP16=1)
+
+
+if (NE_BUILD_TESTS)
+
+function(add_test_target src)
+  get_filename_component(test_target ${src} NAME_WE)
+  get_filename_component(src_dir ${src} DIRECTORY)
+  string(REGEX REPLACE [/\\] "_" src_dir ${src_dir})
+  if(src_dir)
+    set (test_target "${src_dir}_${test_target}")
+  endif()
+  set (test_target "test_${test_target}")
+  add_executable_w_warning(${test_target} ${src})
+  target_compile_definitions(${test_target} PRIVATE NE_TESTS)
+  target_compile_options(${test_target} PRIVATE -fsanitize=address)
+  target_link_options(${test_target} PRIVATE -fsanitize=address)
+  target_include_directories(${test_target} PUBLIC .)
+  target_link_libraries(${test_target} PUBLIC Threads::Threads jblas::jblas ne_vec)
+  if(NOT WIN32)
+    target_link_libraries(${test_target} PUBLIC rt)
+  endif()
+  add_test(NAME ${test_target} COMMAND ${test_target})
+  set_tests_properties(${test_target} PROPERTIES LABELS "${src_dir}_test")
+endfunction()
+
+add_test_target(layers/mha_dense.cpp)
+
+endif()

--- a/intel_extension_for_transformers/backends/neural_engine/graph/core/data_types.h
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/core/data_types.h
@@ -13,10 +13,11 @@
 //  limitations under the License.
 #pragma once
 
-#include <stdint.h>
-#include <stddef.h>
-#include <stdbool.h>
 #include <assert.h>
+#include <math.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <string.h>
 
 #ifdef __cplusplus
@@ -26,6 +27,7 @@ extern "C" {
 // floating point type used to accumulate sums
 typedef double ne_float;
 typedef uint16_t ne_fp16_t;
+typedef uint16_t ne_bf16_t;
 
 enum ne_type {
   NE_TYPE_F32 = 0,

--- a/intel_extension_for_transformers/backends/neural_engine/graph/core/layers/Ops.h
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/core/layers/Ops.h
@@ -47,7 +47,7 @@ enum ne_op {
   NE_OP_RMS_NORM_BACK,
 
   NE_OP_MUL_MAT,
-
+  NE_OP_MUL_MAT_BIAS,
   NE_OP_SCALE,
   NE_OP_SET,
   NE_OP_CPY,
@@ -72,6 +72,8 @@ enum ne_op {
   // LLM related
   NE_OP_MUL_QKV,
   NE_OP_MUL_FFN_SILU,
+  NE_OP_MUL_FFN_GELU,
+  NE_OP_MUL_FFN_ADD_GELU,
   NE_OP_FLASH_ATTN,
   NE_OP_FLASH_FF,
 

--- a/intel_extension_for_transformers/backends/neural_engine/graph/core/layers/ele_wise.h
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/core/layers/ele_wise.h
@@ -40,6 +40,14 @@ inline static void ne_vec_set_f16(const int n, ne_fp16_t* x, const int32_t v) {
   for (int i = 0; i < n; ++i) x[i] = v;
 }
 
+inline static void ne_vec_srl_i32(const int n, int32_t* z, const int32_t* x, int32_t v) {
+  for (int i = 0; i < n; ++i) z[i] = x[i] >> v;
+}
+
+inline static void ne_vec_and_i32(const int n, int32_t* z, const int32_t* x, const int32_t* y) {
+  for (int i = 0; i < n; ++i) z[i] = x[i] & y[i];
+}
+
 inline static void ne_vec_add_f32(const int n, float* z, const float* x, const float* y) {
   for (int i = 0; i < n; ++i) z[i] = x[i] + y[i];
 }
@@ -171,22 +179,38 @@ inline static void ne_vec_gelu_f16(const int n, ne_fp16_t* y, const ne_fp16_t* x
   }
 }
 
-#ifdef NE_GELU_FP16
-inline static void ne_vec_gelu_f32(const int n, float* y, const float* x) {
-  uint16_t t;
-  for (int i = 0; i < n; ++i) {
-    ne_fp16_t fp16 = NE_FP32_TO_FP16(x[i]);
-    memcpy(&t, &fp16, sizeof(uint16_t));
-    y[i] = NE_FP16_TO_FP32(table_gelu_f16[t]);
-  }
+inline static void ne_vec_tanh_f32(const int n, float* y, const float* x) {
+  for (int i = 0; i < n; i++) y[i] = tanhf(x[i]);
 }
-#else
+
 inline static void ne_vec_gelu_f32(const int n, float* y, const float* x) {
+#ifdef NE_GELU_USE_VEC
+  // compute G(x) = sqrt_root_two_over_pi * x * (1 + fitting_const * x * x)
+  float* aux0 = (float*)malloc(n * sizeof(float));
+  ne_vec_sqr_f32(n, aux0, x);
+  float* aux1 = (float*)malloc(n * sizeof(float));
+  ne_vec_set_f32(n, aux1, 1.0f);
+  ne_vec_mad_f32(n, aux1, aux0, GELU_COEF_A);
+  ne_vec_mul_f32(n, aux0, x, aux1);
+  ne_vec_set_f32(n, aux1, SQRT_2_OVER_PI);
+  ne_vec_mul_f32(n, aux1, aux0, aux1);
+
+  // compute tanh(G(x))
+  ne_vec_tanh_f32(n, aux0, aux1);
+  // Gelu(x)= 0.5f * x * (1.0f + tanh(G(x)))
+  ne_vec_acc1_f32(n, aux0, 1.0f);
+  ne_vec_mul_f32(n, y, x, aux0);
+  ne_vec_set_f32(n, aux0, 0.5f);
+  ne_vec_mul_f32(n, y, y, aux0);
+
+  free(aux0);
+  free(aux1);
+#else
   for (int i = 0; i < n; ++i) {
     y[i] = ne_gelu_f32(x[i]);
   }
-}
 #endif
+}
 
 // Sigmoid Linear Unit (SiLU) function
 inline static float ne_silu_f32(float x) { return x / (1.0f + expf(-x)); }

--- a/intel_extension_for_transformers/backends/neural_engine/graph/core/layers/inner_product.cpp
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/core/layers/inner_product.cpp
@@ -17,21 +17,46 @@
 #include "jblas/jit_blas_transformer.h"
 
 using namespace jblas;
-
+void jblas_init() {
+  GetCPUDevice();
+  if (_cd->AMX_BF16() || _cd->AMX_INT8()) {
+    utils::request_perm_xtile_data();
+  }
+  _cd->print();
+}
 void jblas_weights4block_f32_forward(float* activation, void* weiptr, float* output, int _m, int _n, int _k, int lda,
                                      int ldo) {
+  GetCPUDevice();
+  auto ret = JblasRuntimeError;
   auto wtmp = prologue::weight_comp::gemm::CompressedPackedWeight::deserialBuffer(weiptr, 0);
-  if (wtmp->mCoreType == jblas::gemm::GemmCoreType::AVX512_VNNI_8X48 ||
+  if (wtmp->mCoreType == jblas::gemm::GemmCoreType::AMX_INT8_16X48_KBLOCK ||
+      wtmp->mCoreType == jblas::gemm::GemmCoreType::AVX512_VNNI_8X48 ||
       wtmp->mCoreType == jblas::gemm::GemmCoreType::AVX512_VNNI_3X48_KBLOCK) {
-    using GemmKernel = jblas::wrapper::gemm_default::weight_comp::avx512_vnni::GemmSKernelDynamicS4KBlock;
-    static GemmKernel kernel;
-    auto ret = kernel.compute({_m, _n, _k, activation, lda, wtmp, output, ldo});
+    auto wbtmp = dynamic_cast<prologue::weight_comp::PackedWeightKBlock*>(wtmp);
+    if (_cd->AMX_INT8() && wbtmp->mBlockSize % 128 == 0) {
+      using GemmKernel = jblas::wrapper::gemm_default::weight_comp::amx_int8::GemmSKernelDynamicS4KBlock;
+      static GemmKernel kernel;
+      ret = kernel.compute({_m, _n, _k, activation, lda, wtmp, output, ldo});
+    } else if (_cd->AVX512_VNNI()) {
+      using GemmKernel = jblas::wrapper::gemm_default::weight_comp::avx512_vnni::GemmSKernelDynamicS4KBlock;
+      static GemmKernel kernel;
+      ret = kernel.compute({_m, _n, _k, activation, lda, wtmp, output, ldo});
+    }
   } else if (wtmp->mCoreType == jblas::gemm::GemmCoreType::AVX512F_8X48) {
     using GemmKernel = jblas::wrapper::gemm_default::weight_comp::avx512f::GemmKernelS4KBlock;
     float alpha = 1.f, beta = 0.f;
     static GemmKernel kernel;
-    auto ret = kernel.compute({_m, _n, _k, activation, lda, wtmp, output, output, ldo, ldo, alpha, beta});
+    if (_cd->AVX512F()) {
+      ret = kernel.compute({_m, _n, _k, activation, lda, wtmp, output, output, ldo, ldo, alpha, beta});
+    }
+  } else if (wtmp->mCoreType == jblas::gemm::GemmCoreType::AMX_BF16_16x64) {
+    using GemmKernel = jblas::wrapper::gemm_default::weight_comp::amx_bf16::GemmKernelS4KBlock;
+    static GemmKernel kernel;
+    if (_cd->AMX_BF16()) {
+      ret = kernel.compute({_m, _n, _k, activation, lda, wtmp, output, ldo});
+    }
   }
+  assert(ret == JblasSuccess);
   delete wtmp;
 }
 
@@ -63,13 +88,99 @@ class Silu {
     return JblasSuccess;
   }
 };
+
+template <typename _T>
+class Gelu {
+ public:
+  struct Param {
+    _T* C;
+    int ldc;
+  };
+
+  template <JBLAS_ISA ISA_T>
+  JBLAS_CODE forward(const float* cacheptr, const int cachestep, const int M_offset, const int N_offset, const int M,
+                     const int N, const Param& _param) {
+    auto COffset = M_offset * _param.ldc + N_offset;
+    auto cptr = _param.C + COffset;
+    // for (int i = 0; i < M; i++) {
+    //   ne_vec_gelu_f32(N, cptr + i * _param.ldc, cacheptr + i * cachestep);
+    // }
+    for (int i = 0; i < M; i++) {
+      for (int j = 0; j < N; j++) {
+        cptr[i * _param.ldc + j] = ne_gelu_f32(cacheptr[i * cachestep + j]);
+      }
+    }
+    return JblasSuccess;
+  }
+};
+
+template <typename _T>
+class Add {
+ public:
+  struct Param {
+    _T *C, *D;
+    int ldc, ldd;
+  };
+
+  template <JBLAS_ISA ISA_T>
+  JBLAS_CODE forward(const float* cacheptr, const int cachestep, const int M_offset, const int N_offset, const int M,
+                     const int N, const Param& _param) {
+    auto COffset = M_offset * _param.ldc + N_offset;
+    auto DOffset = M_offset * _param.ldd + N_offset;
+    auto cptr = _param.C + COffset;
+    auto dptr = _param.D + DOffset;
+    // for (int i = 0; i < M; i++) {
+    //   ne_vec_add_f32(N, cptr + i * _param.ldc,dptr + i * _param.ldd, cacheptr + i * cachestep);
+    // }
+    for (int i = 0; i < M; i++) {
+      for (int j = 0; j < N; j++) {
+        cptr[i * _param.ldc + j] = dptr[i * _param.ldd + j] + cacheptr[i * cachestep + j];
+      }
+    }
+    return JblasSuccess;
+  }
+};
+
+template <typename _T>
+class Add_Gelu {
+ public:
+  struct Param {
+    _T *C, *D;
+    int ldc, ldd;
+  };
+
+  template <JBLAS_ISA ISA_T>
+  JBLAS_CODE forward(const float* cacheptr, const int cachestep, const int M_offset, const int N_offset, const int M,
+                     const int N, const Param& _param) {
+    auto COffset = M_offset * _param.ldc + N_offset;
+    auto DOffset = M_offset * _param.ldd + N_offset;
+    auto cptr = _param.C + COffset;
+    auto dptr = _param.D + DOffset;
+    for (int i = 0; i < M; i++) {
+      ne_vec_add_f32(N, cptr + i * _param.ldc, dptr + i * _param.ldd, cacheptr + i * cachestep);
+      // ne_vec_gelu_f32(N, cptr + i * _param.ldc, cptr + i * _param.ldc);
+    }
+    jblas::epilogue::gemm::AccumulatorWriteBackWithGelu<float, float> ker;
+    jblas::epilogue::gemm::AccumulatorWriteBackWithGelu<float, float>::Param param{_param.C, _param.ldc};
+    ker.forward<JblasAVX512F>(cptr, _param.ldc, M_offset, N_offset, M, N, param);
+    /*for (int i = 0; i < M; i++) {
+      for (int j = 0; j < N; j++) {
+        cptr[i * _param.ldc + j] = dptr[i * _param.ldd + j] + cacheptr[i * cachestep + j];
+        cptr[i * _param.ldc + j] = ne_gelu_f32(cptr[i * _param.ldc + j]);
+      }
+    }*/
+    return JblasSuccess;
+  }
+};
+
 }  // namespace epilogue
 namespace wrapper {
 namespace transformer {
 template <class _SiluLauncher_T, class _Launcher_T>
 class FFNFusedInterface {
  public:
-  static_assert(std::is_same<typename _Launcher_T::AParam, typename _SiluLauncher_T::AParam>::value);
+  static_assert(std::is_same<typename _Launcher_T::AParam, typename _SiluLauncher_T::AParam>::value,
+                "Prologue A param of the 2 Launcher (w/wo SILU) should be the same.");
   struct Arguments {
     const int Seq, Fin, FMid, FOut;
     const typename _Launcher_T::AParam paramA;
@@ -127,6 +238,7 @@ class FFNFusedInterface {
           int row_r = jblas::utils::remainsize(rowidx, _paral.mRows, rowsize);
           int col_r = jblas::utils::remainsize(colidx, _paral.mCols, colsize);
 
+          // TODO(Yu): replace the naive inplace eltwise mul
           for (int i = 0; i < row_r; i++) {
             for (int j = 0; j < col_r; j++) {
               _param.param1.C[(rowidx + i) * _param.param1.ldc + colidx + j] *=
@@ -159,29 +271,264 @@ class FFNFusedInterface {
   _Launcher_T mLauncher;
   _SiluLauncher_T mActLauncher;
 };
+
+template <class _GeluLauncher_T, class _Launcher_T>
+class GeluFusedInterface {
+ public:
+  struct Arguments {
+    const int Seq, Fin, FMid, FOut;
+    const typename _GeluLauncher_T::AParam paramA;
+    const typename _GeluLauncher_T::BParam paramW1;
+    const typename _Launcher_T::BParam paramW2;
+    const typename _GeluLauncher_T::EpiParam param1;
+    const typename _Launcher_T::EpiParam param2;
+  };
+  using Config = typename _Launcher_T::ParallelConfig;
+  using ActConfig = typename _GeluLauncher_T::ParallelConfig;
+  using GemmCore = typename _Launcher_T::GemmCore;
+  using LArguments = typename _Launcher_T::Param;
+  using CParam = typename _Launcher_T::EpiParam;
+  using Parallel = jblas::utils::parallel::Parallel2DGemmKBlockFixed<GemmCore>;
+
+  // forward=packB+compute
+  JBLAS_CODE compute(const Arguments& _param) {
+    auto bptr = dynamic_cast<const prologue::weight_comp::PackedWeightKBlock*>(_param.paramW1.packedW);
+    if (bptr == nullptr) {
+      return JblasInvalidParam;
+    }
+    // dynamic quantization: Seq*Fin
+    auto paraA = mActLauncher.mProA.createParallel(_param.Seq, _param.Fin, bptr->mBlockSize);
+    auto quanA = mActLauncher.mProA.createObj(_param.Seq, _param.Fin, bptr->mBlockSize);
+    auto cb = utils::CpuBase();
+    Parallel _paral = Parallel();   // w1 from Seq* Fin=>FMid
+    Parallel _paral2 = Parallel();  // w2 from Seq* FMid=>Fout
+    _paral.update(_param.Seq, _param.FMid, _param.Fin, bptr->mBlockSize, cb.mNumThreads);
+    _paral2.update(_param.Seq, _param.FOut, _param.FMid, bptr->mBlockSize, cb.mNumThreads);
+
+    auto paraA2 = mLauncher.mProA.createParallel(_param.Seq, _param.FMid, bptr->mBlockSize);
+    auto quanA2 = mLauncher.mProA.createObj(_param.Seq, _param.FMid, bptr->mBlockSize);
+    omp_set_num_threads(cb.mNumThreads);
+#pragma omp parallel
+    {
+      int tidx = omp_get_thread_num();
+      mActLauncher.mProA.template quantizeT<_Launcher_T::RT_ISA>(_param.paramA, tidx, quanA, paraA);
+#pragma omp barrier
+      {
+        int colidx, rowidx, rowsize, colsize;
+        _paral.getIndex(tidx, &rowidx, &colidx, &rowsize, &colsize);
+        if (rowsize > 0 && colsize > 0) {
+          ActConfig _actconfig{
+              rowidx, colidx, rowsize, colsize, _paral.getMStep(), _paral.getNStep(), _paral.getKStep(), cb.mL2Cache};
+          mActLauncher.launch(_actconfig,
+                              {_param.Seq, _param.FMid, _param.Fin, _param.paramA, _param.paramW1, _param.param1, NULL},
+                              quanA);
+        }
+      }
+#pragma omp barrier
+      mLauncher.mProA.template quantizeT<_Launcher_T::RT_ISA>({_param.param1.C, _param.param1.ldc}, tidx, quanA2,
+                                                              paraA2);
+#pragma omp barrier
+      {
+        int colidx, rowidx, rowsize, colsize;
+        _paral2.getIndex(tidx, &rowidx, &colidx, &rowsize, &colsize);
+        if (rowsize > 0 && colsize > 0) {
+          Config _config{
+              rowidx,     colidx, rowsize, colsize, _paral2.getMStep(), _paral2.getNStep(), _paral2.getKStep(),
+              cb.mL2Cache};
+          mLauncher.launch(_config,
+                           {_param.Seq, _param.FOut, _param.FMid, _param.paramA, _param.paramW2, _param.param2, NULL},
+                           quanA2);
+        }
+      }
+    }
+    return JblasSuccess;
+  }
+
+ protected:
+  _Launcher_T mLauncher;
+  _GeluLauncher_T mActLauncher;
+};
+
+template <class _GeluLauncher_T, class _Launcher_T>
+class FpGeluFusedInterface {
+ public:
+  struct Arguments {
+    const int Seq, Fin, FMid, FOut;
+    const typename _GeluLauncher_T::AParam paramA;
+    const typename _GeluLauncher_T::BParam paramW1;
+    const typename _Launcher_T::BParam paramW2;
+    const typename _GeluLauncher_T::EpiParam param1;
+    const typename _Launcher_T::EpiParam param2;
+  };
+  using Config = typename _Launcher_T::ParallelConfig;
+  using ActConfig = typename _GeluLauncher_T::ParallelConfig;
+  using GemmCore = typename _Launcher_T::GemmCore;
+  using LArguments = typename _Launcher_T::Param;
+  using CParam = typename _Launcher_T::EpiParam;
+  using Parallel = jblas::utils::parallel::Parallel2DGemmKBlockFixed<GemmCore>;
+
+  JBLAS_CODE compute(const Arguments& _param) {
+    auto bptr = dynamic_cast<const prologue::weight_comp::PackedWeightKBlock*>(_param.paramW1.packedW);
+    if (bptr == nullptr) {
+      return JblasInvalidParam;
+    }
+    auto cb = utils::CpuBase();
+    Parallel _paral = Parallel();   // w1 from Seq* Fin=>FMid
+    Parallel _paral2 = Parallel();  // w2 from Seq* FMid=>Fout
+    _paral.update(_param.Seq, _param.FMid, _param.Fin, bptr->mBlockSize, cb.mNumThreads);
+    _paral2.update(_param.Seq, _param.FOut, _param.FMid, bptr->mBlockSize, cb.mNumThreads);
+
+    omp_set_num_threads(cb.mNumThreads);
+#pragma omp parallel
+    {
+      int tidx = omp_get_thread_num();
+      {
+        int colidx, rowidx, rowsize, colsize;
+        _paral.getIndex(tidx, &rowidx, &colidx, &rowsize, &colsize);
+        if (rowsize > 0 && colsize > 0) {
+          ActConfig _actconfig{
+              rowidx, colidx, rowsize, colsize, _paral.getMStep(), _paral.getNStep(), _paral.getKStep(), cb.mL2Cache};
+          mActLauncher.launch(
+              _actconfig, {_param.Seq, _param.FMid, _param.Fin, _param.paramA, _param.paramW1, _param.param1, NULL});
+        }
+      }
+
+#pragma omp barrier
+      {
+        int colidx, rowidx, rowsize, colsize;
+        _paral2.getIndex(tidx, &rowidx, &colidx, &rowsize, &colsize);
+        if (rowsize > 0 && colsize > 0) {
+          Config _config{
+              rowidx,     colidx, rowsize, colsize, _paral2.getMStep(), _paral2.getNStep(), _paral2.getKStep(),
+              cb.mL2Cache};
+          mLauncher.launch(_config, {_param.Seq,
+                                     _param.FOut,
+                                     _param.FMid,
+                                     {_param.param1.C, _param.param1.ldc},
+                                     _param.paramW2,
+                                     _param.param2,
+                                     NULL});
+        }
+      }
+    }
+    return JblasSuccess;
+  }
+
+ protected:
+  _Launcher_T mLauncher;
+  _GeluLauncher_T mActLauncher;
+};
+
 }  // namespace transformer
 namespace kblock {
 namespace avx512_vnni {
 using GemmSKernelDynamicS4KBlock = jblas::wrapper::gemm_kblock::GemmSLauncherKBlockPackWeight<
-    JblasAVX512_VNNI, jblas::prologue::gemm::ActivationF32U8KBlockQuantize,
-    jblas::prologue::weight_comp::gemm::WeightS4_KBlock, jblas::epilogue::gemm::AccumulateWriteBack<float>>;
+    JblasAVX512_VNNI, jblas::gemm::kblock::GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK,
+    jblas::prologue::gemm::ActivationF32U8KBlockQuantize, jblas::prologue::weight_comp::gemm::WeightS4_KBlock,
+    jblas::epilogue::gemm::AccumulatorWriteBack<float, float>>;
 using SiluGemmSKernelDynamicS4KBlock = jblas::wrapper::gemm_kblock::GemmSLauncherKBlockPackWeight<
-    JblasAVX512_VNNI, jblas::prologue::gemm::ActivationF32U8KBlockQuantize,
-    jblas::prologue::weight_comp::gemm::WeightS4_KBlock, custom::epilogue::Silu<float>>;
+    JblasAVX512_VNNI, jblas::gemm::kblock::GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK,
+    jblas::prologue::gemm::ActivationF32U8KBlockQuantize, jblas::prologue::weight_comp::gemm::WeightS4_KBlock,
+    custom::epilogue::Silu<float>>;
+using GeluGemmSKernelDynamicS4KBlock = jblas::wrapper::gemm_kblock::GemmSLauncherKBlockPackWeight<
+    JblasAVX512_VNNI, jblas::gemm::kblock::GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK,
+    jblas::prologue::gemm::ActivationF32U8KBlockQuantize, jblas::prologue::weight_comp::gemm::WeightS4_KBlock,
+    custom::epilogue::Gelu<float>>;
+using AddGeluGemmSKernelDynamicS4KBlock = jblas::wrapper::gemm_kblock::GemmSLauncherKBlockPackWeight<
+    JblasAVX512_VNNI, jblas::gemm::kblock::GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK,
+    jblas::prologue::gemm::ActivationF32U8KBlockQuantize, jblas::prologue::weight_comp::gemm::WeightS4_KBlock,
+    custom::epilogue::Add_Gelu<float>>;
+using AddGemmSKernelDynamicS4KBlock = jblas::wrapper::gemm_kblock::GemmSLauncherKBlockPackWeight<
+    JblasAVX512_VNNI, jblas::gemm::kblock::GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK,
+    jblas::prologue::gemm::ActivationF32U8KBlockQuantize, jblas::prologue::weight_comp::gemm::WeightS4_KBlock,
+    custom::epilogue::Add<float>>;
 }  // namespace avx512_vnni
+namespace amx_int8 {
+using GemmSKernelDynamicS4KBlock = jblas::wrapper::gemm_kblock::GemmSLauncherKBlockPackWeight<
+    JblasAMX_INT8, jblas::gemm::kblock::GemmCore_Row_NN_16x48_AMX_INT8_KBLOCK,
+    jblas::prologue::gemm::ActivationF32S8KBlockQuantize, jblas::prologue::weight_comp::gemm::WeightS4_KBlock,
+    jblas::epilogue::gemm::AccumulatorWriteBack<float, float>>;
+using SiluGemmSKernelDynamicS4KBlock = jblas::wrapper::gemm_kblock::GemmSLauncherKBlockPackWeight<
+    JblasAMX_INT8, jblas::gemm::kblock::GemmCore_Row_NN_16x48_AMX_INT8_KBLOCK,
+    jblas::prologue::gemm::ActivationF32S8KBlockQuantize, jblas::prologue::weight_comp::gemm::WeightS4_KBlock,
+    custom::epilogue::Silu<float>>;
+using GeluGemmSKernelDynamicS4KBlock = jblas::wrapper::gemm_kblock::GemmSLauncherKBlockPackWeight<
+    JblasAMX_INT8, jblas::gemm::kblock::GemmCore_Row_NN_16x48_AMX_INT8_KBLOCK,
+    jblas::prologue::gemm::ActivationF32S8KBlockQuantize, jblas::prologue::weight_comp::gemm::WeightS4_KBlock,
+    custom::epilogue::Gelu<float>>;
+using AddGeluGemmSKernelDynamicS4KBlock = jblas::wrapper::gemm_kblock::GemmSLauncherKBlockPackWeight<
+    JblasAMX_INT8, jblas::gemm::kblock::GemmCore_Row_NN_16x48_AMX_INT8_KBLOCK,
+    jblas::prologue::gemm::ActivationF32S8KBlockQuantize, jblas::prologue::weight_comp::gemm::WeightS4_KBlock,
+    custom::epilogue::Add_Gelu<float>>;
+using AddGemmSKernelDynamicS4KBlock = jblas::wrapper::gemm_kblock::GemmSLauncherKBlockPackWeight<
+    JblasAMX_INT8, jblas::gemm::kblock::GemmCore_Row_NN_16x48_AMX_INT8_KBLOCK,
+    jblas::prologue::gemm::ActivationF32S8KBlockQuantize, jblas::prologue::weight_comp::gemm::WeightS4_KBlock,
+    custom::epilogue::Add<float>>;
+}  // namespace amx_int8
+namespace amx_bf16 {
+using GemmKernelS4KBlock = jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<
+    JblasAMX_BF16, jblas::gemm::GemmCore_Row_NN_16x64_AMX_BF16, jblas::prologue::gemm::ActivationConverterFp32,
+    jblas::prologue::weight_comp::gemm::WeightS4_KBlock, jblas::epilogue::gemm::AccumulatorWriteBack<float, float>>;
+using SiluGemmKernelS4KBlock = jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<
+    JblasAMX_BF16, jblas::gemm::GemmCore_Row_NN_16x64_AMX_BF16, jblas::prologue::gemm::ActivationConverterFp32,
+    jblas::prologue::weight_comp::gemm::WeightS4_KBlock, custom::epilogue::Silu<float>>;
+using GeluGemmKernelS4KBlock = jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<
+    JblasAMX_BF16, jblas::gemm::GemmCore_Row_NN_16x64_AMX_BF16, jblas::prologue::gemm::ActivationConverterFp32,
+    jblas::prologue::weight_comp::gemm::WeightS4_KBlock, custom::epilogue::Gelu<float>>;
+using AddGeluGemmKernelS4KBlock = jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<
+    JblasAMX_BF16, jblas::gemm::GemmCore_Row_NN_16x64_AMX_BF16, jblas::prologue::gemm::ActivationConverterFp32,
+    jblas::prologue::weight_comp::gemm::WeightS4_KBlock, custom::epilogue::Add_Gelu<float>>;
+using AddGemmKernelS4KBlock = jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<
+    JblasAMX_BF16, jblas::gemm::GemmCore_Row_NN_16x64_AMX_BF16, jblas::prologue::gemm::ActivationConverterFp32,
+    jblas::prologue::weight_comp::gemm::WeightS4_KBlock, custom::epilogue::Add<float>>;
+}  // namespace amx_bf16
 }  // namespace kblock
 }  // namespace wrapper
 }  // namespace custom
 
 void jblas_weightcomp_QKV_f32_forward(float* activation, void* wqptr, void* wkptr, void* wvptr, float* output, int _m,
                                       int _n, int _k, int lda, int ldo) {
+  GetCPUDevice();
+  auto ret = JblasRuntimeError;
   auto wqtmp = prologue::weight_comp::gemm::CompressedPackedWeight::deserialBuffer(wqptr, 0);
   auto wktmp = prologue::weight_comp::gemm::CompressedPackedWeight::deserialBuffer(wkptr, 0);
   auto wvtmp = prologue::weight_comp::gemm::CompressedPackedWeight::deserialBuffer(wvptr, 0);
   float alpha = 1.f, beta = 0.f;
-  if (wqtmp->mCoreType == jblas::gemm::GemmCoreType::AVX512_VNNI_8X48 ||
-      wqtmp->mCoreType == jblas::gemm::GemmCoreType::AVX512_VNNI_3X48_KBLOCK) {
-    using GemmKernel = jblas::wrapper::transformer_default::weight_comp::avx512_vnni::QKVGemmSKernelDynamicS4KBlock;
+  if (wqtmp->mCoreType == jblas::gemm::GemmCoreType::AVX512_VNNI_3X48_KBLOCK ||
+      wqtmp->mCoreType == jblas::gemm::GemmCoreType::AVX512_VNNI_8X48 ||
+      wqtmp->mCoreType == jblas::gemm::GemmCoreType::AMX_INT8_16X48_KBLOCK) {
+    auto wbtmp = dynamic_cast<prologue::weight_comp::PackedWeightKBlock*>(wqtmp);
+    if (_cd->AMX_INT8() && wbtmp->mBlockSize % 128 == 0) {
+      using GemmKernel = jblas::wrapper::transformer_default::weight_comp::amx_int8::QKVGemmSKernelDynamicS4KBlock;
+      static GemmKernel kernel;
+      GemmKernel::WeightType::Param wparams[3]{
+          wqtmp,
+          wktmp,
+          wvtmp,
+      };
+      GemmKernel::CParam oparams[3]{
+          {output, ldo},
+          {output + _m * _n, ldo},
+          {output + 2 * _m * _n, ldo},
+      };
+      ret = kernel.compute2({_m, _n, _k, 3, activation, lda, wparams, oparams, NULL});
+    } else if (_cd->AVX512_VNNI()) {
+      using GemmKernel = jblas::wrapper::transformer_default::weight_comp::avx512_vnni::QKVGemmSKernelDynamicS4KBlock;
+      static GemmKernel kernel;
+      GemmKernel::WeightType::Param wparams[3]{
+          wqtmp,
+          wktmp,
+          wvtmp,
+      };
+      GemmKernel::CParam oparams[3]{
+          {output, ldo},
+          {output + _m * _n, ldo},
+          {output + 2 * _m * _n, ldo},
+      };
+      ret = kernel.compute2({_m, _n, _k, 3, activation, lda, wparams, oparams, NULL});
+    }
+  } else if (wqtmp->mCoreType == jblas::gemm::GemmCoreType::AMX_BF16_16x64) {
+    using GemmKernel = jblas::wrapper::transformer_default::weight_comp::amx_bf16::QKVGemm;
     static GemmKernel kernel;
     GemmKernel::WeightType::Param wparams[3]{
         wqtmp,
@@ -193,11 +540,64 @@ void jblas_weightcomp_QKV_f32_forward(float* activation, void* wqptr, void* wkpt
         {output + _m * _n, ldo},
         {output + 2 * _m * _n, ldo},
     };
-    auto ret = kernel.compute2({_m, _n, _k, 3, activation, lda, wparams, oparams, NULL});
+    if (_cd->AMX_BF16()) {
+      ret = kernel.compute({_m, _n, _k, 3, activation, lda, wparams, oparams, NULL});
+    }
+  } else if (wqtmp->mCoreType == jblas::gemm::GemmCoreType::AVX512F_8X48) {
+    using GemmKernel = jblas::wrapper::transformer_default::weight_comp::avx512_f::QKVGemm;
+    static GemmKernel kernel;
+    GemmKernel::WeightType::Param wparams[3]{
+        wqtmp,
+        wktmp,
+        wvtmp,
+    };
+    GemmKernel::CParam oparams[3]{
+        {output, ldo},
+        {output + _m * _n, ldo},
+        {output + 2 * _m * _n, ldo},
+    };
+    if (_cd->AVX512F()) {
+      ret = kernel.compute({_m, _n, _k, 3, activation, lda, wparams, oparams, NULL});
+    }
   }
+  assert(ret == JblasSuccess);
   delete wqtmp;
   delete wktmp;
   delete wvtmp;
+}
+
+void jblas_weights4block_add_f32_forward(float* activation, void* weiptr, float* bias, float* output, int _m, int _n,
+                                         int _k, int lda, int ldo, bool boardcast_bias) {
+  GetCPUDevice();
+  auto ret = JblasRuntimeError;
+  auto wtmp = prologue::weight_comp::gemm::CompressedPackedWeight::deserialBuffer(weiptr, 0);
+  if (wtmp->mCoreType == jblas::gemm::GemmCoreType::AMX_INT8_16X48_KBLOCK ||
+      wtmp->mCoreType == jblas::gemm::GemmCoreType::AVX512_VNNI_8X48 ||
+      wtmp->mCoreType == jblas::gemm::GemmCoreType::AVX512_VNNI_3X48_KBLOCK) {
+    auto wbtmp = dynamic_cast<prologue::weight_comp::PackedWeightKBlock*>(wtmp);
+    if (_cd->AMX_INT8() && wbtmp->mBlockSize % 128 == 0) {
+      using GemmKernel = jblas::wrapper::gemm_kblock::GemmInterfaceKBlockPackWeight<
+          custom::wrapper::kblock::amx_int8::AddGemmSKernelDynamicS4KBlock,
+          jblas::utils::parallel::Parallel2DGemmKBlockFixed>;
+      static GemmKernel kernel;
+      ret = kernel.compute({_m, _n, _k, activation, lda, wtmp, output, bias, ldo, boardcast_bias ? 0 : ldo});
+    } else if (_cd->AVX512_VNNI()) {
+      using GemmKernel = jblas::wrapper::gemm_kblock::GemmInterfaceKBlockPackWeight<
+          custom::wrapper::kblock::avx512_vnni::AddGemmSKernelDynamicS4KBlock,
+          jblas::utils::parallel::Parallel2DGemmKBlockFixed>;
+      static GemmKernel kernel;
+      ret = kernel.compute({_m, _n, _k, activation, lda, wtmp, output, bias, ldo, boardcast_bias ? 0 : ldo});
+    }
+  } else if (wtmp->mCoreType == jblas::gemm::GemmCoreType::AMX_BF16_16x64) {
+    using GemmKernel = jblas::wrapper::gemm_pack_weight::GemmInterfacePackWeight<
+        custom::wrapper::kblock::amx_bf16::AddGemmKernelS4KBlock, jblas::wrapper::gemm_default::DefaultParallel>;
+    static GemmKernel kernel;
+    if (_cd->AMX_BF16()) {
+      ret = kernel.compute({_m, _n, _k, activation, lda, wtmp, output, bias, ldo, boardcast_bias ? 0 : ldo});
+    }
+  }
+  assert(ret == JblasSuccess);
+  delete wtmp;
 }
 
 void jblas_weightcomp_FFN_SiLu_f32_forward(float* activation, void* w1ptr, void* w2ptr, void* w3ptr, float* tmp1,
@@ -205,8 +605,8 @@ void jblas_weightcomp_FFN_SiLu_f32_forward(float* activation, void* w1ptr, void*
   auto w1tmp = prologue::weight_comp::gemm::CompressedPackedWeight::deserialBuffer(w1ptr, 0);
   auto w2tmp = prologue::weight_comp::gemm::CompressedPackedWeight::deserialBuffer(w2ptr, 0);
   auto w3tmp = prologue::weight_comp::gemm::CompressedPackedWeight::deserialBuffer(w3ptr, 0);
-  if (w1tmp->mCoreType == jblas::gemm::GemmCoreType::AVX512_VNNI_8X48 ||
-      w1tmp->mCoreType == jblas::gemm::GemmCoreType::AVX512_VNNI_3X48_KBLOCK) {
+  if (w1tmp->mCoreType == jblas::gemm::GemmCoreType::AVX512_VNNI_3X48_KBLOCK ||
+      w1tmp->mCoreType == jblas::gemm::GemmCoreType::AVX512_VNNI_8X48) {
     using GemmKernel = custom::wrapper::kblock::avx512_vnni::GemmSKernelDynamicS4KBlock;
     using SiluGemmKernel = custom::wrapper::kblock::avx512_vnni::SiluGemmSKernelDynamicS4KBlock;
     using FusedInter = custom::wrapper::transformer::FFNFusedInterface<SiluGemmKernel, GemmKernel>;
@@ -221,6 +621,88 @@ void jblas_weightcomp_FFN_SiLu_f32_forward(float* activation, void* w1ptr, void*
   delete w1tmp;
   delete w2tmp;
   delete w3tmp;
+}
+
+void jblas_weightcomp_FFN_GeLu_f32_forward(float* activation, void* w1ptr, void* w2ptr, float* tmp1, float* output,
+                                           int seq, int fin, int fmid, int fout) {
+  auto w1tmp = prologue::weight_comp::gemm::CompressedPackedWeight::deserialBuffer(w1ptr, 0);
+  auto w2tmp = prologue::weight_comp::gemm::CompressedPackedWeight::deserialBuffer(w2ptr, 0);
+  if (w1tmp->mCoreType == jblas::gemm::GemmCoreType::AVX512_VNNI_8X48 ||
+      w1tmp->mCoreType == jblas::gemm::GemmCoreType::AVX512_VNNI_3X48_KBLOCK) {
+    using GemmKernel = custom::wrapper::kblock::avx512_vnni::GemmSKernelDynamicS4KBlock;
+    using GeluGemmKernel = custom::wrapper::kblock::avx512_vnni::GeluGemmSKernelDynamicS4KBlock;
+    using FusedInter = custom::wrapper::transformer::GeluFusedInterface<GeluGemmKernel, GemmKernel>;
+    static FusedInter finter;
+    int lda = fin;
+    int ldtmp1 = fmid;
+    int ldo = fout;
+    finter.compute({seq, fin, fmid, fout, activation, lda, w1tmp, w2tmp, tmp1, ldtmp1, output, ldo});
+  }
+  delete w1tmp;
+  delete w2tmp;
+}
+
+void jblas_weightcomp_FFN_Add_GeLu_f32_forward(float* activation, void* w1ptr, void* w2ptr, float* b1ptr, float* b2ptr,
+                                               float* tmp1, float* output, int seq, int fin, int fmid, int fout,
+                                               bool boardcast_bias) {
+  GetCPUDevice();
+  auto ret = JblasRuntimeError;
+  auto w1tmp = prologue::weight_comp::gemm::CompressedPackedWeight::deserialBuffer(w1ptr, 0);
+  auto w2tmp = prologue::weight_comp::gemm::CompressedPackedWeight::deserialBuffer(w2ptr, 0);
+  if (w1tmp->mCoreType == jblas::gemm::GemmCoreType::AVX512_VNNI_8X48 ||
+      w1tmp->mCoreType == jblas::gemm::GemmCoreType::AVX512_VNNI_3X48_KBLOCK) {
+    auto wbtmp = dynamic_cast<prologue::weight_comp::PackedWeightKBlock*>(w1tmp);
+    if (_cd->AMX_INT8() && wbtmp->mBlockSize % 128 == 0) {
+      using GemmKernel = custom::wrapper::kblock::amx_int8::AddGemmSKernelDynamicS4KBlock;
+      using GeluGemmKernel = custom::wrapper::kblock::amx_int8::AddGeluGemmSKernelDynamicS4KBlock;
+      using FusedInter = custom::wrapper::transformer::GeluFusedInterface<GeluGemmKernel, GemmKernel>;
+      static FusedInter finter;
+      int lda = fin;
+      int ldtmp1 = fmid;
+      int ldo = fout;
+      // FusedInter::Arguments::paramA paramA={activation, lda};
+      // FusedInter::Arguments::paramW1 paramW1={w1tmp};
+      // FusedInter::Arguments::paramW2 paramW2={w2tmp};
+      // FusedInter::Arguments::param1 param1={tmp1, b1ptr, ldtmp1, ldtmp1};
+      ret = finter.compute({seq, fin, fmid, fout, activation, lda, w1tmp, w2tmp, tmp1, b1ptr, ldtmp1,
+                            boardcast_bias ? 0 : ldtmp1, output, b2ptr, ldo, boardcast_bias ? 0 : ldo});
+    } else if (_cd->AVX512_VNNI()) {
+      using GemmKernel = custom::wrapper::kblock::avx512_vnni::AddGemmSKernelDynamicS4KBlock;
+      using GeluGemmKernel = custom::wrapper::kblock::avx512_vnni::AddGeluGemmSKernelDynamicS4KBlock;
+      using FusedInter = custom::wrapper::transformer::GeluFusedInterface<GeluGemmKernel, GemmKernel>;
+      static FusedInter finter;
+      int lda = fin;
+      int ldtmp1 = fmid;
+      int ldo = fout;
+      // FusedInter::Arguments::paramA paramA={activation, lda};
+      // FusedInter::Arguments::paramW1 paramW1={w1tmp};
+      // FusedInter::Arguments::paramW2 paramW2={w2tmp};
+      // FusedInter::Arguments::param1 param1={tmp1, b1ptr, ldtmp1, ldtmp1};
+      ret = finter.compute({seq, fin, fmid, fout, activation, lda, w1tmp, w2tmp, tmp1, b1ptr, ldtmp1,
+                            boardcast_bias ? 0 : ldtmp1, output, b2ptr, ldo, boardcast_bias ? 0 : ldo});
+    }
+  } else if (w1tmp->mCoreType == jblas::gemm::GemmCoreType::AMX_BF16_16x64) {
+    if (_cd->AMX_BF16()) {
+      using GemmKernel = custom::wrapper::kblock::amx_bf16::AddGemmKernelS4KBlock;
+      using GeluGemmKernel = custom::wrapper::kblock::amx_bf16::AddGeluGemmKernelS4KBlock;
+      using FusedInter = custom::wrapper::transformer::FpGeluFusedInterface<GeluGemmKernel, GemmKernel>;
+      static FusedInter finter;
+      int lda = fin;
+      int ldtmp1 = fmid;
+      int ldo = fout;
+      // FusedInter::Arguments::paramA paramA={activation, lda};
+      // FusedInter::Arguments::paramW1 paramW1={w1tmp};
+      // FusedInter::Arguments::paramW2 paramW2={w2tmp};
+      // FusedInter::Arguments::param1 param1={tmp1, b1ptr, ldtmp1, ldtmp1};
+      ret = finter.compute({seq, fin, fmid, fout, activation, lda, w1tmp, w2tmp, tmp1, b1ptr, ldtmp1,
+                            boardcast_bias ? 0 : ldtmp1, output, b2ptr, ldo, boardcast_bias ? 0 : ldo});
+    } else {
+      assert(false);
+    }
+  }
+  assert(ret == JblasSuccess);
+  delete w1tmp;
+  delete w2tmp;
 }
 
 void jblas_timer(bool _init) {

--- a/intel_extension_for_transformers/backends/neural_engine/graph/core/layers/inner_product.h
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/core/layers/inner_product.h
@@ -11,8 +11,8 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-#ifndef NE_GRAPH_INNER_PRODUCT_H
-#define NE_GRAPH_INNER_PRODUCT_H
+#ifndef NE_CORE_GRAPH_INNER_PRODUCT_H
+#define NE_CORE_GRAPH_INNER_PRODUCT_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -20,17 +20,29 @@ extern "C" {
 void jblas_weights4block_f32_forward(float* activation, void* weiptr, float* output, int _m, int _n, int _k, int lda,
                                      int ldo);
 
+void jblas_weights4block_add_f32_forward(float* activation, void* weiptr, float* bias, float* output, int _m, int _n,
+                                         int _k, int lda, int ldo, bool boardcast_bias);
+
 void jblas_weightcomp_QKV_f32_forward(float* activation, void* wqptr, void* wkptr, void* wvptr, float* output, int _m,
                                       int _n, int _k, int lda, int ldo);
 
 void jblas_weightcomp_FFN_SiLu_f32_forward(float* activation, void* w1ptr, void* w2ptr, void* w3ptr, float* tmp1,
                                            float* tmp2, float* output, int seq, int fin, int fmid, int fout);
 
+void jblas_weightcomp_FFN_GeLu_f32_forward(float* activation, void* w1ptr, void* w2ptr, float* tmp1, float* output,
+                                           int seq, int fin, int fmid, int fout);
+
+void jblas_weightcomp_FFN_Add_GeLu_f32_forward(float* activation, void* w1ptr, void* w2ptr, float* b1ptr, float* b2ptr,
+                                               float* tmp1, float* output, int seq, int fin, int fmid, int fout,
+                                               bool boardcast_bias);
+
 void jblas_timer(bool _init);
 
 int jblas_set_threads(int _nth);
 
+void jblas_init();
+
 #ifdef __cplusplus
 }
 #endif
-#endif
+#endif  // NE_CORE_GRAPH_INNER_PRODUCT_H

--- a/intel_extension_for_transformers/backends/neural_engine/graph/core/layers/mha_dense.cpp
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/core/layers/mha_dense.cpp
@@ -1,0 +1,872 @@
+//  Copyright (c) 2023 Intel Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+#include "layers/mha_dense.h"
+
+#include <cmath>
+#ifdef NE_TESTS
+#include <memory>
+#include <random>
+
+#include "layers/ne_test_layers_utils.hpp"
+#endif
+
+#include <immintrin.h>
+
+#include "core/data_types.h"
+#include "jblas/jit_blas_gemm.h"
+#include "jblas/jit_blas_prologue.h"
+#include "jblas/jit_blas_utils.h"
+#include "jblas/jit_blas_wrapper.h"
+
+#define MHA_2ND_EXP 1
+#ifdef __GNUC__
+#pragma GCC push_options
+#pragma GCC target("avx512f", "avx512bw", "avx512vl", "avx512bf16")
+#endif
+
+namespace {
+using namespace jblas::utils;
+
+template <typename Q_T, typename K_T, typename V_T, typename DST_T>
+struct attn_fwd_args_t {
+  Q_T* Q;
+  K_T* K;
+  V_T* V;
+  DST_T* dst;
+  char* tmp;
+  float QK_scale;
+  bool is_causal;
+  int batch_size, head_num, head_size, sl_q, sl_kv;
+  int step_q_bs, step_q_head_num, step_q_sl;
+  int step_k_bs, step_k_head_num, step_k_sl;
+  int step_v_bs, step_v_head_num, step_v_sl;
+  int step_dst_bs, step_dst_head_num, step_dst_sl;
+};
+using jblas_attn_fp32_fp16_fp16_fp32_fwd_args_t = attn_fwd_args_t<float, fp16, fp16, float>;
+
+/**
+ * @brief An Epilogue that scale the fp32 result, performing exp, accumulating sum of each line of exp, and storing exp
+ * as bf16 results
+ */
+template <typename T_DST>
+class ScaleExpAccSumFp32 {
+ public:
+  struct Param {
+    T_DST* dst;
+    float* dst_sum;
+    int ld_dst;  // #elements
+    float scale;
+    int causal_offset;  // offset for causal mask; negative value for disabling causal mask
+  };
+
+  static inline __m512 snd_order_poly_exp(__m512 z, __m512 f, const float c[]) {
+    const auto c0 = _mm512_set1_ps(c[0]);
+    const auto c1 = _mm512_set1_ps(c[1]);
+    const auto c2 = _mm512_set1_ps(c[2]);
+
+    auto y = _mm512_fmadd_ps(_mm512_fmadd_ps(f, c0, c1), f, c2);  // auto y = (f * c0 + c1) * f + c2;
+    auto exp = _mm512_scalef_ps(y, z);
+
+    return exp;
+  }
+
+  static inline __m512 exp_ps_0_1(__m512 x) {
+    static const float v_log2e = std::log2(std::exp(1.f));
+    const auto log2e = _mm512_set1_ps(v_log2e);
+    const float _c[] = {0.240226507f, 0.452920674f, 0.713483036f};
+
+    auto x1 = _mm512_fmadd_ps(x, log2e, _mm512_set1_ps(.5f));  // auto x1 = x * log2e + _mm512_set1_ps(.5f);
+    auto z = _mm512_floor_ps(x1);
+    auto f = _mm512_sub_ps(x1, z);  // auto f = x1 - z;
+
+    return snd_order_poly_exp(z, f, _c);
+  }
+
+  template <JBLAS_ISA ISA_T>
+  JBLAS_CODE forward(const float* src, const int src_step, const int M_offset, const int N_offset, const int M,
+                     const int N, const Param& p) const {
+    const auto dst = p.dst + M_offset * p.ld_dst + N_offset;
+    const auto dst_sum = p.dst_sum + M_offset;
+#if MHA_2ND_EXP
+    const auto v_scale = _mm512_set1_ps(p.scale);
+    for (int i = 0; i < M; ++i) {
+      const auto N_unmasked =
+          std::min(N, p.causal_offset < 0 ? INT32_MAX : i + M_offset - N_offset + p.causal_offset + 1);
+
+      const auto v_mask = _cvtu32_mask16((1U << (N_unmasked % 16)) - 1);
+      int j = 0;
+      auto v_sum = _mm512_setzero_ps();
+      for (; j < N_unmasked - 15; j += 16) {
+        const auto v_exp = exp_ps_0_1(_mm512_mul_ps(v_scale, _mm512_loadu_ps(src + i * src_step + j)));
+        static_assert(std::is_same<T_DST, bf16>::value, "bf16 support only");
+        v_sum = _mm512_add_ps(v_sum, v_exp);
+        _mm256_storeu_epi16(dst + i * p.ld_dst + j, (__m256i)_mm512_cvtneps_pbh(v_exp));
+      }
+      if (j < N_unmasked) {
+        const auto v_exp = exp_ps_0_1(_mm512_mul_ps(v_scale, _mm512_maskz_loadu_ps(v_mask, src + i * src_step + j)));
+        static_assert(std::is_same<T_DST, bf16>::value, "bf16 support only");
+        v_sum = _mm512_mask_add_ps(v_sum, v_mask, v_sum, v_exp);
+        _mm256_storeu_epi16(dst + i * p.ld_dst + j, (__m256i)_mm512_maskz_cvtneps_pbh(v_mask, v_exp));
+        j += 16;
+      }
+      dst_sum[i] += _mm512_reduce_add_ps(v_sum);
+
+      if (j < jblas::utils::padto(N, 64))
+        memset(dst + i * p.ld_dst + j, 0, sizeof(*dst) * (jblas::utils::padto(N, 64) - j));
+    }
+#else
+    for (int i = 0; i < M; ++i) {
+      const auto N_unmasked =
+          std::min(N, p.causal_offset < 0 ? INT32_MAX : i + M_offset - N_offset + p.causal_offset + 1);
+      for (int j = 0; j < N_unmasked; ++j) {
+        const auto exp_ = expf(src[i * src_step + j] * p.scale);
+        dst[i * p.ld_dst + j] = static_cast<T_DST>(exp_);
+        dst_sum[i] += exp_;
+      }
+      if (N_unmasked < jblas::utils::padto(N, 64))
+        memset(dst + i * p.ld_dst + N_unmasked, 0, sizeof(*dst) * (jblas::utils::padto(N, 64) - N_unmasked));
+    }
+#endif
+
+    return JblasSuccess;
+  }
+};
+
+/**
+ * @brief An Epilogue that scale the fp32 result, convert to bf16 and write back to memory
+ */
+template <typename T_DST>
+class ScaleWriteBackFp32 {
+ public:
+  struct Param {
+    const float* scale;
+    T_DST* dst;
+    int ld_dst;
+  };
+
+  template <JBLAS_ISA ISA_T>
+  JBLAS_CODE forward(const float* src, const int src_step, const int M_offset, const int N_offset, const int M,
+                     const int N, const Param& p) {
+    const auto dst = p.dst + M_offset * p.ld_dst + N_offset;
+    const auto scale = p.scale + M_offset;
+    // TODO(Yi): high performance implementation
+    for (int i = 0; i < M; ++i)
+      for (int j = 0; j < N; ++j)  //
+        dst[i * p.ld_dst + j] = static_cast<T_DST>(src[i * src_step + j] * scale[i]);
+
+    return JblasSuccess;
+  }
+};
+
+/**
+ * @brief PackedWeight(Default) with batch
+ *
+ * @tparam T element type of the weight
+ */
+template <typename T>
+class PackedWeightBatch : public jblas::prologue::gemm::PackedWeightDefault<T> {
+ public:
+  explicit PackedWeightBatch(jblas::gemm::GemmCoreType _type)
+      : jblas::prologue::gemm::PackedWeightDefault<T>(_type), mBatch(0) {}
+
+  void resize(int NPad, int KPad) = delete;
+  void resize(int NPad, int KPad, int num_batch) {
+    // See：https://stackoverflow.com/questions/11405
+    this->mNPad = NPad;
+    this->mKPad = KPad;
+    this->mBatch = num_batch;
+    this->mWeights.resize((size_t)mBatch * NPad * KPad);
+    this->mWPtr = this->mWeights.data();
+    this->mWSize = this->mWeights.size();
+  }
+  int mBatch;
+
+ protected:
+  virtual size_t getDataSerializedSize() override {
+    return jblas::prologue::gemm::PackedWeightDefault<T>::getSerializedSize() + sizeof(mBatch);
+  }
+};
+
+/**
+ * @brief An weight Prologue that Packs transposed Bf16 weight; optimized for runtime packing. It is the base type of
+ * that for transposed / non-transposed source
+ */
+template <class GemmCore_T, JBLAS_ISA ISA_T, bool IsTrans, typename T_SRC = typename GemmCore_T::BType>
+class WeightPackBatchBf16Base {
+ public:
+  using WType = typename GemmCore_T::BType;  // weight type
+  using PW_T = PackedWeightBatch<WType>;     // packed weight type
+  using Parallel = parallel::Parallel2DRowMajor;
+
+  struct Param {
+    const jblas::prologue::PackedWeight* packedW;
+  };
+
+  // additional parameter to pack weight at runtime
+  struct PackParam {
+    T_SRC* src;
+    int ld;
+    std::function<int(int)> step_batch;
+    int K;
+    int N;
+  };
+
+  JBLAS_CODE getWeight(...) = delete;
+
+  JBLAS_CODE getWeight(WType** dstptr, int* dststep, int /* b_size */, int /* k_size */, int /* n_size */, int b_offset,
+                       int k_offset, int n_offset, const jblas::prologue::PackedWeight* ptr) {
+    const auto wptr = dynamic_cast<const PW_T*>(ptr);
+    if (!wptr) return JblasInvalidParam;
+    assert(k_offset % GemmCore_T::KTILE == 0);
+    assert(n_offset % GemmCore_T::NTILE == 0);
+    auto KPad = wptr->mKPad;
+    auto NPad = wptr->mNPad;
+    *dstptr = wptr->mWPtr + n_offset * KPad + k_offset * GemmCore_T::NTILE;
+    *dststep = KPad;
+    return JblasSuccess;
+  }
+
+  JBLAS_CODE getWeight(WType** dstptr, int* dststep, int k_size, int n_size, int k_offset, int n_offset,
+                       const jblas::prologue::PackedWeight* ptr) {
+    return getWeight(dstptr, dststep, 1, k_size, n_size, 0, k_offset, n_offset, ptr);
+  }
+
+  JBLAS_CODE packWeight(...) = delete;
+
+  // from KxN int8 symmetric weight to packed N//NtilexKPadxNTile int4 weight
+  jblas::prologue::PackedWeight* packWeight(const int N, const int K, const WType* src, const int ld,
+                                            jblas::prologue::gemm::PackType type) {
+    static_assert(std::is_same<WType, ne_bf16_t>::value, "Only support BF16 weight pack.");
+    const auto KPad = padto(K, GemmCore_T::KTILE);
+    const auto NPad = padto(N, GemmCore_T::NTILE);
+    if (type == jblas::prologue::gemm::PackType::Default) {
+      const auto pw = new PackedWeightBatch<WType>(GemmCore_T::TYPE);
+      pw->resize(NPad, KPad);
+      assert(false);  // TODO(Yi): call reorderT
+      return pw;
+    }
+    return nullptr;
+  }
+
+  /**
+   * @brief Create a Parallel object (batch major)
+   *
+   * @param b batch dim size
+   * @param k K dim size (or N dim for transposed pack)
+   * @param bblock batch dim block
+   * @param kblock
+   * @return Parallel
+   */
+  Parallel createParallel(int b, int k, int bblock, int kblock) {
+    Parallel _paral;
+    auto cb = CpuBase();
+    _paral.update(b, k, bblock, kblock, cb.mNumThreads);
+    return _paral;
+  }
+
+  /// Reorder job of a thread
+  void reorderT(const Param& p, const int tid, const PackParam& pp, const Parallel& paral) {
+    assert(false);  // Use the overload function
+  };
+};
+
+template <class GemmCore_T, JBLAS_ISA ISA_T, typename T_SRC = typename GemmCore_T::BType>
+class WeightPackBatchBf16Trans : public WeightPackBatchBf16Base<GemmCore_T, ISA_T, true, T_SRC> {
+  using Base = WeightPackBatchBf16Base<GemmCore_T, ISA_T, true, T_SRC>;
+
+ public:
+  using typename Base::PackParam;
+  using typename Base::Parallel;
+  using typename Base::Param;
+  using typename Base::PW_T;
+  using typename Base::WType;
+
+  /// Reorder job of a thread
+  void reorderT(const Param& p, const int tid, const PackParam& pp, const Parallel& paral) {
+    const auto pw = dynamic_cast<const PW_T*>(p.packedW);
+    assert(pw != nullptr);
+    const int KPad = pw->mKPad;  // K size after transpose & padding
+    const int NPad = pw->mNPad;  // N size after transpose & padding
+    assert(pp.K <= KPad);
+    assert(pp.N <= NPad);
+
+    int y, x, ny, nx_pad;  // y for batch; x for major-dim of the source data (N-dim of the packed weight)
+    paral.getIndex(tid, &y, &x, &ny, &nx_pad);
+    if (ny <= 0 || nx_pad <= 0) return;
+    ny = remainsize(y, paral.mRows, ny);
+    int nx = remainsize(x, paral.mCols, nx_pad);
+    assert(paral.mRows == pw->mBatch);
+    assert(paral.mPadRow == 1);  // batch should not have paddings (pad tp 1)
+
+    assert(padto(pp.N, GemmCore_T::NTILE) == NPad);
+
+    using KernInterleave = typename jblas::kernel::wrapper::PaddingTransInterleaveMN<  //
+        GemmCore_T::NTILE, sizeof(WType), GemmCore_T::PACK_ROW>;
+
+    for (int ibat = y; ibat < y + ny; ++ibat) {
+      const auto forward_stat = KernInterleave::template forward_cvt<ISA_T, T_SRC, WType>(  //
+          pp.src + pp.step_batch(ibat) + x * pp.ld,                                         //
+          pw->mWPtr + ibat * KPad * NPad + x * KPad,                                        //
+          nx, pp.K,                                                                         // size
+          nx_pad, KPad,                                                                     // padded size
+          pp.ld, KPad);                                                                     // step
+      assert(forward_stat == JblasSuccess);
+    }
+  };
+};
+
+template <class GemmCore_T, JBLAS_ISA ISA_T, typename T_SRC = typename GemmCore_T::BType>
+class WeightPackBatchBf16NonTr : public WeightPackBatchBf16Base<GemmCore_T, ISA_T, false, T_SRC> {
+  using Base = WeightPackBatchBf16Base<GemmCore_T, ISA_T, false, T_SRC>;
+
+ public:
+  using typename Base::PackParam;
+  using typename Base::Parallel;
+  using typename Base::Param;
+  using typename Base::PW_T;
+  using typename Base::WType;
+
+  /// Reorder job of a thread
+  void reorderT(const Param& p, const int tid, const PackParam& pp, const Parallel& paral) {
+    const auto pw = dynamic_cast<const PW_T*>(p.packedW);
+    assert(pw != nullptr);
+    const int KPad = pw->mKPad;  // K size after padding
+    const int NPad = pw->mNPad;  // N size after padding
+    assert(pp.K <= KPad);
+    assert(pp.N <= NPad);
+
+    int y, x, ny, nx_pad;  // y for batch; x for major-dim of the source data (K-dim)
+    paral.getIndex(tid, &y, &x, &ny, &nx_pad);
+    if (ny <= 0 || nx_pad <= 0) return;
+    ny = remainsize(y, paral.mRows, ny);
+    int nx = remainsize(x, paral.mCols, nx_pad);
+    assert(paral.mRows == pw->mBatch);
+    assert(paral.mPadRow == 1);  // batch should not have paddings (pad tp 1)
+
+    assert(padto(pp.N, GemmCore_T::NTILE) == NPad);
+
+    using KernInterleave = typename jblas::kernel::wrapper::PaddingInterleaveMN<  //
+        GemmCore_T::NTILE, sizeof(WType), GemmCore_T::PACK_ROW>;
+
+    for (int ibat = y; ibat < y + ny; ++ibat) {
+      const auto forward_stat = KernInterleave::template forward_cvt<ISA_T, T_SRC, WType>(  //
+          pp.src + pp.step_batch(ibat) + x * pp.ld,                                         //
+          pw->mWPtr + ibat * KPad * NPad + x * GemmCore_T::NTILE,                           //
+          nx, pp.N,                                                                         // size
+          nx_pad, NPad,                                                                     // padded size
+          pp.ld, KPad);                                                                     // stride
+      assert(forward_stat == JblasSuccess);
+    }
+  };
+};
+
+/**
+ * @brief GemmLauncherPackWeight with addition input as packed weight offset
+ */
+template <JBLAS_ISA RT_ISA_, class _GemmCore_T, template <class _T> class _PrologueA_T,
+          template <class, JBLAS_ISA> class _PrologueB_T, class _Epilogue_T>
+class GemmLauncherPackWeightOff                                         //
+    : public jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<  //
+          RT_ISA_, _GemmCore_T, _PrologueA_T, _PrologueB_T, _Epilogue_T> {
+  using Base = jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<  //
+      RT_ISA_, _GemmCore_T, _PrologueA_T, _PrologueB_T, _Epilogue_T>;
+
+ public:
+  using typename Base::GemmCore;
+  using Param = typename Base::Param;
+  using AType = typename Base::AType;
+  using BType = typename Base::BType;
+  using CType = typename Base::CType;
+  static constexpr auto RT_ISA = RT_ISA_;
+
+  struct ParallelConfig {
+    const int rowidx, colidx;
+    const int rowsize, colsize;
+    const int MStep, NStep, KStep;
+    const int w_offset;  // weight offset for batching
+    const size_t StackSize;
+  };
+
+  void launch(const ParallelConfig& _config, const Param& _param) {
+    int rowremain = remainsize(_config.rowidx, _param.M, _config.rowsize);
+    int colremain = remainsize(_config.colidx, _param.N, _config.colsize);
+    const auto StackSize = _config.StackSize
+                               ? _config.StackSize
+                               : sizeof(BType) * _config.NStep * _config.KStep +      //
+                                     sizeof(AType) * _config.MStep * _config.KStep +  //
+                                     sizeof(CType) * padto(rowremain, _config.MStep) * padto(colremain, _config.NStep);
+    auto StackTmp = alloca(StackSize);
+    auto tmpB = (BType*)(StackTmp);
+    auto tmpA = (AType*)(tmpB + _config.NStep * _config.KStep);
+    auto tmpC = (CType*)(tmpA + _config.MStep * _config.KStep);
+    for (int itern = 0; itern < colremain; itern += _config.NStep) {
+      int n_remain = remainsize(itern, colremain, _config.NStep);
+      for (int iterm = 0; iterm < rowremain; iterm += _config.MStep) {
+        int m_remain = remainsize(iterm, rowremain, _config.MStep);
+        run_block(_config, _param, iterm, itern, m_remain, n_remain, tmpA, tmpB, tmpC);
+      }
+    }
+  }
+
+ protected:
+  void run_block(const ParallelConfig& _config, const Param& _param, int blk_m, int blk_n, int blk_msize, int blk_nsize,
+                 AType* tmpA, BType* /*tmpB*/, CType* tmpC) {
+    int n_padded = padto(blk_nsize, GemmCore::NTILE);
+    for (int iterk = 0; iterk < _param.K; iterk += _config.KStep) {
+      int k_remain = remainsize(iterk, _param.K, _config.KStep);
+      int k_padded = padto(k_remain, GemmCore::KTILE);
+      int k_paddedle = padto_le(k_remain, GemmCore::KTILE);
+      BType* bptr_cache = nullptr;
+      int bcache_step = 0;
+      this->mProB.getWeight(&bptr_cache, &bcache_step,      //
+                            k_padded, n_padded,             //
+                            iterk, _config.colidx + blk_n,  //
+                            _param.paramB.packedW);
+      bptr_cache += _config.w_offset;
+      int bcache_stride = bcache_step * sizeof(BType);
+      for (int i = 0; i < blk_msize; i += GemmCore::MTILE) {
+        int m_remain = remainsize(i, blk_msize, GemmCore::MTILE);
+        auto cptr_cache = tmpC + i * _config.NStep;
+        int ccache_stride = _config.NStep * sizeof(CType);
+
+        int acache_step = 0;
+        if (k_paddedle) {
+          AType* aptr_cache = tmpA;
+          this->mProA.template getActivation<RT_ISA>(&aptr_cache, &acache_step, _param.paramA, m_remain, k_paddedle,
+                                                     (blk_m + i + _config.rowidx), iterk);
+          this->mGemmCore.forward(aptr_cache, bptr_cache, cptr_cache, m_remain, n_padded, k_paddedle,
+                                  acache_step * sizeof(AType), bcache_stride, ccache_stride, iterk);
+        }
+        int k_tail = k_remain - k_paddedle;
+        if (k_tail) {
+          AType* aptr_cache = tmpA;
+          this->mProA.template getActivation<RT_ISA>(&aptr_cache, &acache_step, _param.paramA, m_remain, k_tail,
+                                                     blk_m + i + _config.rowidx, iterk + k_paddedle);
+          this->mGemmCore.forward(aptr_cache, bptr_cache + k_paddedle * GemmCore::NTILE, cptr_cache, m_remain, n_padded,
+                                  GemmCore::KTILE, acache_step * sizeof(AType), bcache_stride, ccache_stride,
+                                  iterk + k_paddedle);
+        }
+      }
+    }
+    this->mEpilogue.template forward<RT_ISA>(tmpC, _config.NStep, _config.rowidx + blk_m, _config.colidx + blk_n,
+                                             blk_msize, blk_nsize, _param.paramC);
+  }
+};
+
+/**
+ * @brief MHA interface
+ *
+ * @tparam L_ExpSum Launcher type of the QK exp sum matmul
+ * @tparam L_Scale Launcher type of the PV scale matmul (S for that in the flash-attn paper)
+ */
+template <class L_ExpSum, class L_Scale>
+class MHAInterface {
+ public:
+  using PC_QK = typename L_ExpSum::ParallelConfig;
+  using PC_PV = typename L_Scale::ParallelConfig;
+
+  using PrologueQ = typename L_ExpSum::PrologueA;
+  using PrologueK = typename L_ExpSum::PrologueB;
+  using QKProQArgs = typename PrologueQ::Param;
+  using QKProKArgs = typename PrologueK::Param;
+  using QKProKPackArgs = typename PrologueK::PackParam;
+  using QKArgs = typename L_ExpSum::Param;
+  using QKEpiArgs = typename L_ExpSum::EpiParam;
+
+  using PrologueS = typename L_Scale::PrologueA;
+  using PrologueV = typename L_Scale::PrologueB;
+  using PVProPArgs = typename PrologueS::Param;
+  using PVProVArgs = typename PrologueV::Param;
+  using PVProVPackArgs = typename PrologueV::PackParam;
+  using PVArgs = typename L_Scale::Param;
+  using PVEpiArgs = typename L_Scale::EpiParam;
+
+  using GemmQK = typename L_ExpSum::GemmCore;
+  using GemmPV = typename L_Scale::GemmCore;
+  using Parallel2DRowMajor = parallel::Parallel2DRowMajor;
+
+  static_assert(GemmQK::MTILE == GemmPV::MTILE, "2 GEMM should have the same M_TILE.");
+  static constexpr auto M_TILE = GemmQK::MTILE;
+
+  template <typename Q_T, typename K_T, typename V_T, typename DST_T>
+  JBLAS_CODE compute(const attn_fwd_args_t<Q_T, K_T, V_T, DST_T>& p) {
+    const auto num_heads = p.batch_size * p.head_num;  // Total number of heads
+    const auto cb = CpuBase();
+    omp_set_num_threads(cb.mNumThreads);
+    assert(!p.is_causal || p.sl_q <= p.sl_kv);
+    const auto sl_diff = p.sl_kv - p.sl_q;
+
+    // prepare memory for packed weight
+    // TODO(Yi): init packed weight with p.tmp
+    PackedWeightBatch<typename GemmQK::BType> K_pack(jblas::gemm::GemmCoreType::AMX_BF16_16x64);  // packed K
+    K_pack.resize(padto(p.sl_kv, GemmQK::NTILE), padto(p.head_size, GemmQK::KTILE), num_heads);
+    PackedWeightBatch<typename GemmPV::BType> V_pack(jblas::gemm::GemmCoreType::AMX_BF16_16x64);  // packed V
+    V_pack.resize(padto(p.head_size, GemmPV::NTILE), padto(p.sl_kv, GemmPV::KTILE), num_heads);
+    const auto K_pack_batch_off = K_pack.mKPad * K_pack.mNPad;
+    const auto V_pack_batch_off = V_pack.mKPad * V_pack.mNPad;
+
+    // prepare parallel scheme for packed weight
+    const auto paralK = l_expsum.mProB.createParallel(num_heads, p.sl_kv, 1, GemmQK::NTILE);
+    const auto paralV = l_scale.mProB.createParallel(num_heads, p.sl_kv, 1, GemmPV::KTILE);
+
+    const auto step_batch_k = [step_bs = p.step_k_bs, step_hn = p.step_k_head_num, hn = p.head_num](int ibat) {
+      return (ibat / hn) * step_bs + (ibat % hn) * step_hn;
+    };
+    const auto step_batch_v = [step_bs = p.step_v_bs, step_hn = p.step_v_head_num, hn = p.head_num](int ibat) {
+      return (ibat / hn) * step_bs + (ibat % hn) * step_hn;
+    };
+
+    Parallel2DRowMajor parl;  // w1&w3 from Seq* Fin=>FMid
+    const auto m_tiles = updiv(p.sl_q, M_TILE);
+    const auto num_tasks = num_heads * m_tiles;
+    parl.update(num_tasks, 1, 1, 1, cb.mNumThreads);
+
+#pragma omp parallel
+    {
+      const int tid = omp_get_thread_num();
+      const int tmp_exp_size = M_TILE * padto(p.sl_kv, GemmQK::NTILE) * sizeof(ne_bf16_t);  // TODO
+      const auto tmp = p.tmp + tid * tmp_exp_size;
+
+      // pack K/V
+      {
+        l_expsum.mProB.reorderT(  // pack K
+            QKProKArgs{&K_pack}, tid,
+            QKProKPackArgs{
+                /* .src = */ p.K,
+                /* .ld = */ p.step_k_sl,
+                /* .step_batch = */ step_batch_k,
+                /* .K = */ p.head_size,
+                /* .N = */ p.sl_kv,
+            },
+            paralK);
+        l_scale.mProB.reorderT(  // pack V
+            PVProVArgs{&V_pack}, tid,
+            PVProVPackArgs{
+                /* .src = */ p.V,
+                /* .ld = */ p.step_v_sl,
+                /* .step_batch = */ step_batch_v,
+                /* .K = */ p.sl_kv,
+                /* .N = */ p.head_size,
+            },
+            paralV);
+      }
+
+#pragma omp barrier
+
+      // calculate mm + softmax + mm
+      {
+        int task_start, _assert0, task_size, _assert_max1;
+        parl.getIndex(tid, &task_start, &_assert0, &task_size, &_assert_max1);
+        assert(task_size == 0 || _assert0 == 0);
+        assert(task_size == 0 || _assert_max1 == 1 || _assert_max1 == 0);
+        if (_assert_max1 == 0) task_size = 0;
+
+        for (int task_id = task_start; task_id < task_start + task_size; ++task_id) {
+          const int ibat = task_id / m_tiles;
+          const int i_m = task_id % m_tiles * M_TILE;
+          const int ibs = ibat / p.head_num;
+          const int ihn = ibat % p.head_num;
+          float exp_sum[M_TILE]{};
+          memset(exp_sum, 0, sizeof(exp_sum));
+
+          // ptr to Q / dst matrix of the current head
+          const auto head_q = p.Q + ibs * p.step_q_bs + ihn * p.step_q_head_num;
+          const auto head_dst = p.dst + ibs * p.step_dst_bs + ihn * p.step_dst_head_num;
+          const auto max_unmasked = p.is_causal ? std::min(p.sl_kv, p.sl_kv - p.sl_q + i_m + M_TILE - 1 + 1) : p.sl_kv;
+
+          const auto max_unmasked_pad_qk = std::min(p.sl_kv, padto(max_unmasked, GemmQK::NTILE));
+          const auto max_unmasked_pad_pv = std::min(p.sl_kv, padto(max_unmasked, GemmPV::KTILE));
+          const auto ld_tmp_exp = padto(padto(max_unmasked_pad_pv, GemmQK::NTILE), GemmPV::KTILE);
+          l_expsum.launch(  // QxK => S ==exp==> P
+              PC_QK{
+                  /* rowidx = */ i_m,
+                  /* colidx = */ 0,
+                  /* rowsize = */ M_TILE,
+                  /* colsize = */ max_unmasked_pad_qk,
+                  /* MStep = */ M_TILE,
+                  /* NStep = */ GemmQK::NTILE,
+                  /* KStep = */ p.head_size,
+                  /* w_offset = */ ibat * K_pack_batch_off,
+                  /* StackSize = */ 0,
+              },
+              QKArgs{
+                  /* .M = */ p.sl_q,
+                  /* .N = */ max_unmasked_pad_qk,
+                  /* .K = */ p.head_size,
+                  /* .paramA = */ QKProQArgs{head_q, p.step_q_sl},
+                  /* .paramB = */ QKProKArgs{&K_pack},
+                  /* .paramC = */
+                  QKEpiArgs{
+                      /* .dst = */ (bf16*)tmp - i_m * ld_tmp_exp,  // pretend that we have a whole exp mat
+                      /* .dst_sum = */ exp_sum - i_m,              // pretend that we have a whole exp sum
+                      /* .ld_dst = */ ld_tmp_exp,
+                      /* .scale = */ p.QK_scale,
+                      /* .causal_offset = */ p.is_causal ? sl_diff : -1,
+                  },
+                  /* .workspace = */ nullptr,
+              });
+          for (int ii = 0; ii < M_TILE; ++ii) exp_sum[ii] = 1.f / exp_sum[ii];
+          l_scale.launch(  // PxV => O
+              PC_PV{
+                  /* rowidx = */ 0,
+                  /* colidx = */ 0,
+                  /* rowsize = */ M_TILE,
+                  /* colsize = */ p.head_size,
+                  /* MStep = */ M_TILE,
+                  /* NStep = */ GemmPV::NTILE,
+                  /* KStep = */ max_unmasked_pad_qk,  // TODO(Yi): pad?
+                  /* w_offset = */ ibat * V_pack_batch_off,
+                  /* StackSize = */ 0,
+              },
+              PVArgs{
+                  /* .M = */ std::min(p.sl_q - i_m, M_TILE),
+                  /* .N = */ p.head_size,
+                  /* .K = */ max_unmasked_pad_qk,
+                  /* .paramA = */ PVProPArgs{(jblas::utils::bf16*)tmp, ld_tmp_exp},
+                  /* .paramB = */ PVProVArgs{&V_pack},
+                  /* .paramC = */
+                  PVEpiArgs{
+                      /* .scale = */ exp_sum,
+                      /* .dst = */ head_dst + i_m * p.step_dst_sl,
+                      /* .ld_dst = */ p.step_dst_sl,
+                  },
+                  /* .workspace = */ nullptr,
+              });
+        }
+      }
+    }
+    return JblasSuccess;
+  }
+
+ protected:
+  L_ExpSum l_expsum;
+  L_Scale l_scale;
+};
+
+template <typename Q_T, typename K_T, typename V_T, typename DST_T>
+void jblas_attn_forward(const attn_fwd_args_t<Q_T, K_T, V_T, DST_T>* params) = delete;
+
+template <class GEMM_T, JBLAS_ISA ISA_T>
+using WeightPackBatchBf16Bf16NonTr = WeightPackBatchBf16NonTr<GEMM_T, ISA_T, bf16>;
+template <class GEMM_T, JBLAS_ISA ISA_T>
+using WeightPackBatchBf16Bf16Trans = WeightPackBatchBf16Trans<GEMM_T, ISA_T, bf16>;
+template <>
+void jblas_attn_forward<bf16, bf16, bf16, bf16>(const attn_fwd_args_t<bf16, bf16, bf16, bf16>* params) {
+  using GemmKernelBF16ExpSum = ::GemmLauncherPackWeightOff<  //
+      JblasAMX_BF16,                                         //
+      jblas::gemm::GemmCore_Row_NN_16x64_AMX_BF16,           //
+      jblas::prologue::gemm::ActivationBase,                 //
+      WeightPackBatchBf16Bf16Trans,                          //
+      ::ScaleExpAccSumFp32<bf16>>;                           //
+  using GemmKernelBF16 = ::GemmLauncherPackWeightOff<        //
+      JblasAMX_BF16,                                         //
+      jblas::gemm::GemmCore_Row_NN_16x64_AMX_BF16,           //
+      jblas::prologue::gemm::ActivationBase,                 //
+      WeightPackBatchBf16Bf16NonTr,                          //
+      ::ScaleWriteBackFp32<bf16>>;
+  static MHAInterface<GemmKernelBF16ExpSum, GemmKernelBF16> kernel;
+  kernel.compute(*params);
+}
+
+template <class GEMM_T, JBLAS_ISA ISA_T>
+using WeightPackBatchFp16Bf16NonTr = WeightPackBatchBf16NonTr<GEMM_T, ISA_T, fp16>;
+template <class GEMM_T, JBLAS_ISA ISA_T>
+using WeightPackBatchFp16Bf16Trans = WeightPackBatchBf16Trans<GEMM_T, ISA_T, fp16>;
+template <>
+void jblas_attn_forward<float, fp16, fp16, float>(const attn_fwd_args_t<float, fp16, fp16, float>* params) {
+  GetCPUDevice();
+  if (_cd->AMX_BF16()) {
+    using GemmKernelFP32FP16BF16ExpSum = ::GemmLauncherPackWeightOff<  //
+        JblasAMX_BF16,                                                 //
+        jblas::gemm::GemmCore_Row_NN_16x64_AMX_BF16,                   //
+        jblas::prologue::gemm::ActivationConverterFp32,                //
+        WeightPackBatchFp16Bf16Trans,                                  //
+        ::ScaleExpAccSumFp32<bf16>>;                                   //
+    using GemmKernelBF16FP16FP32 = ::GemmLauncherPackWeightOff<        //
+        JblasAMX_BF16,                                                 //
+        jblas::gemm::GemmCore_Row_NN_16x64_AMX_BF16,                   //
+        jblas::prologue::gemm::ActivationBase,                         //
+        WeightPackBatchFp16Bf16NonTr,                                  //
+        ::ScaleWriteBackFp32<float>>;
+    static MHAInterface<GemmKernelFP32FP16BF16ExpSum, GemmKernelBF16FP16FP32> kernel;
+    kernel.compute(*params);
+  } else {
+    assert(0);
+  }
+}
+
+template <typename Q_T, typename K_T, typename V_T, typename DST_T>
+void jblas_attn_forward_ref(const attn_fwd_args_t<Q_T, K_T, V_T, DST_T>* params) {
+  const auto p = *params;
+  assert(!p.is_causal || p.sl_q <= p.sl_kv);
+  attn_shape_t attn_shape{
+      p.batch_size, p.head_num, p.head_size, p.sl_q, p.sl_kv,
+  };
+  const auto workspace_size = jblas_attn_bf16_workspace_size(&attn_shape);
+  std::fill_n(params->tmp, workspace_size, 'f');
+
+#pragma omp parallel for collapse(3)
+  for (int ibs = 0; ibs < p.batch_size; ++ibs)
+    for (int ihn = 0; ihn < p.head_num; ++ihn)
+      for (int i = 0; i < p.sl_q; ++i) {
+        const auto q_curr = p.Q + ibs * p.step_q_bs + ihn * p.step_q_head_num + i * p.step_q_sl;
+        const auto dst_curr = p.dst + ibs * p.step_dst_bs + ihn * p.step_dst_head_num + i * p.step_dst_sl;
+
+        const auto k_curr = p.K + ibs * p.step_k_bs + ihn * p.step_k_head_num;
+        const auto v_curr = p.V + ibs * p.step_v_bs + ihn * p.step_v_head_num;
+
+        const auto sl_diff = p.sl_kv - p.sl_q;
+        const auto unmasked = p.is_causal ? sl_diff + i + 1 : p.sl_kv;
+        const auto curr_row = std::unique_ptr<float[]>(new float[unmasked]);
+
+        // Q x K
+        float row_max = -INFINITY;
+        for (int j = 0; j < unmasked; ++j) {
+          curr_row[j] = 0.f;
+          for (int k = 0; k < p.head_size; ++k) {
+            curr_row[j] += static_cast<float>(static_cast<bf16>(q_curr[k])) *  // TODO(Yi) fp16 acc
+                           static_cast<float>(static_cast<bf16>(k_curr[j * p.step_k_sl + k]));
+          }
+          curr_row[j] *= p.QK_scale;
+          row_max = std::max(row_max, curr_row[j]);
+        }
+
+        // exp
+        float exp_sum = 0.f;
+        for (int j = 0; j < unmasked; ++j) {
+          curr_row[j] = expf(curr_row[j] /* - row_max */);
+          exp_sum += curr_row[j];
+        }
+
+        // softmax
+        for (int j = 0; j < unmasked; ++j) curr_row[j] /= exp_sum;
+
+        // P x V
+        for (int j = 0; j < p.head_size; ++j) {
+          float dst_f32_v = 0.f;
+          for (int k = 0; k < unmasked; ++k) {
+            dst_f32_v += curr_row[k] * static_cast<float>(static_cast<bf16>(v_curr[k * p.step_v_sl + j]));
+          }
+          dst_curr[j] = static_cast<DST_T>(dst_f32_v);
+        }
+      }
+}
+}  // namespace
+
+void jblas_attn_bf16_forward(const attn_bf16_fwd_args_t* params) {
+  return jblas_attn_forward(reinterpret_cast<const attn_fwd_args_t<bf16, bf16, bf16, bf16>*>(params));
+}
+
+void jblas_attn_fp32_fp16_fp16_fp32_forward(const attn_fp32_fp16_fp16_fp32_fwd_args_t* params) {
+  return jblas_attn_forward(reinterpret_cast<const attn_fwd_args_t<float, fp16, fp16, float>*>(params));
+  // return jblas_attn_forward_ref(reinterpret_cast<const attn_fwd_args_t<float, fp16, fp16, float>*>(params));
+}
+
+size_t jblas_attn_bf16_workspace_size(const attn_shape_t* params) {
+  const auto& p = *params;  // TODO(Yi): Better way to get tmp size?
+  return size_t(omp_get_max_threads() * sizeof(float) * 16) * padto(p.sl_kv, 64);
+}
+
+#ifdef __GNUC__
+#pragma GCC pop_options
+#endif
+
+#ifdef NE_TESTS
+namespace {
+bool return_success = true;
+
+class TestMhaDese {
+ public:
+  TestMhaDese() {
+    printf("Test suit: %s\n", __FUNCTION__);
+    CheckISA(AMX_BF16);
+    jblas::utils::request_perm_xtile_data();
+    return_success &= test_case({1, 1, 32, 128, 64});
+    return_success &= test_case({2, 5, 32, 64, 128});
+    return_success &= test_case({2, 5, 80, 128, 77});
+    return_success &= test_case({1, 1, 256, 63, 63});
+    return_success &= test_case({3, 4, 256, 1, 384});
+    return_success &= test_case({1, 1, 64, 64, 64}, true);
+    printf("Test suit done: %s\n", __FUNCTION__);
+  }
+  bool test_case(const attn_shape_t& s, bool is_causal = false) {
+    using namespace jblas::utils;
+    const auto batch_size = s.batch_size;
+    const auto head_num = s.head_num;
+    const auto head_size = s.head_size;
+    const auto sl_q = s.sl_q;
+    const auto sl_kv = s.sl_kv;
+
+    printf("Test case : bs_%d hn_%d hs_%d sl_q_%d sk_kv_%d %s\n", batch_size, head_num, head_size, sl_q, sl_kv,
+           is_causal ? "maksed" : "unmask");
+    std::vector<float> src_q(batch_size * head_num * sl_q * head_size);
+    std::vector<fp16> src_k(batch_size * head_num * sl_kv * head_size);
+    std::vector<fp16> src_v(batch_size * head_num * sl_kv * head_size);
+    std::vector<float> dst(batch_size * head_num * sl_q * head_size);
+    std::vector<float> ref(batch_size * head_num * sl_q * head_size);  // reference result
+    std::vector<char> tmp(jblas_attn_bf16_workspace_size(&s));
+
+    // init vector
+    static std::mt19937 rng(1);
+    std::uniform_int_distribution<> dist;
+    init_vector(&src_q, -1.f, 1.f, dist(rng));
+    init_vector(&src_k, -1.f, 1.f, dist(rng));
+    init_vector(&src_v, -1.f, 1.f, dist(rng));
+
+    jblas_attn_fp32_fp16_fp16_fp32_fwd_args_t args{
+        /* .Q = */ src_q.data(),
+        /* .K = */ src_k.data(),
+        /* .V = */ src_v.data(),
+        /* .dst = */ ref.data(),
+        /* .tmp = */ tmp.data(),
+        /* .QK_scale = */ 1.f / sqrtf(static_cast<float>(batch_size)),
+        /* .is_causal = */ is_causal,
+        /* .batch_size = */ batch_size,
+        /* .head_num = */ head_num,
+        /* .head_size = */ head_size,
+        /* .sl_q = */ sl_q,
+        /* .sl_kv = */ sl_kv,
+        /* .step_q_bs = */ sl_q * head_num * head_size,
+        /* .step_q_head_num = */ head_size,
+        /* .step_q_sl = */ head_num * head_size,
+        /* .step_k_bs = */ sl_kv * head_num * head_size,
+        /* .step_k_head_num = */ head_size,
+        /* .step_k_sl = */ head_num * head_size,
+        /* .step_v_bs = */ sl_kv * head_num * head_size,
+        /* .step_v_head_num = */ head_size,
+        /* .step_v_sl = */ head_num * head_size,
+        /* .step_dst_bs = */ sl_q * head_num * head_size,
+        /* .step_dst_head_num = */ head_size,
+        /* .step_dst_sl = */ head_num * head_size,
+    };
+
+    jblas_attn_forward_ref(&args);
+
+    args.dst = dst.data();
+    jblas_attn_forward(&args);
+
+    // Check result
+    return compare_data(dst.data(), ref.data(), dst.size(), 1e-2f);
+  }
+};
+static const TestMhaDese inst_;
+
+}  // namespace
+
+int main() {
+  printf("NE_TESTS: mha_dense ");
+  printf(return_success ? "OK\n" : "FAILED\n");
+  return return_success ? 0 : -1;
+}
+#endif

--- a/intel_extension_for_transformers/backends/neural_engine/graph/core/layers/mha_dense.h
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/core/layers/mha_dense.h
@@ -1,0 +1,63 @@
+//  Copyright (c) 2023 Intel Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+#ifndef NE_CORE_GRAPH_MHA_DENSE_H
+#define NE_CORE_GRAPH_MHA_DENSE_H
+
+#include "core/data_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct attn_shape_t {
+  int batch_size, head_num, head_size, sl_q, sl_kv;
+} attn_shape_t;
+
+typedef struct attn_bf16_fwd_args_t {
+  ne_bf16_t *Q, *K, *V, *dst;
+  char* tmp;
+  float QK_scale;
+  bool is_causal;
+  int batch_size, head_num, head_size, sl_q, sl_kv;
+  int step_q_bs, step_q_head_num, step_q_sl;
+  int step_k_bs, step_k_head_num, step_k_sl;
+  int step_v_bs, step_v_head_num, step_v_sl;
+  int step_dst_bs, step_dst_head_num, step_dst_sl;
+} attn_bf16_fwd_args_t;
+
+typedef struct attn_fp32_fp16_fp16_fp32_fwd_args_t {
+  float* Q;
+  ne_fp16_t* K;
+  ne_fp16_t* V;
+  float* dst;
+  char* tmp;
+  float QK_scale;
+  bool is_causal;
+  int batch_size, head_num, head_size, sl_q, sl_kv;
+  int step_q_bs, step_q_head_num, step_q_sl;
+  int step_k_bs, step_k_head_num, step_k_sl;
+  int step_v_bs, step_v_head_num, step_v_sl;
+  int step_dst_bs, step_dst_head_num, step_dst_sl;
+} attn_fp32_fp16_fp16_fp32_fwd_args_t;
+
+void jblas_attn_bf16_forward(const attn_bf16_fwd_args_t* params);
+
+void jblas_attn_fp32_fp16_fp16_fp32_forward(const attn_fp32_fp16_fp16_fp32_fwd_args_t* params);
+
+size_t jblas_attn_bf16_workspace_size(const attn_shape_t* params);
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // NE_CORE_GRAPH_MHA_DENSE_H

--- a/intel_extension_for_transformers/backends/neural_engine/graph/core/layers/ne_test_layers_utils.hpp
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/core/layers/ne_test_layers_utils.hpp
@@ -1,0 +1,85 @@
+//  Copyright (c) 2023 Intel Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include <iostream>
+#include <memory>
+#include <random>
+
+#include "jblas/jit_blas_utils.h"
+
+#ifndef NE_TESTS
+static_assert(false, "Only include this header file for testing!");
+#endif
+
+template <typename T>
+void init_vector(std::vector<T>* v, float range1 = -10, float range2 = 10, int seed = 5489u) {
+  float low_value = std::max(range1, static_cast<float>(std::numeric_limits<T>::lowest()) + 1);
+  std::mt19937 gen(seed);
+  std::uniform_real_distribution<float> u(low_value, range2);
+  for (size_t i = 0; i < v->size(); ++i) (*v)[i] = u(gen);
+}
+
+template <>
+void init_vector<jblas::utils::bf16>(std::vector<jblas::utils::bf16>* v, float range1, float range2, int seed) {
+  std::mt19937 gen(seed);
+  std::uniform_real_distribution<float> u(range1, range2);
+  for (size_t i = 0; i < v->size(); ++i) (*v)[i] = jblas::utils::bf16(u(gen));
+}
+
+template <>
+void init_vector<jblas::utils::fp16>(std::vector<jblas::utils::fp16>* v, float range1, float range2, int seed) {
+  std::mt19937 gen(seed);
+  std::uniform_real_distribution<float> u(range1, range2);
+  for (size_t i = 0; i < v->size(); ++i) (*v)[i] = jblas::utils::fp16(u(gen));
+}
+
+template <typename T>
+struct s_is_u8s8 {
+  enum { value = false };
+};
+
+template <>
+struct s_is_u8s8<int8_t> {
+  enum { value = true };
+};
+
+template <>
+struct s_is_u8s8<uint8_t> {
+  enum { value = true };
+};
+
+template <typename T>
+inline typename std::enable_if<!s_is_u8s8<T>::value, float>::type get_err(const T& a, const T& b) {
+  // we compare float relative error ratio here
+  return fabs(static_cast<float>(a) - static_cast<float>(b)) /
+         std::max(static_cast<float>(fabs(static_cast<float>(b))), 1.0f);
+}
+template <typename T>
+inline typename std::enable_if<s_is_u8s8<T>::value, float>::type get_err(const T& a, const T& b) {
+  // for quantized value, error ratio was calcualted with its data range
+  return fabs(static_cast<float>(a) - static_cast<float>(b)) / UINT8_MAX;
+}
+
+template <typename T>
+bool compare_data(const T* buf1, const T* buf2, size_t size, float eps = 1e-6) {
+  if (buf1 == buf2) return false;
+
+  for (size_t i = 0; i < size; ++i) {
+    if (get_err(buf1[i], buf2[i]) > eps) {
+      std::cerr << static_cast<float>(buf1[i]) << "vs" << static_cast<float>(buf2[i]) << " idx=" << i << std::endl;
+      return false;
+    }
+  }
+  return true;
+}

--- a/intel_extension_for_transformers/backends/neural_engine/graph/core/ne_layers.c
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/core/ne_layers.c
@@ -48,6 +48,7 @@
 #include "layers/Ops.h"
 #include "layers/ele_reduce.h"
 #include "layers/ele_wise.h"
+#include "layers/mha_dense.h"
 #include "ne.h"
 
 // if C99 - static_assert is noop
@@ -411,7 +412,7 @@ static const char* NE_OP_LABEL[NE_OP_COUNT] = {
     "RMS_NORM_BACK",
 
     "MUL_MAT",
-
+    "MUL_MAT_WITH_BIAS",
     "SCALE",
     "SET",
     "CPY",
@@ -435,6 +436,8 @@ static const char* NE_OP_LABEL[NE_OP_COUNT] = {
 
     "MUL_QKV",
     "FFN_SILU",
+    "FFN_GeLU",
+    "FFN_ADD_GeLU",
     "FLASH_ATTN",
     "FLASH_FF",
 
@@ -442,7 +445,7 @@ static const char* NE_OP_LABEL[NE_OP_COUNT] = {
     "MAP_BINARY",
 };
 
-static_assert(NE_OP_COUNT == 53, "NE_OP_COUNT != 53");
+static_assert(NE_OP_COUNT == 56, "NE_OP_COUNT != 56");
 
 static const char* NE_OP_SYMBOL[NE_OP_COUNT] = {
     "none",
@@ -474,7 +477,7 @@ static const char* NE_OP_SYMBOL[NE_OP_COUNT] = {
     "rms_norm_back(x)",
 
     "X*Y",
-
+    "X*Y+Z",
     "x*v",
     "y-\\>view(x)",
     "x-\\>y",
@@ -498,6 +501,8 @@ static const char* NE_OP_SYMBOL[NE_OP_COUNT] = {
 
     "QKV(x)",
     "ffn_silu(x)",
+    "ffn_gelu(x)",
+    "ffn_gelu_with_bias(x)",
     "flash_attn(x)",
     "flash_ff(x)",
 
@@ -731,7 +736,8 @@ struct ne_context* ne_init(struct ne_init_params params) {
   if (is_first_call) {
     // initialize time system (required on Windows)
     ne_time_init();
-
+    // initialize jblas's amx instruction.
+    jblas_init();
     // initialize GELU, SILU and EXP F32 tables
     {
       const uint64_t t_start = ne_time_us();
@@ -1314,14 +1320,18 @@ struct ne_tensor* ne_dup_impl(struct ne_context* ctx, struct ne_tensor* a, bool 
   return result;
 }
 
-struct ne_tensor* ne_dup(struct ne_context* ctx, struct ne_tensor* a) { return ne_dup_impl(ctx, a, false); }
+struct ne_tensor* ne_dup(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_dup_impl(ctx, a, false);
+}
 
-struct ne_tensor* ne_dup_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_dup_impl(ctx, a, true); }
+struct ne_tensor* ne_dup_inplace(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_dup_impl(ctx, a, true);
+}
 
 // ne_add
 
 struct ne_tensor* ne_add_impl(struct ne_context* ctx, struct ne_tensor* a, struct ne_tensor* b, bool inplace) {
-  NE_ASSERT(ne_are_same_shape(a, b));
+  NE_ASSERT(ne_can_repeat_rows(b, a));
 
   bool is_node = false;
 
@@ -1543,9 +1553,13 @@ struct ne_tensor* ne_sqr_impl(struct ne_context* ctx, struct ne_tensor* a, bool 
   return result;
 }
 
-struct ne_tensor* ne_sqr(struct ne_context* ctx, struct ne_tensor* a) { return ne_sqr_impl(ctx, a, false); }
+struct ne_tensor* ne_sqr(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_sqr_impl(ctx, a, false);
+}
 
-struct ne_tensor* ne_sqr_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_sqr_impl(ctx, a, true); }
+struct ne_tensor* ne_sqr_inplace(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_sqr_impl(ctx, a, true);
+}
 
 // ne_sqrt
 
@@ -1566,9 +1580,13 @@ struct ne_tensor* ne_sqrt_impl(struct ne_context* ctx, struct ne_tensor* a, bool
   return result;
 }
 
-struct ne_tensor* ne_sqrt(struct ne_context* ctx, struct ne_tensor* a) { return ne_sqrt_impl(ctx, a, false); }
+struct ne_tensor* ne_sqrt(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_sqrt_impl(ctx, a, false);
+}
 
-struct ne_tensor* ne_sqrt_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_sqrt_impl(ctx, a, true); }
+struct ne_tensor* ne_sqrt_inplace(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_sqrt_impl(ctx, a, true);
+}
 
 // ne_log
 
@@ -1589,9 +1607,13 @@ struct ne_tensor* ne_log_impl(struct ne_context* ctx, struct ne_tensor* a, bool 
   return result;
 }
 
-struct ne_tensor* ne_log(struct ne_context* ctx, struct ne_tensor* a) { return ne_log_impl(ctx, a, false); }
+struct ne_tensor* ne_log(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_log_impl(ctx, a, false);
+}
 
-struct ne_tensor* ne_log_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_log_impl(ctx, a, true); }
+struct ne_tensor* ne_log_inplace(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_log_impl(ctx, a, true);
+}
 
 // ne_sum
 
@@ -1701,9 +1723,13 @@ struct ne_tensor* ne_abs_impl(struct ne_context* ctx, struct ne_tensor* a, bool 
   return result;
 }
 
-struct ne_tensor* ne_abs(struct ne_context* ctx, struct ne_tensor* a) { return ne_abs_impl(ctx, a, false); }
+struct ne_tensor* ne_abs(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_abs_impl(ctx, a, false);
+}
 
-struct ne_tensor* ne_abs_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_abs_impl(ctx, a, true); }
+struct ne_tensor* ne_abs_inplace(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_abs_impl(ctx, a, true);
+}
 
 // ne_sgn
 
@@ -1724,9 +1750,13 @@ struct ne_tensor* ne_sgn_impl(struct ne_context* ctx, struct ne_tensor* a, bool 
   return result;
 }
 
-struct ne_tensor* ne_sgn(struct ne_context* ctx, struct ne_tensor* a) { return ne_sgn_impl(ctx, a, false); }
+struct ne_tensor* ne_sgn(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_sgn_impl(ctx, a, false);
+}
 
-struct ne_tensor* ne_sgn_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_sgn_impl(ctx, a, true); }
+struct ne_tensor* ne_sgn_inplace(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_sgn_impl(ctx, a, true);
+}
 
 // ne_neg
 
@@ -1747,9 +1777,13 @@ struct ne_tensor* ne_neg_impl(struct ne_context* ctx, struct ne_tensor* a, bool 
   return result;
 }
 
-struct ne_tensor* ne_neg(struct ne_context* ctx, struct ne_tensor* a) { return ne_neg_impl(ctx, a, false); }
+struct ne_tensor* ne_neg(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_neg_impl(ctx, a, false);
+}
 
-struct ne_tensor* ne_neg_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_neg_impl(ctx, a, true); }
+struct ne_tensor* ne_neg_inplace(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_neg_impl(ctx, a, true);
+}
 
 // ne_step
 
@@ -1770,9 +1804,13 @@ struct ne_tensor* ne_step_impl(struct ne_context* ctx, struct ne_tensor* a, bool
   return result;
 }
 
-struct ne_tensor* ne_step(struct ne_context* ctx, struct ne_tensor* a) { return ne_step_impl(ctx, a, false); }
+struct ne_tensor* ne_step(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_step_impl(ctx, a, false);
+}
 
-struct ne_tensor* ne_step_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_step_impl(ctx, a, true); }
+struct ne_tensor* ne_step_inplace(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_step_impl(ctx, a, true);
+}
 
 // ne_relu
 
@@ -1793,9 +1831,13 @@ struct ne_tensor* ne_relu_impl(struct ne_context* ctx, struct ne_tensor* a, bool
   return result;
 }
 
-struct ne_tensor* ne_relu(struct ne_context* ctx, struct ne_tensor* a) { return ne_relu_impl(ctx, a, false); }
+struct ne_tensor* ne_relu(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_relu_impl(ctx, a, false);
+}
 
-struct ne_tensor* ne_relu_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_relu_impl(ctx, a, true); }
+struct ne_tensor* ne_relu_inplace(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_relu_impl(ctx, a, true);
+}
 
 // ne_gelu
 
@@ -1816,9 +1858,13 @@ struct ne_tensor* ne_gelu_impl(struct ne_context* ctx, struct ne_tensor* a, bool
   return result;
 }
 
-struct ne_tensor* ne_gelu(struct ne_context* ctx, struct ne_tensor* a) { return ne_gelu_impl(ctx, a, false); }
+struct ne_tensor* ne_gelu(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_gelu_impl(ctx, a, false);
+}
 
-struct ne_tensor* ne_gelu_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_gelu_impl(ctx, a, true); }
+struct ne_tensor* ne_gelu_inplace(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_gelu_impl(ctx, a, true);
+}
 
 // ne_silu
 
@@ -1839,9 +1885,13 @@ struct ne_tensor* ne_silu_impl(struct ne_context* ctx, struct ne_tensor* a, bool
   return result;
 }
 
-struct ne_tensor* ne_silu(struct ne_context* ctx, struct ne_tensor* a) { return ne_silu_impl(ctx, a, false); }
+struct ne_tensor* ne_silu(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_silu_impl(ctx, a, false);
+}
 
-struct ne_tensor* ne_silu_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_silu_impl(ctx, a, true); }
+struct ne_tensor* ne_silu_inplace(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_silu_impl(ctx, a, true);
+}
 
 // ne_silu_back
 
@@ -1883,9 +1933,13 @@ struct ne_tensor* ne_norm_impl(struct ne_context* ctx, struct ne_tensor* a, bool
   return result;
 }
 
-struct ne_tensor* ne_norm(struct ne_context* ctx, struct ne_tensor* a) { return ne_norm_impl(ctx, a, false); }
+struct ne_tensor* ne_norm(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_norm_impl(ctx, a, false);
+}
 
-struct ne_tensor* ne_norm_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_norm_impl(ctx, a, true); }
+struct ne_tensor* ne_norm_inplace(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_norm_impl(ctx, a, true);
+}
 
 struct ne_tensor* ne_rms_norm_impl(struct ne_context* ctx, struct ne_tensor* a, bool inplace) {
   bool is_node = false;
@@ -1904,7 +1958,9 @@ struct ne_tensor* ne_rms_norm_impl(struct ne_context* ctx, struct ne_tensor* a, 
   return result;
 }
 
-struct ne_tensor* ne_rms_norm(struct ne_context* ctx, struct ne_tensor* a) { return ne_rms_norm_impl(ctx, a, false); }
+struct ne_tensor* ne_rms_norm(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_rms_norm_impl(ctx, a, false);
+}
 
 struct ne_tensor* ne_rms_norm_inplace(struct ne_context* ctx, struct ne_tensor* a) {
   return ne_rms_norm_impl(ctx, a, true);
@@ -1940,14 +1996,38 @@ struct ne_tensor* ne_mul_mat(struct ne_context* ctx, struct ne_tensor* a, struct
     is_node = true;
   }
 
-  const int64_t ne[4] = { a->ne[1], b->ne[1], b->ne[2], b->ne[3] };
-  struct ne_tensor * result = ne_new_tensor(ctx, NE_TYPE_F32, MAX(a->n_dims, b->n_dims), ne, NE_SIZE_CALC);
+  const int64_t ne[4] = {a->ne[1], b->ne[1], b->ne[2], b->ne[3]};
+  struct ne_tensor* result = ne_new_tensor(ctx, NE_TYPE_F32, MAX(a->n_dims, b->n_dims), ne, NE_SIZE_CALC);
 
   result->op = NE_OP_MUL_MAT;
   result->grad = is_node ? ne_dup_tensor(ctx, result) : NULL;
   result->src0 = a;
   result->src1 = b;
 
+  return result;
+}
+
+// ne_mul_mat_with_bias
+
+struct ne_tensor* ne_mul_mat_with_bias(struct ne_context* ctx, struct ne_tensor* w, struct ne_tensor* b,
+                                       struct ne_tensor* a) {
+  NE_ASSERT(ne_can_mul_mat(w, a));
+  NE_ASSERT(!ne_is_transposed(w));
+
+  bool is_node = false;
+
+  if (w->grad || b->grad || a->grad) {
+    is_node = true;
+  }
+
+  const int64_t ne[4] = {w->ne[1], a->ne[1], w->ne[2], a->ne[3]};
+  struct ne_tensor* result = ne_new_tensor(ctx, a->type, MIN(w->n_dims, a->n_dims), ne, NE_SIZE_CALC);
+
+  result->op = NE_OP_MUL_MAT_BIAS;
+  result->grad = is_node ? ne_dup_tensor(ctx, result) : NULL;
+  result->src0 = w;
+  result->src1 = a;
+  result->opt[0] = b;
   return result;
 }
 
@@ -2008,6 +2088,56 @@ struct ne_tensor* ne_ffn_silu(struct ne_context* ctx, struct ne_tensor* w1, stru
   result->opt[1] = w3;
   result->opt[2] = tmp;
   result->opt[3] = tmp1;
+  return result;
+}
+
+struct ne_tensor* ne_ffn_add_gelu(struct ne_context* ctx, struct ne_tensor* w1, struct ne_tensor* w2,
+                                  struct ne_tensor* b1, struct ne_tensor* b2, struct ne_tensor* src) {
+  NE_ASSERT(w2->ne[0] == w1->ne[1]);
+
+  bool is_node = false;
+
+  if (src->grad || w1->grad || w2->grad || b1->grad || b2->grad) {
+    is_node = true;
+  }
+
+  const int64_t ne[4] = {w2->ne[1], src->ne[1], src->ne[2], src->ne[3]};
+  struct ne_tensor* result = ne_new_tensor(ctx, NE_TYPE_F32, src->n_dims, ne, NE_SIZE_CALC);
+  const int64_t tne[4] = {w1->ne[1], src->ne[1], src->ne[2], src->ne[3]};
+  struct ne_tensor* tmp = ne_new_tensor(ctx, NE_TYPE_F32, src->n_dims, tne, NE_SIZE_CALC);
+
+  result->op = NE_OP_MUL_FFN_ADD_GELU;
+  result->grad = is_node ? ne_dup_tensor(ctx, result) : NULL;
+  result->src0 = src;
+  result->src1 = w1;
+  result->opt[0] = w2;
+  result->opt[1] = b1;
+  result->opt[2] = b2;
+  result->opt[3] = tmp;
+  return result;
+}
+
+struct ne_tensor* ne_ffn_gelu(struct ne_context* ctx, struct ne_tensor* w1, struct ne_tensor* w2,
+                              struct ne_tensor* src) {
+  NE_ASSERT(w2->ne[0] == w1->ne[1]);
+
+  bool is_node = false;
+
+  if (src->grad || w1->grad || w2->grad) {
+    is_node = true;
+  }
+
+  const int64_t ne[4] = {w2->ne[1], src->ne[1], src->ne[2], src->ne[3]};
+  struct ne_tensor* result = ne_new_tensor(ctx, NE_TYPE_F32, src->n_dims, ne, NE_SIZE_CALC);
+  const int64_t tne[4] = {w1->ne[1], src->ne[1], src->ne[2], src->ne[3]};
+  struct ne_tensor* tmp = ne_new_tensor(ctx, NE_TYPE_F32, src->n_dims, tne, NE_SIZE_CALC);
+
+  result->op = NE_OP_MUL_FFN_GELU;
+  result->grad = is_node ? ne_dup_tensor(ctx, result) : NULL;
+  result->src0 = src;
+  result->src1 = w1;
+  result->opt[0] = w2;
+  result->opt[1] = tmp;
   return result;
 }
 
@@ -2154,9 +2284,13 @@ struct ne_tensor* ne_cont_impl(struct ne_context* ctx, struct ne_tensor* a, bool
   return result;
 }
 
-struct ne_tensor* ne_cont(struct ne_context* ctx, struct ne_tensor* a) { return ne_cont_impl(ctx, a, false); }
+struct ne_tensor* ne_cont(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_cont_impl(ctx, a, false);
+}
 
-struct ne_tensor* ne_cont_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_cont_impl(ctx, a, true); }
+struct ne_tensor* ne_cont_inplace(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_cont_impl(ctx, a, true);
+}
 
 // ne_reshape
 
@@ -2632,7 +2766,9 @@ struct ne_tensor* ne_soft_max_impl(struct ne_context* ctx, struct ne_tensor* a, 
   return result;
 }
 
-struct ne_tensor* ne_soft_max(struct ne_context* ctx, struct ne_tensor* a) { return ne_soft_max_impl(ctx, a, false); }
+struct ne_tensor* ne_soft_max(struct ne_context* ctx, struct ne_tensor* a) {
+  return ne_soft_max_impl(ctx, a, false);
+}
 
 struct ne_tensor* ne_soft_max_inplace(struct ne_context* ctx, struct ne_tensor* a) {
   return ne_soft_max_impl(ctx, a, true);
@@ -2834,26 +2970,31 @@ struct ne_tensor* ne_conv_1d_2s(struct ne_context* ctx, struct ne_tensor* a, str
 // ne_flash_attn
 
 struct ne_tensor* ne_flash_attn(struct ne_context* ctx, struct ne_tensor* q, struct ne_tensor* k, struct ne_tensor* v,
-                                bool masked) {
+                                float scale, bool masked) {
   NE_ASSERT(ne_can_mul_mat(k, q));
-  // TODO: check if vT can be multiplied by (k*qT)
-
-  bool is_node = false;
-
-  if (q->grad || k->grad || v->grad) {
-    NE_ASSERT(false);  // TODO: implement backward
-    is_node = true;
-  }
-
-  // struct ne_tensor * result = ne_dup_tensor(ctx, q);
-  struct ne_tensor* result = ne_new_tensor(ctx, NE_TYPE_F32, 4, q->ne, NE_SIZE_CALC);
-
+  int batch = q->ne[3];
+  int headsize = q->ne[0];
+  int headnum = q->ne[2];
+  int seq_cur = q->ne[1];
+  int seq_all = k->ne[1];
+  int seq_past = seq_all - seq_cur;
+  NE_ASSERT(headsize == v->ne[1]);
+  NE_ASSERT(seq_all == v->ne[0]);
+  NE_ASSERT(headnum == v->ne[2]);
+  NE_ASSERT(batch == v->ne[3]);
+  bool is_node = true;
+  struct ne_tensor* result = ne_new_tensor_4d(ctx, NE_TYPE_F32, headsize, headnum, seq_cur, batch, NE_SIZE_CALC);
+  attn_shape_t atte_shape = {batch, headnum, headsize, seq_cur, seq_all};
+  size_t tmpsize = jblas_attn_bf16_workspace_size(&atte_shape);
+  struct ne_tensor* tmp_t = ne_new_tensor_1d(ctx, NE_TYPE_I8, tmpsize, NE_SIZE_CALC);
   result->op = NE_OP_FLASH_ATTN;
-  result->grad = is_node ? ne_dup_tensor(ctx, result) : NULL;
+  result->grad = NULL;
   result->src0 = q;
   result->src1 = k;
   result->opt[0] = v;
-  result->opt[1] = ne_new_i32(ctx, masked ? 1 : 0);
+  result->opt[1] = tmp_t;
+  *(float*)result->padding = scale;
+  *(bool*)&result->padding[sizeof(scale)] = masked;
 
   return result;
 }
@@ -3352,23 +3493,38 @@ static void ne_compute_forward_dup_f32(const struct ne_compute_params* params, c
           }
         }
       } else if (dst->type == NE_TYPE_F16) {
-        size_t id = 0;
-        ne_fp16_t* dst_ptr = (ne_fp16_t*)dst->data;
+        if (ne_is_contiguous(src0)) {  // fp32->fp16 conversion
+          int nele = ne_nelements(src0);
+          // number of rows per thread
+          int dn = (nele + nth - 1) / nth;
+          // row range for this thread
+          int in0 = dn * ith;
+          int in1 = MIN(in0 + dn, nele);
+          float* srcptr = (float*)src0->data;
+          ne_fp16_t* dstptr = (ne_fp16_t*)dst->data;
+          for (int i = in0; i < in1; i++) {
+            dstptr[i] = NE_FP32_TO_FP16(srcptr[i]);
+          }
+        } else {
+          size_t id = 0;
+          ne_fp16_t* dst_ptr = (ne_fp16_t*)dst->data;
+          for (int i03 = 0; i03 < ne03; i03++) {
+            for (int i02 = 0; i02 < ne02; i02++) {
+              id += ne00 * ir0;
+              for (int i01 = ir0; i01 < ir1; i01++) {
+                for (int i00 = 0; i00 < ne00; i00++) {
+                  const float* src0_ptr =
+                      (float*)((char*)src0->data + i00 * nb00 + i01 * nb01 + i02 * nb02 + i03 * nb03);
 
-        for (int i03 = 0; i03 < ne03; i03++) {
-          for (int i02 = 0; i02 < ne02; i02++) {
-            id += ne00 * ir0;
-            for (int i01 = ir0; i01 < ir1; i01++) {
-              for (int i00 = 0; i00 < ne00; i00++) {
-                const float* src0_ptr = (float*)((char*)src0->data + i00 * nb00 + i01 * nb01 + i02 * nb02 + i03 * nb03);
-
-                dst_ptr[id] = NE_FP32_TO_FP16(*src0_ptr);
-                id++;
+                  dst_ptr[id] = NE_FP32_TO_FP16(*src0_ptr);
+                  id++;
+                }
               }
+              id += ne00 * (ne01 - ir1);
             }
-            id += ne00 * (ne01 - ir1);
           }
         }
+
       } else if (ne_is_quantized(dst->type)) {
         quantize_row_q_t const quantize_row_q = quantize_fns[dst->type].quantize_row_q;
 
@@ -3498,57 +3654,78 @@ static void ne_compute_forward_dup_f32(const struct ne_compute_params* params, c
       }
     }
   } else if (dst->type == NE_TYPE_F16) {
-    for (int64_t i03 = 0; i03 < ne03; i03++) {
-      for (int64_t i02 = 0; i02 < ne02; i02++) {
-        i10 += ne00 * ir0;
-        while (i10 >= ne0) {
-          i10 -= ne0;
-          if (++i11 == ne1) {
-            i11 = 0;
-            if (++i12 == ne2) {
-              i12 = 0;
-              if (++i13 == ne3) {
-                i13 = 0;
+    bool dst_contiguous = nb0 < nb1 && nb1 < nb2 && nb2 < nb3;
+    bool src_perm1203 = nb01 < nb02 && nb02 < nb00 && nb00 < nb03;
+    if (dst_contiguous && src_perm1203) {  // number of rows per thread
+      int nele = ne1 * ne2;
+      int dn = (nele + nth - 1) / nth;
+      // row range for this thread
+      int in0 = dn * ith;
+      int in1 = MIN(in0 + dn, nele);
+
+      for (int ib = 0; ib < ne3; ib++) {
+        float* srcptr = (float*)((char*)src0->data + ib * nb03);
+        ne_fp16_t* dstptr = (ne_fp16_t*)((char*)dst->data + ib * nb3);
+        for (int j = 0; j < ne0; j++) {
+          for (int i = in0; i < in1; i++) {
+            dstptr[i * nb1 / sizeof(*dstptr) + j] = NE_FP32_TO_FP16(srcptr[i + j * nb00 / sizeof(*srcptr)]);
+          }
+        }
+      }
+    } else {
+      for (int64_t i03 = 0; i03 < ne03; i03++) {
+        for (int64_t i02 = 0; i02 < ne02; i02++) {
+          i10 += ne00 * ir0;
+          while (i10 >= ne0) {
+            i10 -= ne0;
+            if (++i11 == ne1) {
+              i11 = 0;
+              if (++i12 == ne2) {
+                i12 = 0;
+                if (++i13 == ne3) {
+                  i13 = 0;
+                }
               }
             }
           }
-        }
-        for (int64_t i01 = ir0; i01 < ir1; i01++) {
-          for (int64_t i00 = 0; i00 < ne00; i00++) {
-            const char* src0_ptr = ((char*)src0->data + i00 * nb00 + i01 * nb01 + i02 * nb02 + i03 * nb03);
-            char* dst_ptr = ((char*)dst->data + i10 * nb0 + i11 * nb1 + i12 * nb2 + i13 * nb3);
+          for (int64_t i01 = ir0; i01 < ir1; i01++) {
+            for (int64_t i00 = 0; i00 < ne00; i00++) {
+              const char* src0_ptr = ((char*)src0->data + i00 * nb00 + i01 * nb01 + i02 * nb02 + i03 * nb03);
+              char* dst_ptr = ((char*)dst->data + i10 * nb0 + i11 * nb1 + i12 * nb2 + i13 * nb3);
 
-            *(ne_fp16_t*)dst_ptr = NE_FP32_TO_FP16(*(const float*)src0_ptr);
+              *(ne_fp16_t*)dst_ptr = NE_FP32_TO_FP16(*(const float*)src0_ptr);
 
-            if (++i10 == ne0) {
-              i10 = 0;
-              if (++i11 == ne1) {
-                i11 = 0;
-                if (++i12 == ne2) {
-                  i12 = 0;
-                  if (++i13 == ne3) {
-                    i13 = 0;
+              if (++i10 == ne0) {
+                i10 = 0;
+                if (++i11 == ne1) {
+                  i11 = 0;
+                  if (++i12 == ne2) {
+                    i12 = 0;
+                    if (++i13 == ne3) {
+                      i13 = 0;
+                    }
                   }
                 }
               }
             }
           }
-        }
-        i10 += ne00 * (ne01 - ir1);
-        while (i10 >= ne0) {
-          i10 -= ne0;
-          if (++i11 == ne1) {
-            i11 = 0;
-            if (++i12 == ne2) {
-              i12 = 0;
-              if (++i13 == ne3) {
-                i13 = 0;
+          i10 += ne00 * (ne01 - ir1);
+          while (i10 >= ne0) {
+            i10 -= ne0;
+            if (++i11 == ne1) {
+              i11 = 0;
+              if (++i12 == ne2) {
+                i12 = 0;
+                if (++i13 == ne3) {
+                  i13 = 0;
+                }
               }
             }
           }
         }
       }
     }
+
   } else {
     NE_ASSERT(false);  // TODO: implement
   }
@@ -3577,7 +3754,7 @@ static void ne_compute_forward_dup(const struct ne_compute_params* params, const
 
 static void ne_compute_forward_add_f32(const struct ne_compute_params* params, const struct ne_tensor* src0,
                                        const struct ne_tensor* src1, struct ne_tensor* dst) {
-  NE_ASSERT(ne_are_same_shape(src0, src1) && ne_are_same_shape(src0, dst));
+  NE_ASSERT(ne_can_repeat_rows(src1, src0) && ne_are_same_shape(src0, dst));
 
   if (params->type == NE_TASK_INIT || params->type == NE_TASK_FINALIZE) {
     return;
@@ -3586,10 +3763,16 @@ static void ne_compute_forward_add_f32(const struct ne_compute_params* params, c
   const int ith = params->ith;
   const int nth = params->nth;
 
-  const int nr = ne_nrows(src0);
-  const int64_t ne0 = src0->ne[0];
-  const int64_t ne1 = src0->ne[1];
-  const int64_t ne2 = src0->ne[2];
+  const int64_t nr = ne_nrows(src0);
+
+  const int64_t ne00 = src0->ne[0];
+  const int64_t ne01 = src0->ne[1];
+  const int64_t ne02 = src0->ne[2];
+
+  const int64_t ne10 = src1->ne[0];
+  const int64_t ne11 = src1->ne[1];
+  const int64_t ne12 = src1->ne[2];
+  const int64_t ne13 = src1->ne[3];
 
   const size_t nb00 = src0->nb[0];
   const size_t nb01 = src0->nb[1];
@@ -3597,9 +3780,9 @@ static void ne_compute_forward_add_f32(const struct ne_compute_params* params, c
   const size_t nb03 = src0->nb[3];
 
   const size_t nb10 = src1->nb[0];
-  const size_t nb11 = src1->nb[1];
-  const size_t nb12 = src1->nb[2];
-  const size_t nb13 = src1->nb[3];
+  const size_t nb11 = ne11 == 1 ? 0 : src1->nb[1];
+  const size_t nb12 = ne12 == 1 ? 0 : src1->nb[2];
+  const size_t nb13 = ne13 == 1 ? 0 : src1->nb[3];
 
   const size_t nb0 = dst->nb[0];
   const size_t nb1 = dst->nb[1];
@@ -3608,39 +3791,43 @@ static void ne_compute_forward_add_f32(const struct ne_compute_params* params, c
 
   NE_ASSERT(nb0 == sizeof(float));
   NE_ASSERT(nb00 == sizeof(float));
-
-  // rows per thread
-  const int dr = (nr + nth - 1) / nth;
-
-  // row range for this thread
-  const int ir0 = dr * ith;
-  const int ir1 = MIN(ir0 + dr, nr);
+  NE_ASSERT(ne00 == ne10);
 
   if (nb10 == sizeof(float)) {
-    for (int ir = ir0; ir < ir1; ++ir) {
-      // src0, src1 and dst are same shape => same indices
-      const int i3 = ir / (ne2 * ne1);
-      const int i2 = (ir - i3 * ne2 * ne1) / ne1;
-      const int i1 = (ir - i3 * ne2 * ne1 - i2 * ne1);
+    for (int64_t ir = ith; ir < nr; ir += nth) {
+      // src0 and dst are same shape => same indices
+      const int64_t i03 = ir / (ne02 * ne01);
+      const int64_t i02 = (ir - i03 * ne02 * ne01) / ne01;
+      const int64_t i01 = (ir - i03 * ne02 * ne01 - i02 * ne01);
 
-      ne_vec_add_f32(ne0, (float*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1),
-                     (float*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01),
-                     (float*)((char*)src1->data + i3 * nb13 + i2 * nb12 + i1 * nb11));
-      // }
-      // }
+      const int64_t i13 = i03 % ne13;
+      const int64_t i12 = i02 % ne12;
+      const int64_t i11 = i01 % ne11;
+
+      float* dst_ptr = (float*)((char*)dst->data + i03 * nb3 + i02 * nb2 + i01 * nb1);
+      float* src0_ptr = (float*)((char*)src0->data + i03 * nb03 + i02 * nb02 + i01 * nb01);
+      float* src1_ptr = (float*)((char*)src1->data + i13 * nb13 + i12 * nb12 + i11 * nb11);
+
+      ne_vec_add_f32(ne00, dst_ptr, src0_ptr, src1_ptr);
     }
   } else {
     // src1 is not contiguous
-    for (int ir = ir0; ir < ir1; ++ir) {
-      // src0, src1 and dst are same shape => same indices
-      const int i3 = ir / (ne2 * ne1);
-      const int i2 = (ir - i3 * ne2 * ne1) / ne1;
-      const int i1 = (ir - i3 * ne2 * ne1 - i2 * ne1);
+    for (int64_t ir = ith; ir < nr; ir += nth) {
+      // src0 and dst are same shape => same indices
+      // src1 is broadcastable across src0 and dst in i1, i2, i3
+      const int64_t i03 = ir / (ne02 * ne01);
+      const int64_t i02 = (ir - i03 * ne02 * ne01) / ne01;
+      const int64_t i01 = (ir - i03 * ne02 * ne01 - i02 * ne01);
 
-      float* dst_ptr = (float*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1);
-      float* src0_ptr = (float*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01);
-      for (int i0 = 0; i0 < ne0; i0++) {
-        float* src1_ptr = (float*)((char*)src1->data + i3 * nb13 + i2 * nb12 + i1 * nb11 + i0 * nb10);
+      const int64_t i13 = i03 % ne13;
+      const int64_t i12 = i02 % ne12;
+      const int64_t i11 = i01 % ne11;
+
+      float* dst_ptr = (float*)((char*)dst->data + i03 * nb3 + i02 * nb2 + i01 * nb1);
+      float* src0_ptr = (float*)((char*)src0->data + i03 * nb03 + i02 * nb02 + i01 * nb01);
+
+      for (int64_t i0 = 0; i0 < ne00; i0++) {
+        float* src1_ptr = (float*)((char*)src1->data + i13 * nb13 + i12 * nb12 + i11 * nb11 + i0 * nb10);
 
         dst_ptr[i0] = src0_ptr[i0] + *src1_ptr;
       }
@@ -4374,9 +4561,9 @@ static void ne_compute_forward_mul_f32(const struct ne_compute_params* params, c
   const size_t nb03 = src0->nb[3];
 
   const size_t nb10 = src1->nb[0];
-  const size_t nb11 = src1->nb[1];
-  const size_t nb12 = src1->nb[2];
-  const size_t nb13 = src1->nb[3];
+  const size_t nb11 = ne11 == 1 ? 0 : src1->nb[1];
+  const size_t nb12 = ne12 == 1 ? 0 : src1->nb[2];
+  const size_t nb13 = ne13 == 1 ? 0 : src1->nb[3];
 
   const size_t nb0 = dst->nb[0];
   const size_t nb1 = dst->nb[1];
@@ -4403,8 +4590,6 @@ static void ne_compute_forward_mul_f32(const struct ne_compute_params* params, c
       float* src1_ptr = (float*)((char*)src1->data + i13 * nb13 + i12 * nb12 + i11 * nb11);
 
       ne_vec_mul_f32(ne00, dst_ptr, src0_ptr, src1_ptr);
-      // }
-      // }
     }
   } else {
     // src1 is not contiguous
@@ -5544,12 +5729,14 @@ static void ne_compute_forward_mul_mat_f32(const struct ne_compute_params* param
   const size_t nb02 = src0->nb[2];
   const size_t nb03 = src0->nb[3];
 
+  const int nb10 = src1->nb[0];
 
-  const size_t nb10 = src1->nb[0];
-
-  const size_t nb11 = src1->nb[1]; UNUSED(nb11);
-  const size_t nb12 = src1->nb[2]; UNUSED(nb12);
-  const size_t nb13 = src1->nb[3]; UNUSED(nb13);
+  const int nb11 = src1->nb[1];
+  UNUSED(nb11);
+  const int nb12 = src1->nb[2];
+  UNUSED(nb12);
+  const int nb13 = src1->nb[3];
+  UNUSED(nb13);
 
   const size_t nb0 = dst->nb[0];
   const size_t nb1 = dst->nb[1];
@@ -5585,51 +5772,37 @@ static void ne_compute_forward_mul_mat_f32(const struct ne_compute_params* param
     return;
   }
 
-   // parallelize by src0 rows
-    const int64_t dr = (ne01 + nth - 1) / nth;
+  // parallelize by src0 rows
+  const int64_t dr = (ne01 + nth - 1) / nth;
 
-    const int64_t ir10 = dr * ith;
-    const int64_t ir11 = MIN(ir10 + dr, ne01);
+  const int64_t ir10 = dr * ith;
+  const int64_t ir11 = MIN(ir10 + dr, ne01);
 
-    // src1 rows
-    const int64_t nr1 = ne11 * ne12 * ne13;
+  // src1 rows
+  const int64_t nr1 = ne11 * ne12 * ne13;
 
-    for (int64_t ir1 = 0; ir1 < nr1; ++ir1) {
-      const int64_t i13 = (ir1 / (ne12 * ne11));
-      const int64_t i12 = (ir1 - i13 * ne12 * ne11) / ne11;
-      const int64_t i11 = (ir1 - i13 * ne12 * ne11 - i12 * ne11);
+  for (int64_t ir1 = 0; ir1 < nr1; ++ir1) {
+    const int64_t i13 = (ir1 / (ne12 * ne11));
+    const int64_t i12 = (ir1 - i13 * ne12 * ne11) / ne11;
+    const int64_t i11 = (ir1 - i13 * ne12 * ne11 - i12 * ne11);
 
-      const int64_t ir0 = (ir1 / ne11) % (ne02 * ne03);
-      const int64_t i03 = (ir0 / (ne02));
-      const int64_t i02 = (ir0 - i03 * ne02);
+    const int64_t ir0 = (ir1 / ne11) % (ne02 * ne03);
+    const int64_t i03 = (ir0 / (ne02));
+    const int64_t i02 = (ir0 - i03 * ne02);
 
-      const int64_t i1 = i11;
-      const int64_t i2 = i12;
-      const int64_t i3 = i13;
+    const int64_t i1 = i11;
+    const int64_t i2 = i12;
+    const int64_t i3 = i13;
 
-      char* src0_row = (char*) src0->data + (0 + i02 * nb02 + i03 * nb03);
-      char* src1_col = (char*) src1->data + (i11 * nb11 + i12 * nb12 + i13 * nb13);
+    char* src0_row = (char*)src0->data + (0 + i02 * nb02 + i03 * nb03);
+    char* src1_col = (char*)src1->data + (i11 * nb11 + i12 * nb12 + i13 * nb13);
 
-      float* dst_col = (float*) ((char*) dst->data + (i1 * nb1 + i2 * nb2 + i3 * nb3));
+    float* dst_col = (float*)((char*)dst->data + (i1 * nb1 + i2 * nb2 + i3 * nb3));
 
-      for (int64_t ir = ir10; ir < ir11; ++ir) {
-        ne_vec_dot_f32(ne00, &dst_col[ir], (float*) (src0_row + ir * nb01), (float*) src1_col);
+    for (int64_t ir = ir10; ir < ir11; ++ir) {
+      ne_vec_dot_f32(ne00, &dst_col[ir], (float*)(src0_row + ir * nb01), (float*)src1_col);
     }
   }
-
-  // int64_t t1 = ne_perf_time_us();
-  // static int64_t acc = 0;
-  // acc += t1 - t0;
-  // if (t1 - t0 > 10) {
-  //     printf("\n");
-  //     printf("ne00 = %5d, ne01 = %5d, ne02 = %5d, ne03 = %5d\n", ne00, ne01, ne02, ne03);
-  //     printf("nb00 = %5d, nb01 = %5d, nb02 = %5d, nb03 = %5d\n", nb00, nb01, nb02, nb03);
-  //     printf("ne10 = %5d, ne11 = %5d, ne12 = %5d, ne13 = %5d\n", ne10, ne11, ne12, ne13);
-  //     printf("nb10 = %5d, nb11 = %5d, nb12 = %5d, nb13 = %5d\n", nb10, nb11, nb12, nb13);
-
-  //    printf("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX task %d/%d: %d us, acc = %d\n", ith, nth, (int) (t1
-  //    - t0), (int) acc);
-  //}
 }
 
 static void ne_compute_forward_mul_mat_f16_f32(const struct ne_compute_params* params, const struct ne_tensor* src0,
@@ -5716,38 +5889,38 @@ static void ne_compute_forward_mul_mat_f16_f32(const struct ne_compute_params* p
   // TODO: do not support transposed src1
   assert(nb10 / 2 == sizeof(ne_fp16_t));
 
-   // parallelize by src0 rows
-    const int64_t dr = (ne01 + nth - 1) / nth;
+  // parallelize by src0 rows
+  const int64_t dr = (ne01 + nth - 1) / nth;
 
-    const int64_t ir10 = dr * ith;
-    const int64_t ir11 = MIN(ir10 + dr, ne01);
+  const int64_t ir10 = dr * ith;
+  const int64_t ir11 = MIN(ir10 + dr, ne01);
 
-    // src1 rows
-    const int64_t nr1 = ne11 * ne12 * ne13;
+  // src1 rows
+  const int64_t nr1 = ne11 * ne12 * ne13;
 
-    void* wdata = params->wdata;
-    const size_t row_size = ne10 * NE_TYPE_SIZE[NE_TYPE_F16];
+  void* wdata = params->wdata;
+  const size_t row_size = ne10 * NE_TYPE_SIZE[NE_TYPE_F16];
 
-    for (int64_t ir1 = 0; ir1 < nr1; ++ir1) {
-      const int64_t i13 = (ir1 / (ne12 * ne11));
-      const int64_t i12 = (ir1 - i13 * ne12 * ne11) / ne11;
-      const int64_t i11 = (ir1 - i13 * ne12 * ne11 - i12 * ne11);
+  for (int64_t ir1 = 0; ir1 < nr1; ++ir1) {
+    const int64_t i13 = (ir1 / (ne12 * ne11));
+    const int64_t i12 = (ir1 - i13 * ne12 * ne11) / ne11;
+    const int64_t i11 = (ir1 - i13 * ne12 * ne11 - i12 * ne11);
 
-      const int64_t ir0 = (ir1 / ne11) % (ne02 * ne03);
-      const int64_t i03 = (ir0 / (ne02));
-      const int64_t i02 = (ir0 - i03 * ne02);
+    const int64_t ir0 = (ir1 / ne11) % (ne02 * ne03);
+    const int64_t i03 = (ir0 / (ne02));
+    const int64_t i02 = (ir0 - i03 * ne02);
 
-      const int64_t i1 = i11;
-      const int64_t i2 = i12;
-      const int64_t i3 = i13;
+    const int64_t i1 = i11;
+    const int64_t i2 = i12;
+    const int64_t i3 = i13;
 
-      char* src0_row = (char*) src0->data + (0 + i02 * nb02 + i03 * nb03);
-      char* src1_col = (char*) wdata + (i11 + i12 * ne11 + i13 * ne12 * ne11) * row_size;
+    char* src0_row = (char*)src0->data + (0 + i02 * nb02 + i03 * nb03);
+    char* src1_col = (char*)wdata + (i11 + i12 * ne11 + i13 * ne12 * ne11) * row_size;
 
-      float* dst_col = (float*) ((char*) dst->data + (i1 * nb1 + i2 * nb2 + i3 * nb3));
+    float* dst_col = (float*)((char*)dst->data + (i1 * nb1 + i2 * nb2 + i3 * nb3));
 
-      for (int64_t ir = ir10; ir < ir11; ++ir) {
-        ne_vec_dot_f16(ne00, &dst_col[ir], (ne_fp16_t*) (src0_row + ir * nb01), (ne_fp16_t*) src1_col);
+    for (int64_t ir = ir10; ir < ir11; ++ir) {
+      ne_vec_dot_f16(ne00, &dst_col[ir], (ne_fp16_t*)(src0_row + ir * nb01), (ne_fp16_t*)src1_col);
     }
   }
 
@@ -5855,7 +6028,7 @@ static void ne_compute_forward_mul_mat_q_f32(const struct ne_compute_params* par
   // src1 rows
   const int64_t nr1 = ne11 * ne12 * ne13;
 
-  const void * wdata = params->wdata;
+  const void* wdata = params->wdata;
   const size_t row_size = ne10 * NE_TYPE_SIZE[vec_dot_type] / NE_BLCK_SIZE[vec_dot_type];
 
   for (int64_t ir1 = 0; ir1 < nr1; ++ir1) {
@@ -5871,10 +6044,10 @@ static void ne_compute_forward_mul_mat_q_f32(const struct ne_compute_params* par
     const int64_t i2 = i12;
     const int64_t i3 = i13;
 
-    const char* src0_row = (const char*) src0->data + (0 + i02 * nb02 + i03 * nb03);
-    const char* src1_col = (const char*) wdata + (i11 + i12 * ne11 + i13 * ne12 * ne11) * row_size;
+    const char* src0_row = (const char*)src0->data + (0 + i02 * nb02 + i03 * nb03);
+    const char* src1_col = (const char*)wdata + (i11 + i12 * ne11 + i13 * ne12 * ne11) * row_size;
 
-    float* dst_col = (float*) ((char*) dst->data + (i1 * nb1 + i2 * nb2 + i3 * nb3));
+    float* dst_col = (float*)((char*)dst->data + (i1 * nb1 + i2 * nb2 + i3 * nb3));
 
     for (int64_t ir = ir10; ir < ir11; ++ir) {
       vec_dot_q(ne00, &dst_col[ir], src0_row + ir * nb01, src1_col);
@@ -5997,6 +6170,98 @@ static void ne_compute_forward_mul_mat(const struct ne_compute_params* params, c
   }
 }
 
+static void ne_compute_forward_mul_mat_bias_q_f32_jblas(const struct ne_compute_params* params,
+                                                        const struct ne_tensor* src0, const struct ne_tensor* src1,
+                                                        const struct ne_tensor* bias, struct ne_tensor* dst) {
+  int64_t t0 = ne_perf_time_us();
+  UNUSED(t0);
+
+  const int64_t ne00 = src0->ne[0];
+  const int64_t ne01 = src0->ne[1];
+  const int64_t ne02 = src0->ne[2];
+  const int64_t ne03 = src0->ne[3];
+
+  const int64_t ne10 = src1->ne[0];
+  const int64_t ne11 = src1->ne[1];
+  const int64_t ne12 = src1->ne[2];
+  const int64_t ne13 = src1->ne[3];
+
+  const int64_t ne0 = dst->ne[0];
+  const int64_t ne1 = dst->ne[1];
+  const int64_t ne2 = dst->ne[2];
+  const int64_t ne3 = dst->ne[3];
+
+  const int nb00 = src0->nb[0];
+  const int nb01 = src0->nb[1];
+  const int nb02 = src0->nb[2];
+  const int nb03 = src0->nb[3];
+
+  const int nb10 = src1->nb[0];
+  const int nb11 = src1->nb[1];
+  const int nb12 = src1->nb[2];
+  const int nb13 = src1->nb[3];
+
+  const int nb0 = dst->nb[0];
+  const int nb1 = dst->nb[1];
+  const int nb2 = dst->nb[2];
+  const int nb3 = dst->nb[3];
+
+  const int ith = params->ith;
+  const int nth = params->nth;
+
+  NE_ASSERT(ne02 == ne12);
+  NE_ASSERT(ne03 == ne13);
+  NE_ASSERT(ne2 == ne12);
+  NE_ASSERT(ne3 == ne13);
+
+  const enum ne_type type = src0->type;
+  quantize_row_q_t const quantize_row_q_dot = quantize_fns[type].quantize_row_q_dot;
+  vec_dot_q_t const vec_dot_q = quantize_fns[type].vec_dot_q;
+  enum ne_type const vec_dot_type = quantize_fns[type].vec_dot_type;
+
+  // we don't support permuted src0 or src1
+  NE_ASSERT(nb00 == (int)NE_TYPE_SIZE[type]);
+  NE_ASSERT(nb10 == sizeof(float));
+
+  // dst cannot be transposed or permuted
+  NE_ASSERT(nb0 == sizeof(float));
+  NE_ASSERT(nb0 <= nb1);
+  NE_ASSERT(nb1 <= nb2);
+  NE_ASSERT(nb2 <= nb3);
+
+  NE_ASSERT(ne0 == ne01);
+  NE_ASSERT(ne1 == ne11);
+  NE_ASSERT(ne2 == ne02);
+  NE_ASSERT(ne3 == ne03);
+
+  // nb01 >= nb00 - src0 is not transposed
+  //   compute by src0 rows
+
+  if (params->type == NE_TASK_INIT) {
+    return;
+  }
+
+  if (params->type == NE_TASK_FINALIZE) {
+    return;
+  }
+  const bool boardcast_bias = bias->ne[1] == 1;
+  jblas_weights4block_add_f32_forward((float*)src1->data, src0->data, (float*)bias->data, (float*)dst->data, ne1, ne0,
+                                      ne10, ne10, ne0, boardcast_bias);
+}
+
+static void ne_compute_forward_mul_mat_bias(const struct ne_compute_params* params, const struct ne_tensor* src0,
+                                            const struct ne_tensor* src1, const struct ne_tensor* bias,
+                                            struct ne_tensor* dst) {
+  switch (src0->type) {
+    case NE_TYPE_JBLAS: {
+      ne_compute_forward_mul_mat_bias_q_f32_jblas(params, src0, src1, bias, dst);
+    } break;
+    default: {
+      NE_ASSERT(false);
+    } break;
+  }
+}
+
 static void ne_compute_forward_mul_qkv(const struct ne_compute_params* params, const struct ne_tensor* src,
                                        const struct ne_tensor* qw, const struct ne_tensor* kw, struct ne_tensor* vw,
                                        struct ne_tensor* dst) {
@@ -6029,6 +6294,44 @@ static void ne_compute_forward_ffn_silu(const struct ne_compute_params* params, 
   const int seq = dst->ne[1];
   jblas_weightcomp_FFN_SiLu_f32_forward((float*)src->data, w1->data, w2->data, w3->data, (float*)tmp->data,
                                         (float*)tmp1->data, (float*)dst->data, seq, fin, fmid, fout);
+}
+
+static void ne_compute_forward_ffn_add_gelu(const struct ne_compute_params* params, const struct ne_tensor* src,
+                                            const struct ne_tensor* w1, const struct ne_tensor* w2,
+                                            const struct ne_tensor* b1, const struct ne_tensor* b2,
+                                            const struct ne_tensor* tmp, struct ne_tensor* dst) {
+  if (params->type == NE_TASK_INIT) {
+    return;
+  }
+
+  if (params->type == NE_TASK_FINALIZE) {
+    return;
+  }
+  const int fin = src->ne[0];
+  const int fout = dst->ne[0];
+  const int fmid = w1->ne[1];
+  const int seq = dst->ne[1];
+  const bool boardcast_bias = b1->ne[1] == 1 || b2->ne[1] == 1;
+  jblas_weightcomp_FFN_Add_GeLu_f32_forward((float*)src->data, w1->data, w2->data, (float*)b1->data, (float*)b2->data,
+                                            (float*)tmp->data, (float*)dst->data, seq, fin, fmid, fout, boardcast_bias);
+}
+
+static void ne_compute_forward_ffn_gelu(const struct ne_compute_params* params, const struct ne_tensor* src,
+                                        const struct ne_tensor* w1, const struct ne_tensor* w2,
+                                        const struct ne_tensor* tmp, struct ne_tensor* dst) {
+  if (params->type == NE_TASK_INIT) {
+    return;
+  }
+
+  if (params->type == NE_TASK_FINALIZE) {
+    return;
+  }
+  const int fin = src->ne[0];
+  const int fout = dst->ne[0];
+  const int fmid = w1->ne[1];
+  const int seq = dst->ne[1];
+  jblas_weightcomp_FFN_GeLu_f32_forward((float*)src->data, w1->data, w2->data, (float*)tmp->data, (float*)dst->data,
+                                        seq, fin, fmid, fout);
 }
 
 // ne_compute_forward_scale
@@ -8041,6 +8344,98 @@ static void ne_compute_forward_flash_attn_f32(const struct ne_compute_params* pa
   }
 }
 
+static void ne_compute_forward_flash_attn_f32_f16_f16(const struct ne_compute_params* params, const struct ne_tensor* q,
+                                                      const struct ne_tensor* k, const struct ne_tensor* v,
+                                                      const struct ne_tensor* tmp, struct ne_tensor* dst) {
+  const int64_t neq0 = q->ne[0];
+  const int64_t neq1 = q->ne[1];
+  const int64_t neq2 = q->ne[2];
+  const int64_t neq3 = q->ne[3];
+
+  const int64_t nek0 = k->ne[0];
+  const int64_t nek1 = k->ne[1];
+  // const int64_t nek2 = k->ne[2];
+  // const int64_t nek3 = k->ne[3];
+
+  // const int64_t nev0 = v->ne[0];
+  const int64_t nev1 = v->ne[1];
+  // const int64_t nev2 = v->ne[2];
+  // const int64_t nev3 = v->ne[3];
+
+  const int64_t ne0 = dst->ne[0];
+  const int64_t ne1 = dst->ne[1];
+  // const int64_t ne2  = dst->ne[2];
+  // const int64_t ne3  = dst->ne[3];
+
+  const int nbk0 = k->nb[0];
+  const int nbk1 = k->nb[1];
+  const int nbk2 = k->nb[2];
+  const int nbk3 = k->nb[3];
+
+  const int nbq0 = q->nb[0];
+  const int nbq1 = q->nb[1];
+  const int nbq2 = q->nb[2];
+  const int nbq3 = q->nb[3];
+
+  const int nbv0 = v->nb[0];
+  const int nbv1 = v->nb[1];
+  const int nbv2 = v->nb[2];
+  const int nbv3 = v->nb[3];
+
+  const int nb0 = dst->nb[0];
+  const int nb1 = dst->nb[1];
+  const int nb2 = dst->nb[2];
+  const int nb3 = dst->nb[3];
+
+  const int64_t headsize = neq0;
+  const int64_t headnum = neq2;
+  const int64_t embedsize = headnum * headsize;
+  const int64_t seq_cur = neq1;
+  const int64_t seq_all = nek1;
+  const int64_t seq_past = seq_all - seq_cur;
+  const int64_t batch = neq3;
+
+  const int step_k_bs = k->nb[3] / sizeof(float);
+  const int step_v_bs = v->nb[3] / sizeof(float);
+
+  if (params->type == NE_TASK_INIT) {
+    return;
+  }
+
+  if (params->type == NE_TASK_FINALIZE) {
+    return;
+  }
+  float scale = *(float*)dst->padding;
+  bool mask = *(bool*)&dst->padding[sizeof(scale)];
+  attn_fp32_fp16_fp16_fp32_fwd_args_t args = {
+      .Q = (float*)q->data,
+      .K = (ne_fp16_t*)k->data,
+      .V = (ne_fp16_t*)v->data,
+      .batch_size = batch,
+      .head_size = headsize,
+      .head_num = headnum,
+      .dst = (float*)dst->data,
+      .is_causal = mask,
+      .QK_scale = scale,
+      .sl_q = seq_cur,
+      .sl_kv = seq_all,
+      .step_q_bs = seq_cur * embedsize,
+      .step_q_head_num = headsize,
+      .step_q_sl = embedsize,
+      .step_k_bs = step_k_bs,
+      .step_k_head_num = headsize,
+      .step_k_sl = embedsize,
+      .step_v_bs = step_v_bs,
+      .step_v_head_num = headsize,
+      .step_v_sl = embedsize,
+      .step_dst_bs = seq_cur * embedsize,
+      .step_dst_head_num = headsize,
+      .step_dst_sl = embedsize,
+      .tmp = tmp->data,
+  };
+  jblas_attn_fp32_fp16_fp16_fp32_forward(&args);
+}
+
 static void ne_compute_forward_flash_attn_f16(const struct ne_compute_params* params, const struct ne_tensor* q,
                                               const struct ne_tensor* k, const struct ne_tensor* v, const bool masked,
                                               struct ne_tensor* dst) {
@@ -8269,14 +8664,15 @@ static void ne_compute_forward_flash_attn_f16(const struct ne_compute_params* pa
 }
 
 static void ne_compute_forward_flash_attn(const struct ne_compute_params* params, const struct ne_tensor* q,
-                                          const struct ne_tensor* k, const struct ne_tensor* v, const bool masked,
-                                          struct ne_tensor* dst) {
+                                          const struct ne_tensor* k, const struct ne_tensor* v,
+                                          const struct ne_tensor* tmp, struct ne_tensor* dst) {
   switch (q->type) {
-    case NE_TYPE_F16: {
-      ne_compute_forward_flash_attn_f16(params, q, k, v, masked, dst);
-    } break;
     case NE_TYPE_F32: {
-      ne_compute_forward_flash_attn_f32(params, q, k, v, masked, dst);
+      if (k->type == NE_TYPE_F16) {
+        ne_compute_forward_flash_attn_f32_f16_f16(params, q, k, v, tmp, dst);
+      } else {
+        NE_ASSERT(false);
+      }
     } break;
     default: {
       NE_ASSERT(false);
@@ -8626,6 +9022,9 @@ static void ne_compute_forward(struct ne_compute_params* params, struct ne_tenso
     case NE_OP_RMS_NORM_BACK: {
       ne_compute_forward_rms_norm_back(params, tensor->src0, tensor->src1, tensor);
     } break;
+    case NE_OP_MUL_MAT_BIAS: {
+      ne_compute_forward_mul_mat_bias(params, tensor->src0, tensor->src1, tensor->opt[0], tensor);
+    } break;
     case NE_OP_MUL_MAT: {
       ne_compute_forward_mul_mat(params, tensor->src0, tensor->src1, tensor);
     } break;
@@ -8635,6 +9034,13 @@ static void ne_compute_forward(struct ne_compute_params* params, struct ne_tenso
     case NE_OP_MUL_FFN_SILU: {
       ne_compute_forward_ffn_silu(params, tensor->src0, tensor->src1, tensor->opt[0], tensor->opt[1], tensor->opt[2],
                                   tensor->opt[3], tensor);
+    } break;
+    case NE_OP_MUL_FFN_ADD_GELU: {
+      ne_compute_forward_ffn_add_gelu(params, tensor->src0, tensor->src1, tensor->opt[0], tensor->opt[1],
+                                      tensor->opt[2], tensor->opt[3], tensor);
+    } break;
+    case NE_OP_MUL_FFN_GELU: {
+      ne_compute_forward_ffn_gelu(params, tensor->src0, tensor->src1, tensor->opt[0], tensor->opt[1], tensor);
     } break;
     case NE_OP_SCALE: {
       ne_compute_forward_scale(params, tensor->src0, tensor->src1, tensor);
@@ -8697,10 +9103,7 @@ static void ne_compute_forward(struct ne_compute_params* params, struct ne_tenso
       ne_compute_forward_conv_1d_2s(params, tensor->src0, tensor->src1, tensor);
     } break;
     case NE_OP_FLASH_ATTN: {
-      int32_t t = ne_get_i32_1d(tensor->opt[1], 0);
-      NE_ASSERT(t == 0 || t == 1);
-      bool masked = t != 0;
-      ne_compute_forward_flash_attn(params, tensor->src0, tensor->src1, tensor->opt[0], masked, tensor);
+      ne_compute_forward_flash_attn(params, tensor->src0, tensor->src1, tensor->opt[0], tensor->opt[1], tensor);
     } break;
     case NE_OP_FLASH_FF: {
       ne_compute_forward_flash_ff(params, tensor->src0, tensor->src1, tensor->opt[0], tensor->opt[1], tensor->opt[2],
@@ -9529,8 +9932,7 @@ void ne_graph_compute(struct ne_context* ctx, struct ne_cgraph* cgraph) {
 
       switch (node->op) {
         case NE_OP_CPY: {
-          node->n_tasks = node->ne[0] == 1 ? n_threads : 1;
-
+          node->n_tasks = n_threads;  // node->ne[0] == 1 ? n_threads : 1;
           size_t cur = 0;
           if (ne_is_quantized(node->type)) {
             cur = NE_TYPE_SIZE[NE_TYPE_F32] * node->ne[0] * n_threads;
@@ -9549,7 +9951,11 @@ void ne_graph_compute(struct ne_context* ctx, struct ne_cgraph* cgraph) {
         } break;
         case NE_OP_ADD:
         case NE_OP_ADD1: {
-          node->n_tasks = 1;
+          if (node->src0->ne[1] > 4) {
+            node->n_tasks = n_threads;
+          } else {
+            node->n_tasks = 1;
+          }
 
           size_t cur = 0;
 
@@ -9578,15 +9984,19 @@ void ne_graph_compute(struct ne_context* ctx, struct ne_cgraph* cgraph) {
         case NE_OP_SUM:
         case NE_OP_SUM_ROWS:
         case NE_OP_MEAN:
-        case NE_OP_REPEAT:
         case NE_OP_ABS:
+        case NE_OP_REPEAT:
         case NE_OP_SGN:
         case NE_OP_NEG:
         case NE_OP_STEP:
         case NE_OP_MUL:
         case NE_OP_RMS_NORM:
         case NE_OP_RELU: {
-          node->n_tasks = 1;
+          if (node->src0->ne[1] > 4) {
+            node->n_tasks = n_threads;
+          } else {
+            node->n_tasks = 1;
+          }
         } break;
         case NE_OP_GELU:
         case NE_OP_SILU:
@@ -9595,6 +10005,7 @@ void ne_graph_compute(struct ne_context* ctx, struct ne_cgraph* cgraph) {
         case NE_OP_RMS_NORM_BACK: {
           node->n_tasks = n_threads;
         } break;
+        case NE_OP_MUL_MAT_BIAS:
         case NE_OP_MUL_MAT: {
           node->n_tasks = n_threads;
 
@@ -9625,6 +10036,8 @@ void ne_graph_compute(struct ne_context* ctx, struct ne_cgraph* cgraph) {
           work_size = MAX(work_size, cur);
         } break;
         case NE_OP_MUL_FFN_SILU:
+        case NE_OP_MUL_FFN_GELU:
+        case NE_OP_MUL_FFN_ADD_GELU:
         case NE_OP_MUL_QKV: {
           node->n_tasks = 1;
         } break;
@@ -9644,10 +10057,17 @@ void ne_graph_compute(struct ne_context* ctx, struct ne_cgraph* cgraph) {
           node->n_tasks = 1;
         } break;
         case NE_OP_DIAG_MASK_INF:
-        case NE_OP_SOFT_MAX:
         case NE_OP_ROPE:
-          node->n_tasks = 1;
+          if (node->src0->ne[1] > 4) {
+            node->n_tasks = n_threads;
+          } else {
+            node->n_tasks = 1;
+          }
           break;
+        case NE_OP_SOFT_MAX: {
+          size_t rows = ne_nrows(node->src0);
+          node->n_tasks = rows > 1 ? n_threads : 1;
+        } break;
         case NE_OP_ROPE_BACK: {
           node->n_tasks = n_threads;
         } break;
@@ -9681,23 +10101,8 @@ void ne_graph_compute(struct ne_context* ctx, struct ne_cgraph* cgraph) {
           work_size = MAX(work_size, cur);
         } break;
         case NE_OP_FLASH_ATTN: {
-          node->n_tasks = n_threads;
-
-          size_t cur = 0;
-
-          const int64_t ne11 = ne_up(node->src1->ne[1], NE_SOFT_MAX_UNROLL);
-
-          if (node->src1->type == NE_TYPE_F32) {
-            cur = sizeof(float) * ne11 * node->n_tasks;   // TODO: this can become (n_tasks-1)
-            cur += sizeof(float) * ne11 * node->n_tasks;  // this is overestimated by x2
-          }
-
-          if (node->src1->type == NE_TYPE_F16) {
-            cur = sizeof(float) * ne11 * node->n_tasks;   // TODO: this can become (n_tasks-1)
-            cur += sizeof(float) * ne11 * node->n_tasks;  // this is overestimated by x2
-          }
-
-          work_size = MAX(work_size, cur);
+          node->n_tasks = 1;
+          work_size = 0LL;
         } break;
         case NE_OP_FLASH_FF: {
           node->n_tasks = n_threads;

--- a/intel_extension_for_transformers/backends/neural_engine/graph/core/ne_layers.h
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/core/ne_layers.h
@@ -226,6 +226,9 @@ NE_API struct ne_tensor* ne_rms_norm_back(struct ne_context* ctx, struct ne_tens
 // result is m columns, p rows
 NE_API struct ne_tensor* ne_mul_mat(struct ne_context* ctx, struct ne_tensor* a, struct ne_tensor* b);
 
+NE_API struct ne_tensor* ne_mul_mat_with_bias(struct ne_context* ctx, struct ne_tensor* w, struct ne_tensor* b,
+                                              struct ne_tensor* a);
+
 // merged Q K V  ne_mul_mat
 NE_API struct ne_tensor* ne_mul_qkv(struct ne_context* ctx, struct ne_tensor* qw, struct ne_tensor* kw,
                                     struct ne_tensor* vw, struct ne_tensor* src);
@@ -233,6 +236,12 @@ NE_API struct ne_tensor* ne_mul_qkv(struct ne_context* ctx, struct ne_tensor* qw
 // merged Q K V  ne_mul_mat
 NE_API struct ne_tensor* ne_ffn_silu(struct ne_context* ctx, struct ne_tensor* w1, struct ne_tensor* w2,
                                      struct ne_tensor* w3, struct ne_tensor* src);
+
+NE_API struct ne_tensor* ne_ffn_add_gelu(struct ne_context* ctx, struct ne_tensor* w1, struct ne_tensor* w2,
+                                         struct ne_tensor* b1, struct ne_tensor* b2, struct ne_tensor* src);
+
+NE_API struct ne_tensor* ne_ffn_gelu(struct ne_context* ctx, struct ne_tensor* w1, struct ne_tensor* w2,
+                                     struct ne_tensor* src);
 
 //
 // operations on tensors without backpropagation
@@ -366,7 +375,7 @@ NE_API struct ne_tensor* ne_conv_1d_1s(struct ne_context* ctx, struct ne_tensor*
 NE_API struct ne_tensor* ne_conv_1d_2s(struct ne_context* ctx, struct ne_tensor* a, struct ne_tensor* b);
 
 NE_API struct ne_tensor* ne_flash_attn(struct ne_context* ctx, struct ne_tensor* q, struct ne_tensor* k,
-                                       struct ne_tensor* v, bool masked);
+                                       struct ne_tensor* v, float scale, bool masked);
 
 NE_API struct ne_tensor* ne_flash_ff(struct ne_context* ctx, struct ne_tensor* a, struct ne_tensor* b0,
                                      struct ne_tensor* b1, struct ne_tensor* c0, struct ne_tensor* c1);

--- a/intel_extension_for_transformers/backends/neural_engine/graph/jblas/jblas/jit_base.hpp
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/jblas/jblas/jit_base.hpp
@@ -183,6 +183,8 @@ class JitAvx512f : protected JitAvx2 {
   }
 };
 
+class JitAvx512_fp16 : protected JitAvx512f {};
+
 class JitAvx512vnni : protected JitAvx512f {
  protected:
 };

--- a/intel_extension_for_transformers/backends/neural_engine/graph/jblas/jblas/jit_blas.h
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/jblas/jblas/jit_blas.h
@@ -28,6 +28,7 @@ enum JBLAS_ISA {
   JblasAVX512_VNNI = 14,
   JblasAMX_BF16 = 15,
   JblasAMX_INT8 = 16,
+  JblasAVX512_FP16 = 17,
 };
 enum JBLAS_DTYPE {
   JblasF64 = 59,
@@ -43,7 +44,20 @@ enum JBLAS_FP8_ENCODING {
   JblasFp8_e3m4 = 82,
 };
 enum JBLAS_LAYOUT { JblasRowMajor = 101, JblasColMajor = 102 };
-enum JBLAS_TRANSPOSE { JblasNoTrans = 111, JblasTrans = 112, JblasConjTrans = 113 };
+enum JBLAS_TRANSPOSE {
+  JblasNoTrans = 111,
+  JblasTrans = 112,
+  JblasConjTrans = 113,
+};
+enum JBLAS_ELTWISEOP {
+  GELU,
+  SWISH,
+  TANH,
+  EXP,
+  LOW_PRECISION_EXP,
+  RELU,
+  LINEAR,
+};
 
 void jblas_sgemm(const JBLAS_LAYOUT Layout, const JBLAS_TRANSPOSE TransA, const JBLAS_TRANSPOSE TransB, const int M,
                  const int N, const int K, const float alpha, const float* A, const int lda, const float* B,

--- a/intel_extension_for_transformers/backends/neural_engine/graph/jblas/jblas/jit_blas_epilogue.h
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/jblas/jblas/jit_blas_epilogue.h
@@ -20,11 +20,11 @@
 namespace jblas {
 namespace epilogue {
 namespace gemm {
-template <typename _T>
-class AccumulateWriteBack {
+template <typename _SRC_T, typename _DST_T>
+class AccumulatorWriteBack {
  public:
   struct Param {
-    _T* C;
+    _DST_T* C;
     int ldc;
   };
 
@@ -33,8 +33,38 @@ class AccumulateWriteBack {
                      const int N, const Param& _param) {
     auto COffset = M_offset * _param.ldc + N_offset;
     auto cptr = _param.C + COffset;
-    return kernel::wrapper::Memcpy2D::template forward<ISA_T>((void*)cacheptr, (void*)cptr, M, N * sizeof(_T),
-                                                              cachestep * sizeof(float), _param.ldc * sizeof(_T));
+    static_assert(std::is_same<_SRC_T, float>::value,
+                  "src data type must be float in AccumulatorWriteBack epilogue now.");
+    if (std::is_same<_DST_T, jblas::utils::bf16>::value) {
+      return kernel::wrapper::Memcpy2DFp32CvtBf16::template forward<ISA_T>(
+          (void*)cacheptr, (void*)cptr, M, N, cachestep * sizeof(_SRC_T), _param.ldc * sizeof(_DST_T));
+    } else if (sizeof(_SRC_T) == sizeof(_DST_T)) {
+      return kernel::wrapper::Memcpy2D::template forward<ISA_T>(
+          (void*)cacheptr, (void*)cptr, M, N * sizeof(_DST_T), cachestep * sizeof(_SRC_T), _param.ldc * sizeof(_DST_T));
+    } else {
+      assert(false);
+    }
+  }
+};
+
+template <typename _SRC_T, typename _DST_T>
+class AccumulatorWriteBackWithGelu {
+ public:
+   struct Param {
+    _DST_T* C;
+    int ldc;
+  };
+
+  template <JBLAS_ISA ISA_T>
+  JBLAS_CODE forward(const float* cacheptr, const int cachestep, const int M_offset, const int N_offset, const int M,
+                     const int N, const Param& _param) {
+    auto COffset = M_offset * _param.ldc + N_offset;
+    auto cptr = _param.C + COffset;
+    static_assert(std::is_same<_SRC_T, float>::value && std::is_same<_DST_T, float>::value,
+                  "src/dst data type must be float in AccumulatorWriteBackWithGelu epilogue now.");
+
+    return kernel::wrapper::Memcpy2D::template forward_with_gelu<ISA_T>(
+        (void*)cacheptr, (void*)cptr, M, N * sizeof(_DST_T), cachestep * sizeof(_SRC_T), _param.ldc * sizeof(_DST_T));
   }
 };
 

--- a/intel_extension_for_transformers/backends/neural_engine/graph/jblas/jblas/jit_blas_gemm.h
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/jblas/jblas/jit_blas_gemm.h
@@ -19,14 +19,19 @@
 
 namespace jblas {
 namespace gemm {
+//Append new type, do not insert. back-ward compatibility
 enum class GemmCoreType : int {
   Undef = 0,
   AVX2_4X24,
   AVX512F_8X48,
   AVX512_VNNI_8X48,
-  AMX_BF16,
-  AMX_INT8,
+  AMX_BF16_16x64,
+  AMX_BF16_16x48,
+  AMX_INT8_16x64,
+  AMX_INT8_16x48,
   AVX512_VNNI_3X48_KBLOCK,
+  AMX_INT8_16X48_KBLOCK,
+  AVX512_FP16_8x64,
 };
 class GemmCore_Row_NN_4x24_AVX2 {
  public:
@@ -482,7 +487,228 @@ class GemmCore_Row_NN_8x48_AVX512F {
 
  private:
   std::array<MicroKernel, MTILE> mCodes;
+}; 
+class GemmCore_Row_NN_8x64_AVX512_FP16 {
+ public:
+  struct params {
+    utils::fp16 *matA, *matB, *matC;
+    int k, nsize;
+    int astep, bstep, cstep;
+    int kpos;
+  };
+  typedef long long (*func_t)(params*);
+  typedef utils::bf16 AType;
+  typedef utils::bf16 BType;
+  typedef utils::bf16 CType;
+  static JBLAS_ISA constexpr ISA = JblasAVX512_FP16;
+  static GemmCoreType constexpr TYPE = GemmCoreType::AVX512_FP16_8x64;
+  static int constexpr NTILE = 64, MTILE = 8, KTILE = 1;
+  static int constexpr KUNROLL = 2;
+  static int constexpr PACK_ROW = 1;
+  static int constexpr PREFERED_N = 128;
+  class MicroKernel : protected jblas::xbyak::JitAvx512_fp16 {
+   public:
+    MicroKernel() {}
+    int CRegCount = 16, BRegCount = 3, ARegCount = 1;
+    int CReg = 0, BReg = 16, AReg = 19, TmpReg = 20;
+    int const NRegs = 2;
+    static int constexpr BKStepSize = KTILE * NTILE * sizeof(BType);
+    static int constexpr AKStepSize = KTILE * sizeof(AType);
+    static int constexpr VecBytes = 64;
+
+    void generate_code(int _mtile) {
+      reset();
+      generate_mtile(_mtile);
+      ready();
+      mKernel = getCode<func_t>();
+    }
+    func_t mKernel = nullptr;
+
+   protected:
+    void generate_mtile(int _mtile) {
+      CRegCount = _mtile * NRegs;
+      BRegCount = NRegs;
+      BReg = CReg + CRegCount;
+      AReg = BReg + BRegCount;
+      TmpReg = AReg + ARegCount;
+      inLocalLabel();  // use local label for multiple instance
+      Xbyak::util::StackFrame st(this, 1, 11, 16 * 10);
+      parambase = st.p[0];
+      reg_matAptr = st.t[0];
+      reg_matBptr = st.t[1];
+      reg_matCptr = st.t[0];
+      reg_ksize = st.t[2];
+      reg_nsize = st.t[9];
+      reg_cstep = st.t[3];
+      reg_astep = st.t[5];
+      reg_iterk = st.t[4];
+      reg_itern = st.t[7];
+      reg_tmp = st.t[6];
+      reg_tmp1 = st.t[8];
+      reg_tmp2 = st.t[10];
+      reg_ret = rax;
+
+      vreg_push(rsp);
+
+      mov(reg_matBptr, ptr[parambase + OFFSET(matB)]);
+      load32(reg_ksize, ptr[parambase + OFFSET(k)]);
+      load32(reg_nsize, ptr[parambase + OFFSET(nsize)]);
+      load32(reg_astep, ptr[parambase + OFFSET(astep)]);
+
+      xor_(reg_itern, reg_itern);
+      L(".nloop");
+      for (int i = 0; i < _mtile; i++) {
+        for (int j = 0; j < NRegs; j++) {
+          vpxorq(Xbyak::Zmm(CReg + i * NRegs + j), Xbyak::Zmm(CReg + i * NRegs + j), Xbyak::Zmm(CReg + i * NRegs + j));
+        }
+      }
+      mov(reg_matAptr, ptr[parambase + OFFSET(matA)]);
+      mov(reg_tmp1, reg_matBptr);
+
+      xor_(reg_iterk, reg_iterk);
+
+      mov(reg_tmp, reg_nsize);
+      sub(reg_tmp, reg_itern);
+      cmp(reg_tmp, NTILE);
+      jl(".n32", T_NEAR);
+      generate_kloop(_mtile, NRegs);
+      write_back(_mtile, NRegs, parambase, reg_matCptr, reg_cstep, reg_itern);
+      load32(reg_tmp, ptr[parambase + OFFSET(bstep)]);
+      imul(reg_tmp, reg_tmp, NTILE);
+      add(reg_matBptr, reg_tmp);
+      add(reg_itern, NTILE);
+      jmp(".nend", T_NEAR);
+
+      L(".n32");
+      generate_kloop(_mtile, 2);
+      write_back(_mtile, 2, parambase, reg_matCptr, reg_cstep, reg_itern);
+      add(reg_itern, 32);
+      add(reg_matBptr, 32 * sizeof(BType));
+
+      L(".nend");
+      cmp(reg_itern, reg_nsize);
+      jb(".nloop");
+
+      mov(reg_ret, 0);
+      vreg_pop(rsp);
+
+      outLocalLabel();  // end of local label
+    }
+
+    void generate_kloop(int _mtile, int _nregs) {
+      inLocalLabel();
+      L(".kloop");
+      mov(reg_tmp, reg_ksize);
+      sub(reg_tmp, reg_iterk);
+      cmp(reg_tmp, KUNROLL * KTILE);
+      jl(".k1loop", T_NEAR);
+      generate_fma(_mtile, _nregs, KUNROLL, reg_tmp, reg_matAptr, reg_tmp1, reg_astep);
+      add(reg_matAptr, KUNROLL * AKStepSize);
+      add(reg_tmp1, KUNROLL * BKStepSize);
+      add(reg_iterk, KUNROLL * KTILE);
+      jmp(".kloopend", T_NEAR);
+
+      L(".k1loop");
+      generate_fma(_mtile, _nregs, 1, reg_tmp, reg_matAptr, reg_tmp1, reg_astep);
+      add(reg_matAptr, 1 * AKStepSize);
+      add(reg_tmp1, 1 * BKStepSize);
+      add(reg_iterk, 1 * KTILE);
+      L(".kloopend");
+      cmp(reg_iterk, reg_ksize);  // k iteration variable
+      jb(".kloop");
+      outLocalLabel();
+    }
+
+    void generate_fma(int _mtile, int _NRegs, int _ktile, const Xbyak::Reg64& reg_tmp, const Xbyak::Reg64& reg_matAptr,
+                      const Xbyak::Reg64& reg_matBptr, const Xbyak::Reg64& reg_astep) {
+      for (int kk = 0; kk < _ktile; kk++) {
+        lea(reg_tmp, ptr[reg_matAptr + kk * AKStepSize]);
+        for (int i = 0; i < _NRegs; i++) {
+          vmovups(Xbyak::Zmm(BReg + i), ptr[reg_matBptr + kk * BKStepSize + i * VecBytes]);
+        }
+        for (int mm = 0; mm < _mtile; mm++) {
+          vpbroadcastw(Xbyak::Zmm(AReg), ptr[reg_tmp]);
+          add(reg_tmp, reg_astep);
+          for (int i = 0; i < _NRegs; i++) {
+            vfmadd231ph(Xbyak::Zmm(CReg + mm * NRegs + i), Xbyak::Zmm(BReg + i), Xbyak::Zmm(AReg));
+          }
+        }
+      }
+    }
+
+    void write_back(int _mtile, int _NRegs, const Xbyak::Reg64& parambase, const Xbyak::Reg64& reg_matCptr,
+                    const Xbyak::Reg64& reg_cstep, const Xbyak::Reg64& reg_itern) {
+      inLocalLabel();
+      load32(reg_matCptr, ptr[parambase + OFFSET(kpos)]);
+      cmp(reg_matCptr, 0);
+      jg(".LACC", T_NEAR);
+      mov(reg_matCptr, ptr[parambase + OFFSET(matC)]);
+      lea(reg_matCptr, ptr[reg_matCptr + reg_itern * sizeof(CType)]);
+      load32(reg_cstep, ptr[parambase + OFFSET(cstep)]);
+      for (int i = 0; i < _mtile; i++) {
+        for (int j = 0; j < _NRegs; j++) {
+          vmovups(ptr[reg_matCptr + j * VecBytes], Xbyak::Zmm(CReg + i * NRegs + j));
+        }
+        add(reg_matCptr, reg_cstep);
+      }
+      jmp(".LEND", T_NEAR);
+      L(".LACC");
+      mov(reg_matCptr, ptr[parambase + OFFSET(matC)]);
+      lea(reg_matCptr, ptr[reg_matCptr + reg_itern * sizeof(CType)]);
+      load32(reg_cstep, ptr[parambase + OFFSET(cstep)]);
+      for (int i = 0; i < _mtile; i++) {
+        for (int j = 0; j < _NRegs; j++) {
+          vaddph(Xbyak::Zmm(CReg + i * NRegs + j), ptr[reg_matCptr + j * VecBytes]);
+          vmovups(ptr[reg_matCptr + j * VecBytes], Xbyak::Zmm(CReg + i * NRegs + j));
+        }
+        add(reg_matCptr, reg_cstep);
+      }
+      L(".LEND");
+      nop();
+      outLocalLabel();
+    }
+
+   private:
+    Xbyak::Reg64 parambase;
+    Xbyak::Reg64 reg_matAptr;
+    Xbyak::Reg64 reg_matBptr;
+    Xbyak::Reg64 reg_matCptr;
+    Xbyak::Reg64 reg_ksize;
+    Xbyak::Reg64 reg_nsize;
+    Xbyak::Reg64 reg_cstep;
+    Xbyak::Reg64 reg_astep;
+    Xbyak::Reg64 reg_iterk;
+    Xbyak::Reg64 reg_itern;
+    Xbyak::Reg64 reg_tmp;
+    Xbyak::Reg64 reg_tmp1;
+    Xbyak::Reg64 reg_tmp2;
+    Xbyak::Reg64 reg_ret = rax;
+    Xbyak::Opmask msk_wr = k1;
+  };
+
+ public:
+  GemmCore_Row_NN_8x64_AVX512_FP16() {
+    for (int i = 0; i < MTILE; i++) {
+      mCodes[i].generate_code(i + 1);
+    }
+  }
+
+  void forward(utils::fp16* matA, utils::fp16* matB, utils::fp16* matC, int _m, int _n, int _k, int _astride,
+               int _bstride,
+               int _cstride,
+               int kpos) {
+    auto param = params{matA, matB, matC, _k, _n, _astride, _bstride, _cstride, kpos};
+    if (_m <= MTILE) {
+      mCodes[_m - 1].mKernel(&param);
+    } else {
+      assert(0);
+    }
+  }
+
+ private:
+  std::array<MicroKernel, MTILE> mCodes;
 };
+
 class GemmCore_Row_NN_8x48_AVX512_VNNI {
  public:
   struct params {
@@ -734,8 +960,8 @@ class GemmCore_Row_NN_8x48_AVX512_VNNI {
 };
 class GemmCore_Row_NN_16x64_AMX_BF16 {
  public:
-  typedef uint16_t AType;
-  typedef uint16_t BType;
+  typedef utils::bf16 AType;
+  typedef utils::bf16 BType;
   typedef float CType;
   struct params {
     AType* matA;
@@ -749,7 +975,7 @@ class GemmCore_Row_NN_16x64_AMX_BF16 {
   typedef long long (*func_t)(params*);
 
   static JBLAS_ISA constexpr ISA = JblasAMX_BF16;
-  static GemmCoreType constexpr TYPE = GemmCoreType::AMX_BF16;
+  static GemmCoreType constexpr TYPE = GemmCoreType::AMX_BF16_16x64;
   static int constexpr NTILE = 64, MTILE = 16, KTILE = 64 / sizeof(BType);
   static int constexpr PACK_ROW = 2;
   static int constexpr KUNROLL = 2;
@@ -991,14 +1217,13 @@ class GemmCore_Row_NN_16x64_AMX_BF16 {
  public:
   GemmCore_Row_NN_16x64_AMX_BF16() {
     mCodes.generate_code();
-    memset(&mCfg, 0, sizeof(mCfg));
-    jblas::xbyak::JitAmxtile::configure_tiles(mCfg, 16, 16, 32, sizeof(BType), MicroKernel::A_tilenum,
-                                              MicroKernel::B_tilenum, MicroKernel::C_tilenum);
   }
 
   void forward(AType* matA, BType* matB, CType* matC, int _m, int _n, int _k, int _astride, int _bstride, int _cstride,
                int kpos) {
     char tmp[NTILE * MTILE * sizeof(CType)];
+    MicroKernel::tileconfig_t mCfg;
+    memset(&mCfg, 0, sizeof(mCfg));
     auto param = params{matA, matB, matC, _k, _m, _n, _astride, _bstride, _cstride, kpos, tmp, &mCfg};
     if (_m <= MTILE) {
       jblas::xbyak::JitAmxtile::configure_tiles(mCfg, _m < 16 ? _m : 16, _n < 16 ? _n : 16, _k < KTILE ? _k : KTILE,
@@ -1014,7 +1239,263 @@ class GemmCore_Row_NN_16x64_AMX_BF16 {
                  int _cstride, int kpos);
 
  private:
-  MicroKernel::tileconfig_t mCfg;
+  MicroKernel mCodes;
+};
+class GemmCore_Row_NN_16x48_AMX_BF16 {
+ public:
+  typedef utils::bf16 AType;
+  typedef utils::bf16 BType;
+  typedef float CType;
+  struct params {
+    AType* matA;
+    BType* matB;
+    CType* matC;
+    int k, msize, nsize;
+    int astep, bstep, cstep;
+    int kpos;
+    void *workspace, *cfg;
+  };
+  typedef long long (*func_t)(params*);
+
+  static JBLAS_ISA constexpr ISA = JblasAMX_BF16;
+  static GemmCoreType constexpr TYPE = GemmCoreType::AMX_BF16_16x48;
+  static int constexpr NTILE = 48, MTILE = 16, KTILE = 64 / sizeof(BType);
+  static int constexpr PACK_ROW = 2;
+  static int constexpr KUNROLL = 2;
+  static int constexpr PREFERED_N = 240;
+  class MicroKernel : protected jblas::xbyak::JitAmxbf16 {
+   public:
+    friend GemmCore_Row_NN_16x48_AMX_BF16;
+    MicroKernel() {}
+    static int constexpr CReg = 0, TmpReg = 4;
+    static int constexpr NRegs = 3;
+    static int constexpr CRegCount = NRegs;
+    static int constexpr C_tilenum = 3, A_tilenum = 1, B_tilenum = 3;
+    static int constexpr CTile = 0, ATile = CTile + C_tilenum, BTile = ATile + A_tilenum;
+    static int constexpr BKStepSize = KTILE * NTILE * sizeof(BType);
+    static int constexpr AKStepSize = KTILE * sizeof(AType);
+    static int constexpr VecBytes = 64;
+
+    void generate_code() {
+      reset();
+      generate_mtile();
+      ready();
+      mKernel = getCode<func_t>();
+    }
+    func_t mKernel = nullptr;
+
+   protected:
+    void generate_mtile() {
+      inLocalLabel();  // use local label for multiple instance
+      Xbyak::util::StackFrame st(this, 1, 11, 16 * 10);
+      parambase = st.p[0];
+      reg_matAptr = st.t[0];
+      reg_matBptr = st.t[1];
+      reg_matCptr = st.t[0];
+      reg_ksize = st.t[2];
+      reg_nsize = st.t[9];
+      reg_cstep = st.t[3];
+      reg_astep = st.t[5];
+      reg_iterk = st.t[4];
+      reg_itern = st.t[7];
+      reg_tmp = st.t[6];
+      reg_tmp1 = st.t[8];
+      reg_tmp2 = st.t[10];
+      reg_ret = rax;
+
+      vreg_push(rsp);
+      mov(reg_tmp, ptr[parambase + OFFSET(cfg)]);
+      ldtilecfg(ptr[reg_tmp]);
+
+      mov(reg_matBptr, ptr[parambase + OFFSET(matB)]);
+      load32(reg_ksize, ptr[parambase + OFFSET(k)]);
+      load32(reg_nsize, ptr[parambase + OFFSET(nsize)]);
+      load32(reg_astep, ptr[parambase + OFFSET(astep)]);
+
+      xor_(reg_itern, reg_itern);
+      L(".nloop");
+      for (int i = 0; i < C_tilenum; i++) {
+        tilezero(Xbyak::Tmm(CTile + i));
+      }
+      mov(reg_matAptr, ptr[parambase + OFFSET(matA)]);
+      mov(reg_tmp1, reg_matBptr);
+
+      xor_(reg_iterk, reg_iterk);
+
+      mov(reg_tmp, reg_nsize);
+      sub(reg_tmp, reg_itern);
+      cmp(reg_tmp, NTILE);
+      jl(".n32", T_NEAR);
+      generate_kloop(NRegs);
+      write_back(MTILE, NRegs, parambase, reg_matCptr, reg_cstep, reg_itern);
+      load32(reg_tmp, ptr[parambase + OFFSET(bstep)]);
+      imul(reg_tmp, reg_tmp, NTILE);
+      add(reg_matBptr, reg_tmp);
+      add(reg_itern, NTILE);
+      jmp(".nend", T_NEAR);
+
+      L(".n32");
+      cmp(reg_tmp, 32);
+      jl(".n16", T_NEAR);
+      generate_kloop(2);
+      write_back(MTILE, 2, parambase, reg_matCptr, reg_cstep, reg_itern);
+      add(reg_itern, 32);
+      add(reg_matBptr, 32 * sizeof(BType));
+      jmp(".nend", T_NEAR);
+
+      L(".n16");
+      xor_(reg_iterk, reg_iterk);
+      generate_kloop(1);
+      write_back(MTILE, 1, parambase, reg_matCptr, reg_cstep, reg_itern);
+      add(reg_itern, 16);
+      add(reg_matBptr, 16 * sizeof(BType));
+      L(".nend");
+      cmp(reg_itern, reg_nsize);
+      jb(".nloop");
+
+      mov(reg_ret, 0);
+      vreg_pop(rsp);
+
+      outLocalLabel();  // end of local label
+    }
+
+    void generate_kloop(int _nregs) {
+      inLocalLabel();
+      L(".kloop");
+      mov(reg_tmp, reg_ksize);
+      sub(reg_tmp, reg_iterk);
+      cmp(reg_tmp, KUNROLL * KTILE);
+      jl(".k1loop", T_NEAR);
+      generate_fma(_nregs, KUNROLL, reg_tmp, reg_matAptr, reg_tmp1, reg_astep);
+      add(reg_matAptr, KUNROLL * AKStepSize);
+      add(reg_tmp1, KUNROLL * BKStepSize);
+      add(reg_iterk, KUNROLL * KTILE);
+      jmp(".kloopend", T_NEAR);
+
+      L(".k1loop");
+      generate_fma(_nregs, 1, reg_tmp, reg_matAptr, reg_tmp1, reg_astep);
+      add(reg_matAptr, 1 * AKStepSize);
+      add(reg_tmp1, 1 * BKStepSize);
+      add(reg_iterk, 1 * KTILE);
+      L(".kloopend");
+      cmp(reg_iterk, reg_ksize);  // k iteration variable
+      jb(".kloop");
+      outLocalLabel();
+    }
+
+    void generate_fma(int _NTile, int _kunroll, const Xbyak::Reg64& reg_tmp, const Xbyak::Reg64& reg_matAptr,
+                      const Xbyak::Reg64& reg_matBptr, const Xbyak::Reg64& reg_astep) {
+      mov(reg_tmp, NTILE * 4);
+      for (int kk = 0; kk < _kunroll; kk++) {
+        for (int i = 0; i < _NTile; i++) {
+          tileloaddt1(Xbyak::Tmm(BTile + i), ptr[reg_matBptr + reg_tmp + kk * BKStepSize + i * 64]);
+        }
+
+        for (int mm = 0; mm < 1; mm++) {
+          tileloadd(Xbyak::Tmm(ATile + mm), ptr[reg_matAptr + reg_astep + kk * AKStepSize]);
+          for (int i = 0; i < _NTile; i++) {
+            tdpbf16ps(Xbyak::Tmm(CTile + mm * C_tilenum + i), Xbyak::Tmm(ATile + mm), Xbyak::Tmm(BTile + i));
+          }
+        }
+      }
+    }
+
+    void write_back(int _mtile, int _NRegs, const Xbyak::Reg64& parambase, const Xbyak::Reg64& reg_matCptr,
+                    const Xbyak::Reg64& reg_cstep, const Xbyak::Reg64& reg_itern) {
+      inLocalLabel();
+      mov(reg_tmp, dword[parambase + OFFSET(workspace)]);
+      mov(reg_tmp1, NTILE * 4);
+      for (int mm = 0; mm < 1; mm++) {
+        for (int i = 0; i < _NRegs; i++) {
+          tilestored(ptr[reg_tmp + reg_tmp1 + i * 64 + mm * 16 * NTILE * 4], Xbyak::Tmm(CTile + mm * C_tilenum + i));
+        }
+      }
+      load32(reg_matCptr, ptr[parambase + OFFSET(kpos)]);
+      cmp(reg_matCptr, 0);
+      jg(".LACC", T_NEAR);
+      mov(reg_matCptr, ptr[parambase + OFFSET(matC)]);
+      lea(reg_matCptr, ptr[reg_matCptr + reg_itern * sizeof(CType)]);
+      load32(reg_cstep, ptr[parambase + OFFSET(cstep)]);
+      inLocalLabel();
+      xor_(reg_tmp1, reg_tmp1);
+      L(".mloop");
+      for (int j = 0; j < _NRegs; j++) {
+        vmovups(Xbyak::Zmm(CReg + j), ptr[reg_tmp + j * 64]);
+        vmovups(ptr[reg_matCptr + j * VecBytes], Xbyak::Zmm(CReg + j));
+      }
+      add(reg_matCptr, reg_cstep);
+      add(reg_tmp, NTILE * 4);
+      add(reg_tmp1, 1);
+      cmp(reg_tmp1.cvt32(), ptr[parambase + OFFSET(msize)]);
+      jb(".mloop");
+      outLocalLabel();
+      jmp(".LEND", T_NEAR);
+      L(".LACC");
+      mov(reg_matCptr, ptr[parambase + OFFSET(matC)]);
+      lea(reg_matCptr, ptr[reg_matCptr + reg_itern * sizeof(CType)]);
+      load32(reg_cstep, ptr[parambase + OFFSET(cstep)]);
+      inLocalLabel();
+      xor_(reg_tmp1, reg_tmp1);
+      L(".mloop");
+      for (int j = 0; j < _NRegs; j++) {
+        vmovups(Xbyak::Zmm(CReg + j), ptr[reg_tmp + j * 64]);
+        vaddps(Xbyak::Zmm(CReg + j), ptr[reg_matCptr + j * VecBytes]);
+        vmovups(ptr[reg_matCptr + j * VecBytes], Xbyak::Zmm(CReg + j));
+      }
+      add(reg_matCptr, reg_cstep);
+      add(reg_tmp, NTILE * 4);
+      add(reg_tmp1, 1);
+      cmp(reg_tmp1.cvt32(), ptr[parambase + OFFSET(msize)]);
+      jb(".mloop");
+      outLocalLabel();
+      L(".LEND");
+      nop();
+      outLocalLabel();
+    }
+
+   private:
+    Xbyak::Reg64 parambase;
+    Xbyak::Reg64 reg_matAptr;
+    Xbyak::Reg64 reg_matBptr;
+    Xbyak::Reg64 reg_matCptr;
+    Xbyak::Reg64 reg_ksize;
+    Xbyak::Reg64 reg_nsize;
+    Xbyak::Reg64 reg_cstep;
+    Xbyak::Reg64 reg_astep;
+    Xbyak::Reg64 reg_iterk;
+    Xbyak::Reg64 reg_itern;
+    Xbyak::Reg64 reg_tmp;
+    Xbyak::Reg64 reg_tmp1;
+    Xbyak::Reg64 reg_tmp2;
+    Xbyak::Reg64 reg_ret = rax;
+    Xbyak::Opmask msk_wr = k1;
+  };
+
+ public:
+  GemmCore_Row_NN_16x48_AMX_BF16() {
+    mCodes.generate_code();
+  }
+
+  void forward(AType* matA, BType* matB, CType* matC, int _m, int _n, int _k, int _astride, int _bstride, int _cstride,
+               int kpos) {
+    char tmp[NTILE * MTILE * sizeof(CType)];
+    MicroKernel::tileconfig_t mCfg;
+    std::memset(&mCfg, 0, sizeof(mCfg));
+    auto param = params{matA, matB, matC, _k, _m, _n, _astride, _bstride, _cstride, kpos, tmp, &mCfg};
+    if (_m <= MTILE) {
+      jblas::xbyak::JitAmxtile::configure_tiles(mCfg, _m < 16 ? _m : 16, _n < 16 ? _n : 16, _k < KTILE ? _k : KTILE,
+                                                sizeof(BType), MicroKernel::A_tilenum, MicroKernel::B_tilenum,
+                                                MicroKernel::C_tilenum);
+      mCodes.mKernel(&param);
+    } else {
+      assert(0);
+    }
+  }
+
+  void reference(AType* matA, BType* matB, CType* matC, int _m, int _n, int _k, int _astride, int _bstride,
+                 int _cstride, int kpos);
+
+ private:
   MicroKernel mCodes;
 };
 class GemmCore_Row_NN_16x64_AMX_INT8 {
@@ -1034,7 +1515,7 @@ class GemmCore_Row_NN_16x64_AMX_INT8 {
   typedef long long (*func_t)(params*);
 
   static JBLAS_ISA constexpr ISA = JblasAMX_INT8;
-  static GemmCoreType constexpr TYPE = GemmCoreType::AMX_INT8;
+  static GemmCoreType constexpr TYPE = GemmCoreType::AMX_INT8_16x64;
   static int constexpr NTILE = 64, MTILE = 16, KTILE = 64 / sizeof(BType);
   static int constexpr PACK_ROW = 4;
   static int constexpr KUNROLL = 2;
@@ -1276,14 +1757,13 @@ class GemmCore_Row_NN_16x64_AMX_INT8 {
  public:
   GemmCore_Row_NN_16x64_AMX_INT8() {
     mCodes.generate_code();
-    memset(&mCfg, 0, sizeof(mCfg));
-    jblas::xbyak::JitAmxint8::configure_tiles(mCfg, 16, 16, 64, sizeof(BType), MicroKernel::A_tilenum,
-                                              MicroKernel::B_tilenum, MicroKernel::C_tilenum);
   }
 
   void forward(AType* matA, BType* matB, CType* matC, int _m, int _n, int _k, int _astride, int _bstride, int _cstride,
                int kpos) {
     char tmp[NTILE * MTILE * sizeof(CType)];
+    MicroKernel::tileconfig_t mCfg;
+    memset(&mCfg, 0, sizeof(mCfg));
     auto param = params{matA, matB, matC, _k, _m, _n, _astride, _bstride, _cstride, kpos, tmp, &mCfg};
     if (_m <= MTILE) {
       jblas::xbyak::JitAmxint8::configure_tiles(mCfg, _m < 16 ? _m : 16, _n < 16 ? _n : 16, _k < KTILE ? _k : KTILE,
@@ -1299,27 +1779,301 @@ class GemmCore_Row_NN_16x64_AMX_INT8 {
                  int _cstride, int kpos);
 
  private:
-  MicroKernel::tileconfig_t mCfg;
   MicroKernel mCodes;
 };
 
-// KBLKs= K/BlkSize
-// Weight scale=KBLKs*N
-// Activation zp=M*KBLKs scale=M*KBLKs
-template <typename _OT, typename _ST>
+class GemmCore_Row_NN_16x48_AMX_INT8 {
+ public:
+  typedef uint8_t AType;
+  typedef int8_t BType;
+  typedef int32_t CType;
+  struct params {
+    AType* matA;
+    BType* matB;
+    CType* matC;
+    int k, msize, nsize;
+    int astep, bstep, cstep;
+    int kpos;
+    void *workspace, *cfg;
+  };
+  typedef long long (*func_t)(params*);
+
+  static JBLAS_ISA constexpr ISA = JblasAMX_INT8;
+  static GemmCoreType constexpr TYPE = GemmCoreType::AMX_INT8_16x48;
+  static int constexpr NTILE = 48, MTILE = 16, KTILE = 64 / sizeof(BType);
+  static int constexpr PACK_ROW = 4 / sizeof(BType);
+  static int constexpr KUNROLL = 2;
+  static int constexpr PREFERED_N = 240;  // TODO?
+  class MicroKernel : protected jblas::xbyak::JitAmxint8 {
+   public:
+    friend GemmCore_Row_NN_16x48_AMX_INT8;
+    MicroKernel() {}
+    static int constexpr CReg = 0;
+    static int constexpr C_tilenum = 3, A_tilenum = 1, B_tilenum = 3;
+    static int constexpr CTile = 0, ATile = CTile + C_tilenum, BTile = ATile + A_tilenum;
+    static int constexpr BKStepSize = KTILE * NTILE * sizeof(BType);
+    static int constexpr AKStepSize = KTILE * sizeof(AType);
+    static int constexpr VecBytes = 64;
+
+    void generate_code() {
+      reset();
+      generate_mtile();
+      ready();
+      mKernel = getCode<func_t>();
+    }
+    func_t mKernel = nullptr;
+
+   protected:
+    void generate_mtile() {
+      inLocalLabel();  // use local label for multiple instance
+      Xbyak::util::StackFrame st(this, 1, 11, 16 * 10);
+      parambase = st.p[0];
+      reg_matAptr = st.t[0];
+      reg_matBptr = st.t[1];
+      reg_matCptr = st.t[0];
+      reg_ksize = st.t[2];
+      reg_nsize = st.t[9];
+      reg_cstep = st.t[3];
+      reg_astep = st.t[5];
+      reg_iterk = st.t[4];
+      reg_itern = st.t[7];
+      reg_tmp = st.t[6];
+      reg_tmp1 = st.t[8];
+      reg_tmp2 = st.t[10];
+      reg_ret = rax;
+
+      vreg_push(rsp);
+      mov(reg_tmp, ptr[parambase + OFFSET(cfg)]);
+      ldtilecfg(ptr[reg_tmp]);
+
+      mov(reg_matBptr, ptr[parambase + OFFSET(matB)]);
+      load32(reg_ksize, ptr[parambase + OFFSET(k)]);
+      load32(reg_nsize, ptr[parambase + OFFSET(nsize)]);
+      load32(reg_astep, ptr[parambase + OFFSET(astep)]);
+
+      xor_(reg_itern, reg_itern);
+      L(".nloop");
+      for (int i = 0; i < C_tilenum; i++) {
+        tilezero(Xbyak::Tmm(CTile + i));
+      }
+      mov(reg_matAptr, ptr[parambase + OFFSET(matA)]);
+      mov(reg_tmp1, reg_matBptr);
+
+      xor_(reg_iterk, reg_iterk);
+
+      mov(reg_tmp, reg_nsize);
+      sub(reg_tmp, reg_itern);
+      cmp(reg_tmp, NTILE);
+      jl(".n32", T_NEAR);
+      generate_kloop(C_tilenum);
+      write_back(MTILE, C_tilenum, parambase, reg_matCptr, reg_cstep, reg_itern);
+      load32(reg_tmp, ptr[parambase + OFFSET(bstep)]);
+      imul(reg_tmp, reg_tmp, NTILE);
+      add(reg_matBptr, reg_tmp);
+      add(reg_itern, NTILE);
+      jmp(".nend", T_NEAR);
+
+      L(".n32");
+      cmp(reg_tmp, 32);
+      jl(".n16", T_NEAR);
+      generate_kloop(2);
+      write_back(MTILE, 2, parambase, reg_matCptr, reg_cstep, reg_itern);
+      add(reg_itern, 32);
+      add(reg_matBptr, 32 * sizeof(BType));
+      jmp(".nend", T_NEAR);
+
+      L(".n16");
+      xor_(reg_iterk, reg_iterk);
+      generate_kloop(1);
+      write_back(MTILE, 1, parambase, reg_matCptr, reg_cstep, reg_itern);
+      add(reg_itern, 16);
+      add(reg_matBptr, 16 * sizeof(BType));
+      L(".nend");
+      cmp(reg_itern, reg_nsize);
+      jb(".nloop");
+
+      mov(reg_ret, 0);
+      vreg_pop(rsp);
+
+      outLocalLabel();  // end of local label
+    }
+
+    void generate_kloop(int _nregs) {
+      inLocalLabel();
+      L(".kloop");
+      mov(reg_tmp, reg_ksize);
+      sub(reg_tmp, reg_iterk);
+      cmp(reg_tmp, KUNROLL * KTILE);
+      jl(".k1loop", T_NEAR);
+      generate_fma(_nregs, KUNROLL, reg_tmp, reg_matAptr, reg_tmp1, reg_astep);
+      add(reg_matAptr, KUNROLL * AKStepSize);
+      add(reg_tmp1, KUNROLL * BKStepSize);
+      add(reg_iterk, KUNROLL * KTILE);
+      jmp(".kloopend", T_NEAR);
+
+      L(".k1loop");
+      generate_fma(_nregs, 1, reg_tmp, reg_matAptr, reg_tmp1, reg_astep);
+      add(reg_matAptr, 1 * AKStepSize);
+      add(reg_tmp1, 1 * BKStepSize);
+      add(reg_iterk, 1 * KTILE);
+      L(".kloopend");
+      cmp(reg_iterk, reg_ksize);  // k iteration variable
+      jb(".kloop");
+      outLocalLabel();
+    }
+
+    void generate_fma(int _NTile, int _kunroll, const Xbyak::Reg64& reg_tmp, const Xbyak::Reg64& reg_matAptr,
+                      const Xbyak::Reg64& reg_matBptr, const Xbyak::Reg64& reg_astep) {
+      mov(reg_tmp, NTILE * 4);
+      if (_NTile <= B_tilenum) {
+        for (int kk = 0; kk < _kunroll; kk++) {
+          for (int i = 0; i < _NTile; i++) {
+            tileloaddt1(Xbyak::Tmm(BTile + i), ptr[reg_matBptr + reg_tmp + kk * BKStepSize + i * 64]);
+          }
+
+          for (int mm = 0; mm < 1; mm++) {
+            tileloadd(Xbyak::Tmm(ATile + mm), ptr[reg_matAptr + reg_astep + kk * AKStepSize]);
+            for (int i = 0; i < _NTile; i++) {
+              tdpbusd(Xbyak::Tmm(CTile + mm * C_tilenum + i), Xbyak::Tmm(ATile + mm), Xbyak::Tmm(BTile + i));
+            }
+          }
+        }
+      } else {
+        for (int kk = 0; kk < _kunroll; kk++) {
+          for (int i = 0; i < _NTile - 1; i++) {
+            tileloaddt1(Xbyak::Tmm(BTile + i), ptr[reg_matBptr + reg_tmp + kk * BKStepSize + i * 64]);
+          }
+
+          for (int mm = 0; mm < 1; mm++) {
+            tileloadd(Xbyak::Tmm(ATile + mm), ptr[reg_matAptr + reg_astep + kk * AKStepSize]);
+            for (int i = 0; i < _NTile - 1; i++) {
+              tdpbusd(Xbyak::Tmm(CTile + mm * C_tilenum + i), Xbyak::Tmm(ATile + mm), Xbyak::Tmm(BTile + i));
+            }
+            tileloaddt1(Xbyak::Tmm(BTile + 0), ptr[reg_matBptr + reg_tmp + kk * BKStepSize + (_NTile - 1) * 64]);
+            tdpbusd(Xbyak::Tmm(CTile + mm * C_tilenum + _NTile - 1), Xbyak::Tmm(ATile + mm), Xbyak::Tmm(BTile + 0));
+          }
+        }
+      }
+    }
+
+    void write_back(int _mtile, int _NRegs, const Xbyak::Reg64& parambase, const Xbyak::Reg64& reg_matCptr,
+                    const Xbyak::Reg64& reg_cstep, const Xbyak::Reg64& reg_itern) {
+      inLocalLabel();
+      mov(reg_tmp, dword[parambase + OFFSET(workspace)]);
+      mov(reg_tmp1, NTILE * 4);
+      for (int mm = 0; mm < 1; mm++) {
+        for (int i = 0; i < _NRegs; i++) {
+          tilestored(ptr[reg_tmp + reg_tmp1 + i * 64 + mm * 16 * NTILE * 4], Xbyak::Tmm(CTile + mm * C_tilenum + i));
+        }
+      }
+      load32(reg_matCptr, ptr[parambase + OFFSET(kpos)]);
+      cmp(reg_matCptr, 0);
+      jg(".LACC", T_NEAR);
+      mov(reg_matCptr, ptr[parambase + OFFSET(matC)]);
+      lea(reg_matCptr, ptr[reg_matCptr + reg_itern * sizeof(CType)]);
+      load32(reg_cstep, ptr[parambase + OFFSET(cstep)]);
+      inLocalLabel();
+      xor_(reg_tmp1, reg_tmp1);
+      L(".mloop");
+      for (int j = 0; j < _NRegs; j++) {
+        vmovups(Xbyak::Zmm(CReg + j), ptr[reg_tmp + j * 64]);
+        vmovups(ptr[reg_matCptr + j * VecBytes], Xbyak::Zmm(CReg + j));
+      }
+      add(reg_matCptr, reg_cstep);
+      add(reg_tmp, NTILE * 4);
+      add(reg_tmp1, 1);
+      cmp(reg_tmp1.cvt32(), ptr[parambase + OFFSET(msize)]);
+      jb(".mloop");
+      outLocalLabel();
+      jmp(".LEND", T_NEAR);
+      L(".LACC");
+      mov(reg_matCptr, ptr[parambase + OFFSET(matC)]);
+      lea(reg_matCptr, ptr[reg_matCptr + reg_itern * sizeof(CType)]);
+      load32(reg_cstep, ptr[parambase + OFFSET(cstep)]);
+      inLocalLabel();
+      xor_(reg_tmp1, reg_tmp1);
+      L(".mloop");
+      for (int j = 0; j < _NRegs; j++) {
+        vmovups(Xbyak::Zmm(CReg + j), ptr[reg_tmp + j * 64]);
+        vpaddd(Xbyak::Zmm(CReg + j), Xbyak::Zmm(CReg + j), ptr[reg_matCptr + j * VecBytes]);
+        vmovups(ptr[reg_matCptr + j * VecBytes], Xbyak::Zmm(CReg + j));
+      }
+      add(reg_matCptr, reg_cstep);
+      add(reg_tmp, NTILE * 4);
+      add(reg_tmp1, 1);
+      cmp(reg_tmp1.cvt32(), ptr[parambase + OFFSET(msize)]);
+      jb(".mloop");
+      outLocalLabel();
+      L(".LEND");
+      nop();
+      outLocalLabel();
+    }
+
+   private:
+    Xbyak::Reg64 parambase;
+    Xbyak::Reg64 reg_matAptr;
+    Xbyak::Reg64 reg_matBptr;
+    Xbyak::Reg64 reg_matCptr;
+    Xbyak::Reg64 reg_ksize;
+    Xbyak::Reg64 reg_nsize;
+    Xbyak::Reg64 reg_cstep;
+    Xbyak::Reg64 reg_astep;
+    Xbyak::Reg64 reg_iterk;
+    Xbyak::Reg64 reg_itern;
+    Xbyak::Reg64 reg_tmp;
+    Xbyak::Reg64 reg_tmp1;
+    Xbyak::Reg64 reg_tmp2;
+    Xbyak::Reg64 reg_ret = rax;
+    Xbyak::Opmask msk_wr = k1;
+  };
+
+ public:
+  GemmCore_Row_NN_16x48_AMX_INT8() {
+    mCodes.generate_code();
+  }
+
+  void forward(AType* matA, BType* matB, CType* matC, int _m, int _n, int _k, int _astride, int _bstride, int _cstride,
+               int kpos) {
+    char tmp[NTILE * MTILE * sizeof(CType)];
+    MicroKernel::tileconfig_t mCfg;
+    memset(&mCfg, 0, sizeof(mCfg));
+    auto param = params{matA, matB, matC, _k, _m, _n, _astride, _bstride, _cstride, kpos, tmp, &mCfg};
+    if (_m <= MTILE) {
+      jblas::xbyak::JitAmxint8::configure_tiles(mCfg, _m < 16 ? _m : 16, _n < 16 ? _n : 16, _k < KTILE ? _k : KTILE,
+                                                sizeof(BType), MicroKernel::A_tilenum, MicroKernel::B_tilenum,
+                                                MicroKernel::C_tilenum);
+      mCodes.mKernel(&param);
+    } else {
+      assert(0);
+    }
+  }
+
+  void reference(AType* matA, BType* matB, CType* matC, int _m, int _n, int _k, int _astride, int _bstride,
+                 int _cstride, int kpos);
+
+ private:
+  MicroKernel mCodes;
+};
+
+// special kblock core: A:u8/s8 B:s8 intra-block accumulator:s32 inter-block
+// accumulator:f32
+//  KBlocks= K/kblock
+//  Weight scale=KBlocks*N
+//  Activation zp=M*KBlocks scale=M*KBlocks
+namespace kblock {
+
 class GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK {
  public:
   typedef uint8_t AType;
   typedef int8_t BType;
-  typedef _OT CType;
-  typedef _ST SType;
+  typedef float CType;
   struct params {
-    uint8_t* matA;
-    int8_t* matB;
-    CType* matC;
-    uint8_t* zpA;
-    float* scaleA;
-    SType* scaleB;
+    uint8_t *matA;
+    int8_t *matB;
+    CType *matC;
+    uint8_t *zpA;
+    float *scaleA;
+    void *scaleB;
     int ldsa, ldsb;
     int kblock;
     int k, nsize;
@@ -1345,7 +2099,8 @@ class GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK {
     static int constexpr AKStepSize = KTILE * sizeof(AType);
     static int constexpr VecBytes = 64;
 
-    void generate_code(int _mtile) {
+    void generate_code(int _mtile, JBLAS_DTYPE _scale_dt) {
+      mScaleType = _scale_dt;
       reset();
       generate_mtile(_mtile);
       ready();
@@ -1354,6 +2109,8 @@ class GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK {
     func_t mKernel = nullptr;
 
    protected:
+    JBLAS_DTYPE mScaleType = JblasF32;
+
     void generate_mtile(int _mtile) {
       CRegCount = _mtile * NRegs;
       ZpARegCount = _mtile;
@@ -1460,17 +2217,22 @@ class GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK {
         lea(reg_tmp, ptr[reg_tmp + reg_tmp1 * sizeof(float)]);
       }
       for (size_t i = 0; i < _nregs; i++) {
-        if (std::is_same<SType, float>::value) {
+        if (mScaleType == JblasF32) {
           vmovups(Xbyak::Zmm(BReg + i), ptr[reg_scaleBptr + i * VecBytes]);
-        } else if (std::is_same<SType, utils::bf16>::value) {
-          loadbf16_f32(Xbyak::Zmm(BReg + i), ptr[reg_scaleBptr + i * VecBytes / (sizeof(float) / sizeof(SType))]);
+        } else if (mScaleType == JblasBF16) {
+          loadbf16_f32(Xbyak::Zmm(BReg + i),
+                       ptr[reg_scaleBptr + i * VecBytes / 2]);
         }
       }
       generate_f32_accumulate(_mtile, _nregs);
       add(reg_zpAptr, sizeof(AType));
       add(reg_scaleAptr, sizeof(float));
       load32(reg_tmp, ptr[parambase + OFFSET(ldsb)]);
-      lea(reg_scaleBptr, ptr[reg_scaleBptr + reg_tmp * sizeof(SType)]);
+      if (mScaleType == JblasF32) {
+        lea(reg_scaleBptr, ptr[reg_scaleBptr + reg_tmp * 4]);
+      } else if (mScaleType == JblasBF16) {
+        lea(reg_scaleBptr, ptr[reg_scaleBptr + reg_tmp * 2]);
+      }
       cmp(reg_iterk, reg_ksize);  // k iteration variable
       jb(".kloop");
       outLocalLabel();
@@ -1574,12 +2336,15 @@ class GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK {
  public:
   GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK() {
     for (int i = 0; i < MTILE; i++) {
-      mCodes[i].generate_code(i + 1);
+      mCodes[i].generate_code(i + 1, JblasF32);
+      mCodesBf16[i].generate_code(i + 1, JblasBF16);
     }
   }
 
-  void forward(AType* matA, BType* matB, CType* matC, AType* zpA, float* scaleA, int _ldsa, SType* scaleB, int _ldsb,
-               int _m, int _n, int _k, int _kblock, int _astride, int _bstride, int _cstride, int kpos) {
+  void forward(AType *matA, BType *matB, CType *matC, AType *zpA, float *scaleA,
+               int _ldsa, float *scaleB, int _ldsb, int _m, int _n, int _k,
+               int _kblock, int _astride, int _bstride, int _cstride,
+               int kpos) {
     int ldb = _bstride / sizeof(BType);
     auto param = params{matA, matB, matC, zpA, scaleA, scaleB, _ldsa, _ldsb, _kblock, _k, _n, _astride, _cstride, kpos};
     if (_m <= MTILE) {
@@ -1595,8 +2360,30 @@ class GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK {
     }
   }
 
-  void reference(AType* matA, BType* matB, CType* matC, AType* zpA, float* scaleA, int _ldsa, float* scaleB, int _ldsb,
-                 int _m, int _n, int _k, int _kblock, int _astride, int _bstride, int _cstride, int kpos) {
+  void forward(AType *matA, BType *matB, CType *matC, AType *zpA, float *scaleA,
+               int _ldsa, utils::bf16 *scaleB, int _ldsb, int _m, int _n,
+               int _k, int _kblock, int _astride, int _bstride, int _cstride,
+               int kpos) {
+    int ldb = _bstride / sizeof(BType);
+    auto param = params{matA,  matB,    matC, zpA, scaleA,   scaleB,   _ldsa,
+                        _ldsb, _kblock, _k,   _n,  _astride, _cstride, kpos};
+    if (_m <= MTILE) {
+      for (int i = 0; i < _n; i += NTILE) {
+        param.matB = matB + i * ldb;
+        param.matC = matC + i;
+        param.nsize = i + NTILE <= _n ? NTILE : _n - i;
+        param.scaleB = scaleB + i;
+        mCodesBf16[_m - 1].mKernel(&param);
+      }
+    } else {
+      assert(0);
+    }
+  }
+
+  void reference(AType *matA, BType *matB, CType *matC, AType *zpA,
+                 float *scaleA, int _ldsa, float *scaleB, int _ldsb, int _m,
+                 int _n, int _k, int _kblock, int _astride, int _bstride,
+                 int _cstride, int kpos) {
     int lda = _astride / sizeof(matA[0]);
     int ldb = _bstride / sizeof(matB[0]);
     int ldc = _cstride / sizeof(matC[0]);
@@ -1659,8 +2446,404 @@ class GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK {
   }
 
  private:
-  std::array<MicroKernel, MTILE> mCodes;
+  std::array<MicroKernel, MTILE> mCodes, mCodesBf16;
 };
+
+class GemmCore_Row_NN_16x48_AMX_INT8_KBLOCK {
+ public:
+  typedef int8_t AType;
+  typedef int8_t BType;
+  typedef float CType;
+  struct params {
+    AType *matA;
+    BType *matB;
+    CType *matC;
+    float *scaleA;
+    void *scaleB;
+    int ldsa, ldsb;
+    int kblock;
+    int k, nsize, msize;
+    int astep, cstep;
+    int kpos;
+    void *workspace, *cfg;
+  };
+
+  typedef long long (*func_t)(params *);
+
+  static JBLAS_ISA constexpr ISA = JblasAMX_INT8;
+  static GemmCoreType constexpr TYPE = GemmCoreType::AMX_INT8_16X48_KBLOCK;
+  static int constexpr NTILE = 48, MTILE = 16, KTILE = 64 / sizeof(BType);
+  static int constexpr PACK_ROW = 4;
+  static int constexpr KUNROLL = 2;
+  static int constexpr PREFERED_N = 256;
+
+  class MicroKernel : protected jblas::xbyak::JitAmxint8 {
+   public:
+    friend GemmCore_Row_NN_16x48_AMX_INT8_KBLOCK;
+    MicroKernel() {}
+    static int constexpr CReg = 0, TmpReg = 3;
+    static int constexpr NRegs = 3;
+    static int constexpr C_tilenum = 4, A_tilenum = 1, B_tilenum = 3;
+    static int constexpr CTile = 0, ATile = CTile + C_tilenum,
+                         BTile = ATile + A_tilenum;
+    static int constexpr BKStepSize = KTILE * NTILE * sizeof(BType);
+    static int constexpr AKStepSize = KTILE * sizeof(AType);
+    static int constexpr VecBytes = 64;
+
+    void generate_code(JBLAS_DTYPE scaletype) {
+      mScaleType = scaletype;
+      reset();
+      generate_mtile();
+      ready();
+      mKernel = getCode<func_t>();
+    }
+    func_t mKernel = nullptr;
+
+   protected:
+    JBLAS_DTYPE mScaleType = JblasF32;
+
+    void generate_mtile() {
+      inLocalLabel();  // use local label for multiple instance
+      Xbyak::util::StackFrame st(this, 1, 13, 16 * 10);
+      parambase = st.p[0];
+      reg_matAptr = st.t[0];
+      reg_matBptr = st.t[1];
+      reg_matCptr = st.t[0];
+      reg_ksize = st.t[2];
+      reg_cstep = st.t[3];
+      reg_iterk = st.t[4];
+      reg_astep = st.t[5];
+      reg_kblock = st.t[6];
+      reg_tmp = st.t[7];
+      reg_tmp1 = st.t[8];
+      reg_tmp2 = st.t[9];
+      reg_tmp3 = st.t[10];
+      reg_scaleAptr = st.t[11];
+      reg_scaleBptr = st.t[12];
+      reg_ret = rax;
+
+      vreg_push(rsp);
+      mov(reg_tmp, ptr[parambase + OFFSET(cfg)]);
+      ldtilecfg(ptr[reg_tmp]);
+
+      load32(reg_ksize, ptr[parambase + OFFSET(k)]);
+      load32(reg_kblock, ptr[parambase + OFFSET(kblock)]);
+      load32(reg_astep, ptr[parambase + OFFSET(astep)]);
+      load32(reg_cstep, ptr[parambase + OFFSET(cstep)]);
+
+      mov(reg_matAptr, ptr[parambase + OFFSET(matA)]);
+      mov(reg_matBptr, ptr[parambase + OFFSET(matB)]);
+      mov(reg_scaleAptr, ptr[parambase + OFFSET(scaleA)]);
+      mov(reg_scaleBptr, ptr[parambase + OFFSET(scaleB)]);
+      xor_(reg_iterk, reg_iterk);
+
+      load32(reg_tmp, ptr[parambase + OFFSET(nsize)]);
+      cmp(reg_tmp, NTILE);
+      jl(".n32", T_NEAR);
+      init_accumulator_mem(NRegs);
+      generate_kloop(NRegs);
+      jmp(".nend", T_NEAR);
+
+      L(".n32");
+      cmp(reg_tmp, 32);
+      jl(".n16", T_NEAR);
+      init_accumulator_mem(2);
+      generate_kloop(2);
+      jmp(".nend", T_NEAR);
+
+      L(".n16");
+      init_accumulator_mem(1);
+      generate_kloop(1);
+
+      L(".nend");
+      mov(reg_ret, 0);
+      vreg_pop(rsp);
+
+      outLocalLabel();  // end of local label
+    }
+
+    void init_accumulator_mem(int _NRegs) {
+      inLocalLabel();
+      push(reg_matCptr);
+      load32(reg_matCptr, ptr[parambase + OFFSET(kpos)]);
+      cmp(reg_matCptr, 0);
+      jg(".END", T_NEAR);
+      mov(reg_matCptr, ptr[parambase + OFFSET(matC)]);
+      load32(reg_tmp, ptr[parambase + OFFSET(msize)]);
+      for (int j = 0; j < _NRegs; j++) {
+        vxorps(Xbyak::Zmm(CReg + j), Xbyak::Zmm(CReg + j));
+      }
+      xor_(reg_tmp1, reg_tmp1);
+      L(".mloop");
+      for (int j = 0; j < _NRegs; j++) {
+        vmovups(ptr[reg_matCptr + j * VecBytes], Xbyak::Zmm(CReg + j));
+      }
+      add(reg_matCptr, reg_cstep);
+      add(reg_tmp1, 1);
+      cmp(reg_tmp1, reg_tmp);
+      jb(".mloop");
+      L(".END");
+      pop(reg_matCptr);
+      outLocalLabel();
+    }
+
+    void generate_kloop(int _nregs) {
+      inLocalLabel();
+      L(".kloop");
+      for (int i = 0; i < C_tilenum; i++) {
+        tilezero(Xbyak::Tmm(CTile + i));
+      }
+      xor_(reg_tmp2, reg_tmp2);
+      L(".kbloop");
+      generate_fma(_nregs, KUNROLL, reg_tmp, reg_matAptr, reg_matBptr,
+                   reg_astep);
+      add(reg_matAptr, AKStepSize * KUNROLL);
+      add(reg_matBptr, BKStepSize * KUNROLL);
+      add(reg_iterk, KTILE * KUNROLL);
+      cmp(reg_iterk, reg_ksize);  // k iteration variable
+      jge(".kbend");
+      add(reg_tmp2, KTILE * KUNROLL);
+      cmp(reg_tmp2.cvt32(), ptr[parambase + OFFSET(kblock)]);
+      jb(".kbloop");
+      L(".kbend");
+      generate_f32_accumulate(_nregs);
+      add(reg_scaleAptr, sizeof(float));
+      load32(reg_tmp, ptr[parambase + OFFSET(ldsb)]);
+      if (mScaleType == JblasBF16) {
+        lea(reg_scaleBptr, ptr[reg_scaleBptr + reg_tmp * 2]);
+      } else if (mScaleType == JblasF32) {
+        lea(reg_scaleBptr, ptr[reg_scaleBptr + reg_tmp * 4]);
+      }
+      cmp(reg_iterk, reg_ksize);  // k iteration variable
+      jb(".kloop");
+      outLocalLabel();
+    }
+
+    void generate_fma(int _NNum, int _kunroll, const Xbyak::Reg64 &reg_tmp,
+                      const Xbyak::Reg64 &reg_matAptr,
+                      const Xbyak::Reg64 &reg_matBptr,
+                      const Xbyak::Reg64 &reg_astep) {
+      mov(reg_tmp, NTILE * 4);
+      for (int kk = 0; kk < _kunroll; kk++) {
+        for (int i = 0; i < _NNum; i++) {
+          tileloaddt1(Xbyak::Tmm(BTile + i),
+                      ptr[reg_matBptr + reg_tmp + kk * BKStepSize + i * 64]);
+        }
+
+        for (int mm = 0; mm < 1; mm++) {
+          tileloadd(Xbyak::Tmm(ATile + mm),
+                    ptr[reg_matAptr + reg_astep + kk * AKStepSize]);
+          for (int i = 0; i < _NNum; i++) {
+            tdpbssd(Xbyak::Tmm(CTile + mm * C_tilenum + i),
+                    Xbyak::Tmm(ATile + mm), Xbyak::Tmm(BTile + i));
+          }
+        }
+      }
+    }
+
+    void generate_f32_accumulate(int _NRegs) {
+      inLocalLabel();
+      push(reg_matCptr);
+      push(reg_astep);
+      load32(reg_astep, ptr[parambase + OFFSET(msize)]);
+      mov(reg_matCptr, ptr[parambase + OFFSET(matC)]);
+      mov(reg_tmp3, qword[parambase + OFFSET(workspace)]);
+      mov(reg_tmp1, NTILE * 4);
+      for (int mm = 0; mm < 1; mm++) {
+        for (int i = 0; i < _NRegs; i++) {
+          tilestored(ptr[reg_tmp3 + reg_tmp1 + i * 64 + mm * 16 * NTILE * 4],
+                     Xbyak::Tmm(CTile + mm * C_tilenum + i));
+        }
+      }
+
+      for (size_t i = 0; i < _NRegs; i++) {
+        if (mScaleType == JblasF32) {
+          vmovups(Xbyak::Zmm(TmpReg + i), ptr[reg_scaleBptr + i * VecBytes]);
+        } else if (mScaleType == JblasBF16) {
+          loadbf16_f32(Xbyak::Zmm(TmpReg + i),
+                       ptr[reg_scaleBptr + i * VecBytes / 2]);
+        }
+      }
+      mov(reg_tmp, reg_scaleAptr);
+      load32(reg_tmp2, ptr[parambase + OFFSET(ldsa)]);
+      xor_(reg_tmp1, reg_tmp1);
+      L(".mloop");
+      for (int i = 0; i < _NRegs; i++) {
+        vcvtdq2ps(Xbyak::Zmm(CReg + i), zword[reg_tmp3 + i * VecBytes]);
+        vmulps(Xbyak::Zmm(TmpReg + _NRegs), Xbyak::Zmm(TmpReg + i),
+               zword_b[reg_tmp]);
+        vmulps(Xbyak::Zmm(CReg + i), Xbyak::Zmm(TmpReg + _NRegs));
+        vaddps(Xbyak::Zmm(CReg + i), zword[reg_matCptr + i * VecBytes]);
+        vmovups(zword[reg_matCptr + i * VecBytes], Xbyak::Zmm(CReg + i));
+      }
+      add(reg_tmp3, NTILE * sizeof(CType));
+      add(reg_matCptr, reg_cstep);
+      lea(reg_tmp, ptr[reg_tmp + reg_tmp2 * sizeof(float)]);
+      add(reg_tmp1, 1);
+      cmp(reg_tmp1.cvt32(), reg_astep);
+      jb(".mloop");
+      pop(reg_astep);
+      pop(reg_matCptr);
+      outLocalLabel();
+    }
+
+   private:
+    Xbyak::Reg64 parambase;
+    Xbyak::Reg64 reg_matAptr;
+    Xbyak::Reg64 reg_matBptr;
+    Xbyak::Reg64 reg_matCptr;
+    Xbyak::Reg64 reg_scaleAptr;
+    Xbyak::Reg64 reg_scaleBptr;
+    Xbyak::Reg64 reg_ksize;
+    Xbyak::Reg64 reg_kblock;
+    Xbyak::Reg64 reg_cstep;
+    Xbyak::Reg64 reg_astep;
+    Xbyak::Reg64 reg_iterk;
+    Xbyak::Reg64 reg_tmp;
+    Xbyak::Reg64 reg_tmp1;
+    Xbyak::Reg64 reg_tmp2;
+    Xbyak::Reg64 reg_tmp3;
+    Xbyak::Reg64 reg_ret = rax;
+  };
+
+ public:
+  GemmCore_Row_NN_16x48_AMX_INT8_KBLOCK() {
+    mCodes.generate_code(JblasF32);
+    mCodesBf16.generate_code(JblasBF16);
+  }
+
+  void forward(AType *matA, BType *matB, CType *matC, AType *zpA, float *scaleA,
+               int _ldsa, float *scaleB, int _ldsb, int _m, int _n, int _k,
+               int _kblock, int _astride, int _bstride, int _cstride,
+               int kpos) {
+    (void)zpA;//keep the same parameter structure
+    int ldb = _bstride / sizeof(BType);
+    char tmp[NTILE * MTILE * sizeof(CType) * 2];  // s32+f32
+    MicroKernel::tileconfig_t mCfg;
+    memset(&mCfg, 0, sizeof(mCfg));
+    MicroKernel::configure_tiles(
+        mCfg, _m < 16 ? _m : 16, 16, _k < KTILE ? _k : KTILE, sizeof(BType),
+        MicroKernel::A_tilenum, MicroKernel::B_tilenum, MicroKernel::C_tilenum);
+
+    auto param =
+        params{matA, matB, matC, scaleA,   scaleB,   _ldsa, _ldsb, _kblock,
+               _k,   _n,   _m,   _astride, _cstride, kpos,  tmp,   &mCfg};
+    if (_m <= MTILE) {
+      for (int i = 0; i < _n; i += NTILE) {
+        param.matB = matB + i * ldb;
+        param.matC = matC + i;
+        param.nsize = i + NTILE <= _n ? NTILE : _n - i;
+        param.scaleB = scaleB + i;
+
+        mCodes.mKernel(&param);
+      }
+    } else {
+      assert(0);
+    }
+  }
+
+  void forward(AType *matA, BType *matB, CType *matC, AType *zpA, float *scaleA,
+               int _ldsa, utils::bf16 *scaleB, int _ldsb, int _m, int _n,
+               int _k, int _kblock, int _astride, int _bstride, int _cstride,
+               int kpos) {
+    (void)zpA;  // keep the same parameter structure
+    int ldb = _bstride / sizeof(BType);
+    char tmp[NTILE * MTILE * sizeof(CType) * 2];  // s32+f32
+    MicroKernel::tileconfig_t mCfg;
+    memset(&mCfg, 0, sizeof(mCfg));
+    MicroKernel::configure_tiles(
+        mCfg, _m < 16 ? _m : 16, 16, _k < KTILE ? _k : KTILE, sizeof(BType),
+        MicroKernel::A_tilenum, MicroKernel::B_tilenum, MicroKernel::C_tilenum);
+
+    auto param =
+        params{matA, matB, matC, scaleA,   scaleB,   _ldsa, _ldsb, _kblock,
+               _k,   _n,   _m,   _astride, _cstride, kpos,  tmp,   &mCfg};
+    if (_m <= MTILE) {
+      for (int i = 0; i < _n; i += NTILE) {
+        param.matB = matB + i * ldb;
+        param.matC = matC + i;
+        param.nsize = i + NTILE <= _n ? NTILE : _n - i;
+        param.scaleB = scaleB + i;
+
+        mCodesBf16.mKernel(&param);
+      }
+    } else {
+      assert(0);
+    }
+  }
+
+  void reference(AType *matA, BType *matB, CType *matC, float *scaleA,
+                 int _ldsa, float *scaleB, int _ldsb, int _m, int _n, int _k,
+                 int _kblock, int _astride, int _bstride, int _cstride,
+                 int kpos) {
+    int lda = _astride / sizeof(matA[0]);
+    int ldb = _bstride / sizeof(matB[0]);
+    int ldc = _cstride / sizeof(matC[0]);
+    for (int i = 0; i < _m; i++) {
+      for (int j = 0; j < _n; j += NTILE) {
+        for (int ij = 0; ij < NTILE; ij++) {
+          if (j + ij >= _n) {
+            break;
+          }
+          float tmpf = 0.f;
+          for (int k = 0; k < _k; k += _kblock) {
+            int tmp = 0;
+            for (int ik = 0; ik < _kblock; ik += 4) {
+              if (k + ik >= _k) {
+                break;
+              }
+              for (int ikk = 0; ikk < 4; ikk++) {
+                tmp += (int(matA[i * lda + k + ik + ikk])) *
+                       int(matB[(k + ik) * NTILE + ij * 4 + ikk + j * ldb]);
+              }
+            }
+            tmpf += tmp * scaleA[i * _ldsa + k / _kblock] *
+                    scaleB[j + ij + k / _kblock * _ldsb];
+          }
+          matC[i * ldc + j + ij] = tmpf;
+        }
+      }
+    }
+  }
+  void reference(AType *matA, BType *matB, CType *matC, float *scaleA,
+                 int _ldsa, utils::bf16 *scaleB, int _ldsb, int _m, int _n,
+                 int _k, int _kblock, int _astride, int _bstride, int _cstride,
+                 int kpos) {
+    int lda = _astride / sizeof(matA[0]);
+    int ldb = _bstride / sizeof(matB[0]);
+    int ldc = _cstride / sizeof(matC[0]);
+    for (int i = 0; i < _m; i++) {
+      for (int j = 0; j < _n; j += NTILE) {
+        for (int ij = 0; ij < NTILE; ij++) {
+          if (j + ij >= _n) {
+            break;
+          }
+          float tmpf = 0.f;
+          for (int k = 0; k < _k; k += _kblock) {
+            int tmp = 0;
+            for (int ik = 0; ik < _kblock; ik += 4) {
+              if (k + ik >= _k) {
+                break;
+              }
+              for (int ikk = 0; ikk < 4; ikk++) {
+                tmp += (int(matA[i * lda + k + ik + ikk])) *
+                       int(matB[(k + ik) * NTILE + ij * 4 + ikk + j * ldb]);
+              }
+            }
+            tmpf += tmp * scaleA[i * _ldsa + k / _kblock] *
+                    scaleB[j + ij + k / _kblock * _ldsb].tofloat();
+          }
+          matC[i * ldc + j + ij] = tmpf;
+        }
+      }
+    }
+  }
+
+ private:
+  MicroKernel mCodes, mCodesBf16;
+};
+
+}  // namespace kblock
 
 }  // namespace gemm
 }  // namespace jblas

--- a/intel_extension_for_transformers/backends/neural_engine/graph/jblas/jblas/jit_blas_prologue.h
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/jblas/jblas/jit_blas_prologue.h
@@ -98,11 +98,39 @@ class ActivationBase {
     } else {
       auto k_pad = utils::padto(k_size, _GemmCore_T::KTILE);
       *dststep = k_pad;
-      return kernel::wrapper::Memcpy2D::forward<ISA_T>(aptr + m_offset * _param.lda + k_offset, *dstptr, m_size,
-                                                       k_size * sizeof(AType), _param.lda * sizeof(AType),
-                                                       k_pad * sizeof(AType));
+      const auto ret = kernel::wrapper::Memcpy2D::forward<ISA_T>(aptr + m_offset * _param.lda + k_offset, *dstptr,
+                                                                 m_size, k_size * sizeof(AType),
+                                                                 _param.lda * sizeof(AType), k_pad * sizeof(AType));
+      for (int i = 0; i < m_size; ++i) memset(*dstptr + k_size, 0, (k_pad - k_size) * sizeof(AType));
+      return ret;
     }
     return JblasSuccess;
+  }
+};
+
+template <class _GemmCore_T>
+class ActivationConverterFp32 {
+ public:
+  using SrcType = float;
+  using AType = typename _GemmCore_T::AType;
+  struct Param {
+    const SrcType* A;
+    int lda;
+  };
+  ActivationConverterFp32() {}
+
+  template <JBLAS_ISA ISA_T>
+  JBLAS_CODE getActivation(AType** dstptr, int* dststep, const Param& _param, int m_size, int k_size, int m_offset,
+                           int k_offset) {
+    auto aptr = const_cast<SrcType*>(_param.A);
+    auto k_pad = utils::padto(k_size, _GemmCore_T::KTILE);
+    *dststep = k_pad;
+    if (std::is_same<AType, utils::bf16>::value) {
+      return kernel::wrapper::Memcpy2DFp32CvtBf16::forward<ISA_T>(aptr + m_offset * _param.lda + k_offset, *dstptr,
+                                                                  m_size, k_size, _param.lda * sizeof(SrcType),
+                                                                  k_pad * sizeof(AType));
+    }
+    return JblasNotSupport;
   }
 };
 
@@ -176,46 +204,13 @@ class ActivationF32U8KBlockQuantize {
 
   template <JBLAS_ISA ISA_T>
   QuanParam quantize(const Param& _param, int m, int k, int kblock) {
-    utils::parallel::Parallel2DRowMajorColBlock paral;
-    utils::CpuBase cb;
-    if (m == 1) {
-      cb.mNumThreads = 1;
-    }
-    paral.update(m, k, 1, 16, kblock, cb.mNumThreads);
-    int kpad = utils::padto(k, _GemmCore_T::KTILE);
-    QuanParam quan;
-    quan.resize(m, kpad, kblock);
-    if (m == 1) {
-      auto srcptr = _param.A;
-      int rowremain = m;
-      int colremain = k;
-      auto thdqptr = quan.A;
-      auto thdsptr = quan.scales;
-      auto thdzptr = quan.zp;
-      kernel::wrapper::QuantizeU8ColBlock::template forward<ISA_T>(rowremain, colremain, srcptr, _param.lda, thdqptr,
-                                                                   quan.lda, thdsptr, quan.lds, thdzptr, kblock);
-      return quan;
-    }
-
-    omp_set_num_threads(cb.mNumThreads);
+    utils::parallel::Parallel2DRowMajorColBlock paral = createParallel(m, k, kblock);
+    QuanParam quan = createObj(m, k, kblock);
     if (paral.mThdsPerBlock == 1) {  // no barrier
 #pragma omp parallel
       {
         int tidx = omp_get_thread_num();
-        int colidx, rowidx, rowsize, colsize;
-        int blkidx, idxinblk;
-        paral.getIndex(tidx, &rowidx, &colidx, &rowsize, &colsize, &blkidx, &idxinblk);
-        if (rowsize > 0 && colsize > 0) {
-          // min max
-          auto srcptr = _param.A + rowidx * _param.lda + colidx;
-          int rowremain = utils::remainsize(rowidx, m, rowsize);
-          int colremain = utils::remainsize(colidx, k, colsize);
-          auto thdqptr = quan.A + rowidx * quan.lda + colidx;
-          auto thdsptr = quan.scales + rowidx * quan.lds + blkidx;
-          auto thdzptr = quan.zp + rowidx * quan.lds + blkidx;
-          kernel::wrapper::QuantizeU8ColBlock::template forward<ISA_T>(
-              rowremain, colremain, srcptr, _param.lda, thdqptr, quan.lda, thdsptr, quan.lds, thdzptr, kblock);
-        }
+        quantizeT<ISA_T>(_param, tidx, quan, paral);
       }
     } else {
       assert(0);
@@ -260,6 +255,110 @@ class ActivationF32U8KBlockQuantize {
   }
 };
 
+template <class _GemmCore_T>
+class ActivationF32S8KBlockQuantize {
+ public:
+  using AType = typename _GemmCore_T::AType;
+  using AQType = int8_t;
+  using SType = float;
+  struct Param {
+    const float* A;
+    int lda;
+  };
+  struct QuanParam {
+    AQType* A;
+    int lda;
+    SType* scales;
+    int lds;
+    int kblock;
+
+    void resize(int m, int kpad, int _kblock) {
+      kblock = _kblock;
+      lda = kpad;
+      mA.resize(m * lda);
+      A = mA.data();
+      lds = utils::updiv(kpad, _kblock);
+      mScales.resize(m * lds);
+      scales = mScales.data();
+    }
+    utils::aligned_vector<AQType> mA;
+    utils::aligned_vector<SType> mScales;
+  };
+  using Parallel = utils::parallel::Parallel2DRowMajorColBlock;
+
+  Parallel createParallel(int m, int k, int kblock) {
+    Parallel _paral;
+    auto cb = utils::CpuBase();
+    _paral.update(m, k, 1, 16, kblock, cb.mNumThreads);
+    return _paral;
+  }
+
+  QuanParam createObj(int m, int k, int kblock) {
+    QuanParam quan;
+    int kpad = utils::padto(k, _GemmCore_T::KTILE);
+    quan.resize(m, kpad, kblock);
+    return quan;
+  }
+
+  template <JBLAS_ISA ISA_T>
+  void quantizeT(const Param& _param, int tidx, QuanParam& quan, Parallel& para) {
+    int colidx, rowidx, rowsize, colsize;
+    int blkidx, idxinblk;
+    para.getIndex(tidx, &rowidx, &colidx, &rowsize, &colsize, &blkidx, &idxinblk);
+
+    if (rowsize > 0 && colsize > 0) {
+      // min max
+      auto srcptr = _param.A + rowidx * _param.lda + colidx;
+      int rowremain = utils::remainsize(rowidx, para.mRows, rowsize);
+      int colremain = utils::remainsize(colidx, para.mCols, colsize);
+      auto thdqptr = quan.A + rowidx * quan.lda + colidx;
+      auto thdsptr = quan.scales + rowidx * quan.lds + blkidx;
+      kernel::wrapper::QuantizeS8ColBlock::template forward<ISA_T>(rowremain, colremain, srcptr, _param.lda, thdqptr,
+                                                                   quan.lda, thdsptr, quan.lds, para.mColBlock);
+    }
+  }
+
+  template <JBLAS_ISA ISA_T>
+  QuanParam quantize(const Param& _param, int m, int k, int kblock) {
+    utils::parallel::Parallel2DRowMajorColBlock paral = createParallel(m, k, kblock);
+    QuanParam quan = createObj(m, k, kblock);
+    if (paral.mThdsPerBlock == 1) {  // no barrier
+#pragma omp parallel
+      {
+        int tidx = omp_get_thread_num();
+        quantizeT<ISA_T>(_param, tidx, quan, paral);
+      }
+    } else {
+      assert(0);
+    }
+    return quan;
+  }
+
+  template <JBLAS_ISA ISA_T>
+  JBLAS_CODE getActivation(AType** dstptr, int* dststep, const QuanParam& _param, int m_size, int k_size, int m_offset,
+                           int k_offset) {
+    auto aptr = const_cast<AType*>(_param.A);
+    *dstptr = aptr + m_offset * _param.lda + k_offset;
+    *dststep = _param.lda;
+    return JblasSuccess;
+  }
+
+  template <JBLAS_ISA ISA_T>
+  JBLAS_CODE getScale(SType** dstptr, int* dststep, const QuanParam& _param, int m_size, int k_size, int m_offset,
+                      int k_offset) {
+    auto ptr = const_cast<SType*>(_param.scales);
+    *dstptr = ptr + m_offset * _param.lds + k_offset / _param.kblock;
+    *dststep = _param.lds;
+    return JblasSuccess;
+  }
+
+  template <JBLAS_ISA ISA_T>
+  static inline JBLAS_CODE getZp(AType** dstptr, int* dststep, const QuanParam& _param, int m_size, int k_size,
+                                 int m_offset, int k_offset) {
+    return JblasSuccess;
+  }
+};
+
 enum class PackType : int {
   Default = 0,
 };
@@ -287,29 +386,26 @@ class PackedWeightDefault : public prologue::PackedWeight {
   virtual size_t getDataSerializedSize() override {
     size_t totalsize = 0;
     totalsize += sizeof(mWSize);
-    totalsize += mWSize * sizeof(mWPtr[0]);
+    totalsize += mWSize * sizeof(WType);
     return totalsize;
   }
   virtual void serializeDataToBuffer(void* buf) override {
     auto wptr = reinterpret_cast<int8_t*>(buf);
     utils::serialize(wptr, mWSize);
-    for (size_t i = 0; i < mWSize; i++) {
-      utils::serialize(wptr, mWPtr[i]);
-    }
+    std::memcpy(mWPtr, wptr, mWSize * sizeof(WType));
   }
   virtual void deserializeDataBuffer(void* buf, int memalloc) override {
     auto rptr = reinterpret_cast<int8_t*>(buf);
     size_t rsize = utils::deserialize<size_t>(rptr);
     if (memalloc) {
       mWeights.resize(rsize);
-      std::memcpy(mWeights.data(), rptr, rsize * sizeof(mWeights[0]));
+      std::memcpy(mWeights.data(), rptr, rsize * sizeof(WType));
       mWPtr = mWeights.data();
       mWSize = mWeights.size();
     } else {
       mWPtr = (WType*)rptr;
       mWSize = rsize;
     }
-    rptr += rsize * sizeof(mWeights[0]);
   }
   utils::aligned_vector<WType> mWeights;
 };
@@ -332,7 +428,7 @@ class PackedWeightBase {
   }
 };
 
-template <class _GemmCore_T>
+template <class _GemmCore_T, JBLAS_ISA ISA_T>
 class WeightPack {
  public:
   struct Param {
@@ -340,7 +436,6 @@ class WeightPack {
   };
   using WType = typename _GemmCore_T::BType;
 
-  template <JBLAS_ISA ISA_T>
   PackedWeight* packTranspose(const int N, const int K, const WType* B, const int ldb,
                               PackType type = PackType::Default) {
     utils::aligned_vector<float> B_NT(N * K);
@@ -348,17 +443,15 @@ class WeightPack {
     return packWeight<ISA_T>(N, K, B_NT.data(), N, type);
   }
 
-  template <JBLAS_ISA ISA_T>
   PackedWeight* pack(const int N, const int K, const WType* B, const int ldb, PackType type = PackType::Default) {
-    return packWeight<ISA_T>(N, K, B, N, type);
+    return packWeight(N, K, B, N, type);
   }
 
-  template <JBLAS_ISA ISA_T, typename _T>
+  template <typename _T>
   inline JBLAS_CODE getWeight(_T* dstptr, int k_size, int n_size, int k_offset, int n_offset, const PackedWeight* ptr) {
     return JblasNotSupport;
   }
 
-  template <JBLAS_ISA ISA_T>
   inline JBLAS_CODE getWeight(WType** dstptr, int* dststep, int k_size, int n_size, int k_offset, int n_offset,
                               const PackedWeight* ptr) {
     {
@@ -376,7 +469,6 @@ class WeightPack {
   }
 
  protected:
-  template <JBLAS_ISA ISA_T>
   void transposeWeight(const int N, const int K, const WType* src, const int ld_src, WType* dst, const int ld_dst) {
     utils::parallel::Parallel2DRowMajor _para;
     utils::CpuBase cb;
@@ -398,7 +490,6 @@ class WeightPack {
   }
 
   // from KxN int8 symmetric weight to packed N//NtilexKPadxNTile int4 weight
-  template <JBLAS_ISA ISA_T>
   PackedWeight* packWeight(const int N, const int K, const WType* B, const int ldb, PackType type) {
     int KPad = utils::padto(K, _GemmCore_T::KTILE);
     int NPad = utils::padto(N, _GemmCore_T::NTILE);
@@ -413,11 +504,10 @@ class WeightPack {
     if (ptr == NULL) {
       return ptr;
     }
-    reorder<ISA_T>(N, K, B, ldb, wptr);
+    reorder(N, K, B, ldb, wptr);
     return ptr;
   }
 
-  template <JBLAS_ISA ISA_T>
   void reorder(const int N, const int K, const WType* B, const int ldb, WType* dstptr) {
     utils::parallel::Parallel2DRowMajor _para;
     utils::CpuBase cb;
@@ -433,10 +523,10 @@ class WeightPack {
         int rowremain = utils::remainsize(rowidx, K,
                                           rowsize);  // rowremain: src valid size. rowsize: padded size
         int colremain = utils::remainsize(colidx, N, colsize);
-        auto ret = kernel::wrapper::PaddingInterleaveMN<_GemmCore_T::NTILE, sizeof(B[0]), _GemmCore_T::PACK_ROW>::
+        auto ret = kernel::wrapper::PaddingInterleaveMN<_GemmCore_T::NTILE, sizeof(WType), _GemmCore_T::PACK_ROW>::
             template forward<ISA_T>((void*)(B + rowidx * ldb + colidx),
                                     dstptr + rowidx * _GemmCore_T::NTILE + colidx * KPad, rowremain, colremain, rowsize,
-                                    colsize, ldb * sizeof(B[0]), KPad * sizeof(dstptr[0]));
+                                    colsize, ldb * sizeof(WType), KPad * sizeof(WType));
         assert(ret == JblasSuccess);
       }
     }

--- a/intel_extension_for_transformers/backends/neural_engine/graph/jblas/jblas/jit_blas_transformer.h
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/jblas/jblas/jit_blas_transformer.h
@@ -1,3 +1,16 @@
+//  Copyright (c) 2023 Intel Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 #pragma once
 #include "jit_blas_weight_compression.h"
 #include "jit_blas_wrapper.h"
@@ -6,6 +19,73 @@
 namespace jblas {
 namespace wrapper {
 namespace transformer {
+// compared with BatchGemm, QKV has the same activation matrix.
+// This is the reason why making it a new template.
+template <class _Launcher_T, template <class _T> class _Parallel_T>
+class QKVGemmInterfacePackWeight {
+ public:
+  struct Arguments {
+    const int M, N, K, Batch;
+    const typename _Launcher_T::AParam paramA;
+    const typename _Launcher_T::BParam* paramsB;
+    const typename _Launcher_T::EpiParam* paramsC;
+    void* workspace;
+  };
+  using Config = typename _Launcher_T::ParallelConfig;
+  using ActivationType = typename _Launcher_T::PrologueA;
+  using WeightType = typename _Launcher_T::PrologueB;
+  using GemmCore = typename _Launcher_T::GemmCore;
+  using LArguments = typename _Launcher_T::Param;
+  using CParam = typename _Launcher_T::EpiParam;
+  using Parallel = _Parallel_T<GemmCore>;
+  Parallel createParallel(int M = 0, int N = 0, int K = 0, int Batch = 1, int KBlock = 0) {
+    Parallel _paral;
+    auto cb = utils::CpuBase();
+    _paral.update(M, N, K, KBlock, cb.mNumThreads);
+    return _paral;
+  }
+  ActivationType* getActivationPtr() { return &mLauncher.mProA; }
+  WeightType* getWeightPtr() { return &mLauncher.mProB; }
+
+  JBLAS_CODE compute(const Arguments& _param, Parallel _paral = Parallel()) {
+    auto bptr = dynamic_cast<const prologue::weight_comp::PackedWeightKBlock*>(_param.paramsB[0].packedW);
+    if (bptr == nullptr) {
+      return JblasInvalidParam;
+    }
+
+    auto cb = utils::CpuBase();
+    if (_paral.update(_param.M, _param.N, _param.K, cb.mNumThreads)) {
+      static bool dbgprint = false;
+      if (dbgprint) {
+        _paral.print();
+        dbgprint = false;
+      }
+    }
+    omp_set_num_threads(cb.mNumThreads);
+#pragma omp parallel
+    {
+      int tidx = omp_get_thread_num();
+      launchT(_param, tidx, _paral, cb.mL2Cache);
+    }
+    return JblasSuccess;
+  }
+
+ protected:
+  void launchT(const Arguments& _param, int tidx, Parallel& _paral, size_t l2cache) {
+    int colidx, rowidx, rowsize, colsize;
+    _paral.getIndex(tidx, &rowidx, &colidx, &rowsize, &colsize);
+    if (rowsize > 0 && colsize > 0) {
+      Config _config{rowidx, colidx, rowsize, colsize, _paral.getMStep(), _paral.getNStep(), _paral.getKStep(),
+                     l2cache};
+      for (size_t i = 0; i < _param.Batch; i++) {
+        mLauncher.launch(_config, {_param.M, _param.N, _param.K, _param.paramA, _param.paramsB[i], _param.paramsC[i],
+                                   _param.workspace});
+      }
+    }
+  }
+
+  _Launcher_T mLauncher;
+};
 
 // compared with BatchGemm, QKV has the same activation matrix.
 // This is the reason why making it a new template.
@@ -126,11 +206,39 @@ static JBLAS_ISA constexpr DefaultISA = JblasAVX512_VNNI;
 
 using QKVGemmSKernelDynamicS4KBlock = jblas::wrapper::transformer::QKVGemmInterfaceKBlockPackWeight<
     jblas::wrapper::gemm_kblock::GemmSLauncherKBlockPackWeight<
-        DefaultISA, jblas::prologue::gemm::ActivationF32U8KBlockQuantize,
-        jblas::prologue::weight_comp::gemm::WeightS4_KBlock, jblas::epilogue::gemm::AccumulateWriteBack<float>>,
+        DefaultISA, jblas::gemm::kblock::GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK,
+        jblas::prologue::gemm::ActivationF32U8KBlockQuantize, jblas::prologue::weight_comp::gemm::WeightS4_KBlock,
+        jblas::epilogue::gemm::AccumulatorWriteBack<float, float>>,
     jblas::utils::parallel::Parallel2DGemmKBlockFixed>;
 
 }  // namespace avx512_vnni
+namespace amx_int8 {
+static JBLAS_ISA constexpr DefaultISA = JblasAMX_INT8;
+using QKVGemmSKernelDynamicS4KBlock = jblas::wrapper::transformer::QKVGemmInterfaceKBlockPackWeight<
+    jblas::wrapper::gemm_kblock::GemmSLauncherKBlockPackWeight<
+        DefaultISA, jblas::gemm::kblock::GemmCore_Row_NN_16x48_AMX_INT8_KBLOCK,
+        jblas::prologue::gemm::ActivationF32S8KBlockQuantize, jblas::prologue::weight_comp::gemm::WeightS4_KBlock,
+        jblas::epilogue::gemm::AccumulatorWriteBack<float, float>>,
+    jblas::utils::parallel::Parallel2DGemmKBlockFixed>;
+}  // namespace amx_int8
+namespace avx512_f {
+static JBLAS_ISA constexpr DefaultISA = JblasAVX512F;
+using QKVGemm = jblas::wrapper::transformer::QKVGemmInterfacePackWeight<
+    jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<
+        DefaultISA, jblas::gemm::GemmCore_Row_NN_8x48_AVX512F,
+        jblas::prologue::gemm::ActivationBase,  // activation fp32->bf16
+        jblas::prologue::weight_comp::gemm::WeightS4_KBlock, jblas::epilogue::gemm::AccumulatorWriteBack<float, float>>,
+    jblas::utils::parallel::Parallel2DGemm>;
+}  // namespace avx512_f
+namespace amx_bf16 {
+static JBLAS_ISA constexpr DefaultISA = JblasAMX_BF16;
+using QKVGemm = jblas::wrapper::transformer::QKVGemmInterfacePackWeight<
+    jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<
+        DefaultISA, jblas::gemm::GemmCore_Row_NN_16x64_AMX_BF16,
+        jblas::prologue::gemm::ActivationConverterFp32,  // activation fp32->bf16
+        jblas::prologue::weight_comp::gemm::WeightS4_KBlock, jblas::epilogue::gemm::AccumulatorWriteBack<float, float>>,
+    jblas::utils::parallel::Parallel2DGemm>;
+}  // namespace amx_bf16
 }  // namespace weight_comp
 }  // namespace transformer_default
 }  // namespace wrapper

--- a/intel_extension_for_transformers/backends/neural_engine/graph/jblas/jblas/jit_blas_wrapper.h
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/jblas/jblas/jit_blas_wrapper.h
@@ -27,12 +27,12 @@ namespace wrapper {
 namespace gemm_pack_weight {
 
 template <JBLAS_ISA _RT_ISA_T, class _GemmCore_T, template <class _T> class _PrologueA_T,
-          template <class _T> class _PrologueB_T, class _Epilogue_T>
+          template <class _T, JBLAS_ISA> class _PrologueB_T, class _Epilogue_T>
 class GemmLauncherPackWeight {
  public:
   using GemmCore = _GemmCore_T;
   using PrologueA = _PrologueA_T<GemmCore>;
-  using PrologueB = _PrologueB_T<GemmCore>;
+  using PrologueB = _PrologueB_T<GemmCore, _RT_ISA_T>;
   using AType = typename GemmCore::AType;
   using AParam = typename PrologueA::Param;
   using BType = typename GemmCore::BType;
@@ -65,7 +65,7 @@ class GemmLauncherPackWeight {
     auto StackTmp = alloca(_config.StackSize);
     auto tmpB = (BType*)(StackTmp);
     auto tmpA = (AType*)(tmpB + _config.NStep * _config.KStep);
-    auto tmpC = (CType*)(tmpA + GemmCore::MTILE * GemmCore::KTILE);
+    auto tmpC = (CType*)(tmpA + GemmCore::MTILE * _config.KStep);
     for (int itern = 0; itern < colremain; itern += _config.NStep) {
       int n_remain = utils::remainsize(itern, colremain, _config.NStep);
       for (int iterm = 0; iterm < rowremain; iterm += _config.MStep) {
@@ -85,15 +85,15 @@ class GemmLauncherPackWeight {
       int k_paddedle = utils::padto_le(k_remain, GemmCore::KTILE);
       auto bptr_cache = tmpB;
       int bcache_step = 0;
-      mProB.template getWeight<_RT_ISA_T>(&bptr_cache, &bcache_step, k_padded, n_padded, iterk, _config.colidx + blk_n,
-                                          _param.paramB.packedW);
+      mProB.getWeight(&bptr_cache, &bcache_step, k_padded, n_padded, iterk, _config.colidx + blk_n,
+                      _param.paramB.packedW);
       int bcache_stride = bcache_step * sizeof(BType);
       for (int i = 0; i < blk_msize; i += GemmCore::MTILE) {
         int m_remain = utils::remainsize(i, blk_msize, GemmCore::MTILE);
         auto cptr_cache = tmpC + i * _config.NStep;
         int ccache_stride = _config.NStep * sizeof(CType);
 
-        AType* aptr_cache = nullptr;
+        AType* aptr_cache = tmpA;
         int acache_step = 0;
         if (k_paddedle) {
           mProA.template getActivation<_RT_ISA_T>(&aptr_cache, &acache_step, _param.paramA, m_remain, k_paddedle,
@@ -103,11 +103,11 @@ class GemmLauncherPackWeight {
         }
         int k_tail = k_remain - k_paddedle;
         if (k_tail) {
-          aptr_cache = tmpA;
           mProA.template getActivation<_RT_ISA_T>(&aptr_cache, &acache_step, _param.paramA, m_remain, k_tail,
                                                   (blk_m + i + _config.rowidx), iterk + k_paddedle);
           mGemmCore.forward(aptr_cache, bptr_cache + k_paddedle * GemmCore::NTILE, cptr_cache, m_remain, n_padded,
-                            k_padded, acache_step * sizeof(AType), bcache_stride, ccache_stride, iterk + k_paddedle);
+                            GemmCore::KTILE, acache_step * sizeof(AType), bcache_stride, ccache_stride,
+                            iterk + k_paddedle);
         }
       }
     }
@@ -169,19 +169,67 @@ using DefaultParallel = jblas::utils::parallel::Parallel2DGemm<T>;
 namespace avx512f {
 JBLAS_ISA constexpr DefaultISA = JblasAVX512F;
 using GemmKernel = jblas::wrapper::gemm_pack_weight::GemmInterfacePackWeight<
-    jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<
-        DefaultISA, jblas::gemm::GemmCore_Row_NN_8x48_AVX512F, jblas::prologue::gemm::ActivationBase,
-        jblas::prologue::gemm::WeightPack, jblas::epilogue::gemm::AlphaBetaProcessFp32>,
+    jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<  //
+        DefaultISA,                                            //
+        jblas::gemm::GemmCore_Row_NN_8x48_AVX512F,             //
+        jblas::prologue::gemm::ActivationBase,                 //
+        jblas::prologue::gemm::WeightPack,                     //
+        jblas::epilogue::gemm::AlphaBetaProcessFp32>,
     DefaultParallel>;
 }  // namespace avx512f
 namespace avx512_vnni {
 JBLAS_ISA constexpr DefaultISA = JblasAVX512_VNNI;
 using GemmKernel = jblas::wrapper::gemm_pack_weight::GemmInterfacePackWeight<
-    jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<
-        DefaultISA, jblas::gemm::GemmCore_Row_NN_8x48_AVX512_VNNI, jblas::prologue::gemm::ActivationBase,
-        jblas::prologue::gemm::WeightPack, jblas::epilogue::gemm::AlphaBetaProcessS32U8>,
+    jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<  //
+        DefaultISA,                                            //
+        jblas::gemm::GemmCore_Row_NN_8x48_AVX512_VNNI,         //
+        jblas::prologue::gemm::ActivationBase,                 //
+        jblas::prologue::gemm::WeightPack,                     //
+        jblas::epilogue::gemm::AlphaBetaProcessS32U8>,
     DefaultParallel>;
 }  // namespace avx512_vnni
+
+namespace amx_bf16 {
+JBLAS_ISA constexpr DefaultISA = JblasAMX_BF16;
+using GemmKernelPackedWeightNN = jblas::wrapper::gemm_pack_weight::GemmInterfacePackWeight<
+    jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<  //
+        DefaultISA,                                            //
+        jblas::gemm::GemmCore_Row_NN_16x64_AMX_BF16,           //
+        jblas::prologue::gemm::ActivationBase,                 //
+        jblas::prologue::gemm::WeightPack,                     //
+        jblas::epilogue::gemm::AccumulatorWriteBack<float, jblas::utils::bf16>>,
+    DefaultParallel>;
+using GemmKernelPackedWeightNN_48 = jblas::wrapper::gemm_pack_weight::GemmInterfacePackWeight<
+    jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<  //
+        DefaultISA,                                            //
+        jblas::gemm::GemmCore_Row_NN_16x48_AMX_BF16,           //
+        jblas::prologue::gemm::ActivationBase,                 //
+        jblas::prologue::gemm::WeightPack,                     //
+        jblas::epilogue::gemm::AccumulatorWriteBack<float, jblas::utils::bf16>>,
+    DefaultParallel>;
+}  // namespace amx_bf16
+
+namespace amx_int8 {
+JBLAS_ISA constexpr DefaultISA = JblasAMX_INT8;
+
+using GemmKernel48 = jblas::wrapper::gemm_pack_weight::GemmInterfacePackWeight<
+    jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<  //
+        DefaultISA,                                            //
+        jblas::gemm::GemmCore_Row_NN_16x48_AMX_INT8,           //
+        jblas::prologue::gemm::ActivationBase,                 //
+        jblas::prologue::gemm::WeightPack,                     //
+        jblas::epilogue::gemm::AlphaBetaProcessS32U8>,
+    DefaultParallel>;
+
+using GemmKernel = jblas::wrapper::gemm_pack_weight::GemmInterfacePackWeight<
+    jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<  //
+        DefaultISA,                                            //
+        jblas::gemm::GemmCore_Row_NN_16x64_AMX_INT8,           //
+        jblas::prologue::gemm::ActivationBase,                 //
+        jblas::prologue::gemm::WeightPack,                     //
+        jblas::epilogue::gemm::AlphaBetaProcessS32U8>,
+    DefaultParallel>;
+}  // namespace amx_int8
 }  // namespace gemm_default
 }  // namespace wrapper
 

--- a/intel_extension_for_transformers/backends/neural_engine/graph/jblas/jblas/kernel_jit.h
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/jblas/jblas/kernel_jit.h
@@ -17,6 +17,7 @@
 
 #include "jit_base.hpp"
 #include "jit_blas_utils.h"
+#include "kernel_jit_injector.h"
 struct decompress_block_s4_f32_codegen_param {
   int row;
   int col;
@@ -216,73 +217,86 @@ class JitMemcpy2DAvx512f : protected jblas::xbyak::JitAvx512f {
  public:
   static int constexpr VBytes = 64;
   JitMemcpy2DAvx512f() {
+    std::vector<kernel::jit_injector::eltwise_injector> empty = {};
+    this->codeGen(empty);
+  }
+  JitMemcpy2DAvx512f(std::vector<kernel::jit_injector::eltwise_injector>& injectors) { this->codeGen(injectors); }
+
+  void codeGen(std::vector<kernel::jit_injector::eltwise_injector>& injectors) {
     inLocalLabel();  // use local label for multiple instance
-    int SF_TmpSize = 64;
-    int SF_TmpPos = 16 * 10;
-    Xbyak::util::StackFrame st(this, 1, 13, 16 * 10 + SF_TmpSize);
-    const Xbyak::Reg64& parambase = st.p[0];
-    const Xbyak::Reg64& reg_srcptr = st.t[0];
-    const Xbyak::Reg64& reg_dstptr = st.t[1];
-    const Xbyak::Reg64& reg_srcstride = st.t[2];
-    const Xbyak::Reg64& reg_dststride = st.t[3];
-    const Xbyak::Reg64& reg_rowsize = st.t[4];
-    const Xbyak::Reg64& reg_colsize = st.t[5];
-    const Xbyak::Reg64& reg_iterrow = st.t[6];
-    const Xbyak::Reg64& reg_itercol = st.t[7];
-    const Xbyak::Reg64& reg_tmp = st.t[8];
-    const Xbyak::Reg64& reg_tmpsrc = st.t[9];
-    const Xbyak::Reg64& reg_tmpdst = st.t[10];
-    const Xbyak::Reg64& reg_tmp1 = st.t[12];
-    const Xbyak::Reg64& reg_ret = rax;
+    {
+      int SF_TmpSize = 64;
+      int SF_TmpPos = 16 * 10;
+      Xbyak::util::StackFrame st(this, 1, 13, 16 * 10 + SF_TmpSize);
+      const Xbyak::Reg64& parambase = st.p[0];
+      const Xbyak::Reg64& reg_srcptr = st.t[0];
+      const Xbyak::Reg64& reg_dstptr = st.t[1];
+      const Xbyak::Reg64& reg_srcstride = st.t[2];
+      const Xbyak::Reg64& reg_dststride = st.t[3];
+      const Xbyak::Reg64& reg_rowsize = st.t[4];
+      const Xbyak::Reg64& reg_colsize = st.t[5];
+      const Xbyak::Reg64& reg_iterrow = st.t[6];
+      const Xbyak::Reg64& reg_itercol = st.t[7];
+      const Xbyak::Reg64& reg_tmp = st.t[8];
+      const Xbyak::Reg64& reg_tmpsrc = st.t[9];
+      const Xbyak::Reg64& reg_tmpdst = st.t[10];
+      const Xbyak::Reg64& reg_tmp1 = st.t[12];
+      const Xbyak::Reg64& reg_ret = rax;
 
-    vreg_push(rsp);
+      vreg_push(rsp);
 
-    mov(reg_srcptr, ptr[parambase + OFFSET(srcptr)]);
-    mov(reg_dstptr, ptr[parambase + OFFSET(dstptr)]);
-    xor_(reg_srcstride, reg_srcstride);
-    mov(reg_srcstride.cvt32(), ptr[parambase + OFFSET(srcstride)]);
-    xor_(reg_dststride, reg_dststride);
-    mov(reg_dststride.cvt32(), ptr[parambase + OFFSET(dststride)]);
+      mov(reg_srcptr, ptr[parambase + OFFSET(srcptr)]);
+      mov(reg_dstptr, ptr[parambase + OFFSET(dstptr)]);
+      xor_(reg_srcstride, reg_srcstride);
+      mov(reg_srcstride.cvt32(), ptr[parambase + OFFSET(srcstride)]);
+      xor_(reg_dststride, reg_dststride);
+      mov(reg_dststride.cvt32(), ptr[parambase + OFFSET(dststride)]);
 
-    load32(reg_colsize, ptr[parambase + OFFSET(col)]);
-    load32(reg_rowsize, ptr[parambase + OFFSET(row)]);
+      load32(reg_colsize, ptr[parambase + OFFSET(col)]);
+      load32(reg_rowsize, ptr[parambase + OFFSET(row)]);
 
-    int const ColUnroll = 4;
-    xor_(reg_iterrow, reg_iterrow);
-    L(".rowloop");
-    xor_(reg_itercol, reg_itercol);
-    mov(reg_tmpsrc, reg_srcptr);
-    mov(reg_tmpdst, reg_dstptr);
-    L(".colloop");
-    mov(reg_tmp, reg_colsize);
-    sub(reg_tmp, reg_itercol);
-    cmp(reg_tmp, ColUnroll * VBytes);
-    jl(".maskproc", T_NEAR);
+      int const ColUnroll = 4;
+      xor_(reg_iterrow, reg_iterrow);
+      L(".rowloop");
+      xor_(reg_itercol, reg_itercol);
+      mov(reg_tmpsrc, reg_srcptr);
+      mov(reg_tmpdst, reg_dstptr);
+      L(".colloop");
+      mov(reg_tmp, reg_colsize);
+      sub(reg_tmp, reg_itercol);
+      cmp(reg_tmp, ColUnroll * VBytes);
+      jl(".maskproc", T_NEAR);
 
-    for (int i = 0; i < ColUnroll; i++) {
-      vmovups(Xbyak::Zmm(i), ptr[reg_srcptr + reg_itercol + i * VBytes]);
-      vmovups(ptr[reg_dstptr + reg_itercol + i * VBytes], Xbyak::Zmm(i));
+      for (int i = 0; i < ColUnroll; i++) used_zmm_idx.insert(i);
+      for (auto&& injector : injectors) injector.assign_resources(this, used_zmm_idx, reg_ret, k2);
+
+      for (int i = 0; i < ColUnroll; i++) {
+        vmovups(Xbyak::Zmm(i), ptr[reg_srcptr + reg_itercol + i * VBytes]);
+        for (auto&& injector : injectors) injector.vector_compute(Xbyak::Zmm(i));
+        vmovups(ptr[reg_dstptr + reg_itercol + i * VBytes], Xbyak::Zmm(i));
+      }
+      add(reg_itercol, ColUnroll * VBytes);
+      jmp(".colend", T_NEAR);
+      L(".maskproc");
+      generate_Nbitsmask(k1, reg_itercol, reg_colsize, reg_tmp, reg_tmp1, VBytes);
+      vmovdqu8(Xbyak::Zmm(0) | k1, ptr[reg_srcptr + reg_itercol]);
+      for (auto&& injector : injectors) injector.vector_compute(Xbyak::Zmm(0));
+      vmovdqu8(ptr[reg_dstptr + reg_itercol], Xbyak::Zmm(0) | k1);
+      add(reg_itercol, VBytes);
+      L(".colend");
+      cmp(reg_itercol, reg_colsize);
+      jb(".colloop");
+      add(reg_iterrow, 1);
+      lea(reg_srcptr, ptr[reg_srcptr + reg_srcstride]);
+      lea(reg_dstptr, ptr[reg_dstptr + reg_dststride]);
+      cmp(reg_iterrow, reg_rowsize);
+      jb(".rowloop");
+
+      mov(reg_ret, 0);
+      vreg_pop(rsp);
     }
-    add(reg_itercol, ColUnroll * VBytes);
-    jmp(".colend");
-    L(".maskproc");
-    generate_Nbitsmask(k1, reg_itercol, reg_colsize, reg_tmp, reg_tmp1, VBytes);
-    vmovdqu8(Xbyak::Zmm(0) | k1, ptr[reg_srcptr + reg_itercol]);
-    vmovdqu8(ptr[reg_dstptr + reg_itercol], Xbyak::Zmm(0) | k1);
-    add(reg_itercol, VBytes);
-    L(".colend");
-    cmp(reg_itercol, reg_colsize);
-    jb(".colloop");
-    add(reg_iterrow, 1);
-    lea(reg_srcptr, ptr[reg_srcptr + reg_srcstride]);
-    lea(reg_dstptr, ptr[reg_dstptr + reg_dststride]);
-    cmp(reg_iterrow, reg_rowsize);
-    jb(".rowloop");
-
-    mov(reg_ret, 0);
-    vreg_pop(rsp);
     outLocalLabel();  // end of local label
-
+    for (auto&& injector : injectors) injector.prepare_table();
     this->ready();
     mKernel = this->getCode<func_t>();
   }
@@ -294,27 +308,48 @@ class JitMemcpy2DAvx512f : protected jblas::xbyak::JitAvx512f {
     return JblasSuccess;
   }
 
+  static JBLAS_CODE forward_with_gelu(void* srcptr, void* dstptr, int row, int col, int srcstride, int dststride) {
+    static std::vector<kernel::jit_injector::eltwise_injector> p = {{GELU}};
+    static JitMemcpy2DAvx512f gelu_instance(p);
+    auto param = params{srcptr, dstptr, row, col, srcstride, dststride};
+    gelu_instance.mKernel(&param);
+    return JblasSuccess;
+  }
+
  private:
   func_t mKernel = nullptr;
+  std::set<int> used_zmm_idx;
 };
+
+static inline Xbyak::Zmm unpack_4bit(Xbyak::CodeGenerator* jit, Xbyak::Ymm v4bits, Xbyak::Zmm zmm, Xbyak::Zmm zmm1,
+                                     Xbyak::Zmm vmask, Xbyak::Opmask unpack_mask) {
+  Xbyak::Ymm ymm1(zmm1.getIdx());
+  jit->vpmovsxbw(zmm, v4bits);
+  jit->vpslld(ymm1, v4bits, 4);
+  jit->vpmovsxbw(zmm1, ymm1);
+  jit->vpsllw(zmm, zmm, 8);
+  jit->vmovdqu8(zmm1 | unpack_mask, zmm);
+  jit->vpandd(zmm1, vmask, zmm1);
+  return zmm1;
+}
+
+static inline Xbyak::Zmm unpack_4bit_2regs(Xbyak::CodeGenerator* jit, Xbyak::Ymm v4bits, Xbyak::Zmm tmp,
+                                           Xbyak::Zmm vmask, Xbyak::Opmask unpack_mask) {
+  Xbyak::Zmm dst(v4bits.getIdx());
+  jit->vpmovsxbw(tmp, v4bits);
+  jit->vpslld(v4bits, v4bits, 4);
+  jit->vpmovsxbw(dst, v4bits);
+  jit->vpsllw(tmp, tmp, 8);
+  jit->vmovdqu8(dst | unpack_mask, tmp);
+  jit->vpandd(dst, vmask, dst);
+  return dst;
+}
 
 class DequanKBlockS4F32 {
  public:
   static inline void decompress_load_scale(Xbyak::CodeGenerator* jit, int zmm_scale_num,
                                            const std::vector<Xbyak::Zmm>& scale_zmms, const Xbyak::Reg64& reg_scale) {
     for (int i = 0; i < zmm_scale_num; i++) jit->vmovups(scale_zmms[i], jit->zword[reg_scale + i * 16 * sizeof(float)]);
-  }
-
-  static inline Xbyak::Zmm unpack_4bit(Xbyak::CodeGenerator* jit, Xbyak::Ymm v4bits, Xbyak::Zmm zmm, Xbyak::Zmm zmm1,
-                                       Xbyak::Zmm vmask, Xbyak::Opmask unpack_mask) {
-    Xbyak::Ymm ymm1(zmm1.getIdx());
-    jit->vpslld(ymm1, v4bits, 4);
-    jit->vpmovsxbw(zmm, v4bits);
-    jit->vpmovsxbw(zmm1, ymm1);
-    jit->vpsllw(zmm, zmm, 8);
-    jit->vmovdqu8(zmm1 | unpack_mask, zmm);
-    jit->vpandd(zmm1, vmask, zmm1);
-    return zmm1;
   }
 
   struct convert_s4_s8_param {
@@ -474,6 +509,104 @@ class DequanKBlockS4F32 {
     int dump_idx = 0;
   };
 };
+
+class DecompressS4S8_AVX512F : protected jblas::xbyak::JitAvx512f {
+ public:
+  struct params {
+    void *srcptr, *dstptr;
+    size_t size;
+  };
+  typedef long long (*func_t)(params*);
+
+ public:
+  static int constexpr VBytes = 64;
+  DecompressS4S8_AVX512F() {
+    inLocalLabel();  // use local label for multiple instance
+    int SF_TmpSize = 64;
+    int SF_TmpPos = 16 * 10;
+    Xbyak::util::StackFrame st(this, 1, 13, 16 * 10 + SF_TmpSize);
+    const Xbyak::Reg64& parambase = st.p[0];
+    const Xbyak::Reg64& reg_srcptr = st.t[0];
+    const Xbyak::Reg64& reg_dstptr = st.t[1];
+    const Xbyak::Reg64& reg_srcstride = st.t[2];
+    const Xbyak::Reg64& reg_dststride = st.t[3];
+    const Xbyak::Reg64& reg_rowsize = st.t[4];
+    const Xbyak::Reg64& reg_size = st.t[5];
+    const Xbyak::Reg64& reg_iterrow = st.t[6];
+    const Xbyak::Reg64& reg_itercol = st.t[7];
+    const Xbyak::Reg64& reg_tmp = st.t[8];
+    const Xbyak::Reg64& reg_tmpsrc = st.t[9];
+    const Xbyak::Reg64& reg_tmpdst = st.t[10];
+    const Xbyak::Reg64& reg_tmp1 = st.t[12];
+    const Xbyak::Reg64& reg_ret = rax;
+
+    vreg_push(rsp);
+
+    mov(reg_srcptr, ptr[parambase + OFFSET(srcptr)]);
+    mov(reg_dstptr, ptr[parambase + OFFSET(dstptr)]);
+    mov(reg_size, ptr[parambase + OFFSET(size)]);
+    Xbyak::Opmask unpack_mask(4);
+    Xbyak::Zmm zmm_mask(31);
+    mov(reg_tmp.cvt32(), uint32_t(0xf0f0f0f0));
+    vpbroadcastd(zmm_mask, reg_tmp.cvt32());
+    mov(reg_tmp, 0xaaaaaaaaaaaaaaaa);
+    kmovq(unpack_mask, reg_tmp);
+    int const ColUnroll = 4;
+    xor_(reg_iterrow, reg_iterrow);
+    xor_(reg_itercol, reg_itercol);
+    L(".colloop");
+    mov(reg_tmp, reg_size);
+    sub(reg_tmp, reg_itercol);
+    cmp(reg_tmp, ColUnroll * VBytes);
+    jl(".maskproc", T_NEAR);
+    mov(reg_tmp, reg_itercol);
+    shr(reg_tmp, 1);
+    for (int i = 0; i < ColUnroll; i++) {
+      vmovups(Xbyak::Ymm(i), ptr[reg_srcptr + reg_tmp + i * VBytes / 2]);
+      unpack_4bit_2regs(this, Xbyak::Ymm(i), Xbyak::Zmm(ColUnroll), zmm_mask, unpack_mask);
+      vmovups(ptr[reg_dstptr + reg_itercol + i * VBytes], Xbyak::Zmm(i));
+    }
+    add(reg_itercol, ColUnroll * VBytes);
+    jmp(".colend");
+    L(".maskproc");
+    generate_Nbitsmask(k1, reg_itercol, reg_size, reg_tmp, reg_tmp1, VBytes);
+    mov(reg_tmp, reg_itercol);
+    shr(reg_tmp, 1);
+    vmovdqu8(Xbyak::Zmm(0) | k1, ptr[reg_srcptr + reg_tmp]);
+    unpack_4bit_2regs(this, Xbyak::Ymm(0), Xbyak::Zmm(ColUnroll), zmm_mask, unpack_mask);
+    vmovdqu8(ptr[reg_dstptr + reg_itercol], Xbyak::Zmm(0) | k1);
+    add(reg_itercol, VBytes);
+    L(".colend");
+    cmp(reg_itercol, reg_size);
+    jb(".colloop");
+
+    mov(reg_ret, 0);
+    vreg_pop(rsp);
+    outLocalLabel();  // end of local label
+
+    this->ready();
+    mKernel = this->getCode<func_t>();
+  }
+
+  static JBLAS_CODE forward(void* srcptr, void* dstptr, size_t size) {
+    static DecompressS4S8_AVX512F instance;
+    auto param = params{srcptr, dstptr, size};
+    instance.mKernel(&param);
+    return JblasSuccess;
+  }
+
+ private:
+  func_t mKernel = nullptr;
+};
+
+static inline JBLAS_CODE decompress_s4_s8(utils::int4x2* srcptr, int8_t* dstptr, int row, int col, int ld_src,
+                                          int ld_dst) {
+  if (col != ld_src) {  // memory is not continueous
+    return JblasNotSupport;
+  }
+  DecompressS4S8_AVX512F::forward(srcptr, dstptr, (size_t)row * col);
+  return JblasSuccess;
+}
 }  // namespace jit
 }  // namespace kernel
 }  // namespace jblas

--- a/intel_extension_for_transformers/backends/neural_engine/graph/jblas/jblas/kernel_jit_injector.h
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/jblas/jblas/kernel_jit_injector.h
@@ -1,0 +1,740 @@
+//  Copyright (c) 2022 Intel Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#pragma once
+
+#include <utility>
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <map>
+#include <set>
+
+#include "jit_blas.h"
+#include "xbyak/xbyak.h"
+using Zmm = Xbyak::Zmm;
+using Ymm = Xbyak::Ymm;
+using Xmm = Xbyak::Xmm;
+namespace jblas {
+namespace kernel {
+namespace jit_injector {
+template <typename T2, typename T1>
+inline const T2 bit_cast(T1 i) {
+  static_assert(sizeof(T1) == sizeof(T2), "Bit-casting must preserve size.");
+  T2 o;
+  memcpy(&o, &i, sizeof(T2));
+  return o;
+}
+
+class eltwise_injector {
+ public:
+  eltwise_injector(JBLAS_ELTWISEOP eltwiseop, float alpha = 0.f, float beta = 0.f, float gamma = 0.f)
+      : elt_op(eltwiseop), alpha_(alpha), beta_(beta), gamma_(gamma) {
+    gain_fin_const();
+    reigster_table_entries();
+  }
+  virtual ~eltwise_injector() {}
+
+  void assign_resources(Xbyak::CodeGenerator* ptr, const std::set<int>& used_zmm_idx, const Xbyak::Reg64& table_reg,
+                        const Xbyak::Opmask& mask_reg) {
+    h = ptr;
+    k_mask = mask_reg;
+    p_table = table_reg;
+    assert(used_zmm_idx.size() <= 26);
+    assign_zmm(used_zmm_idx, &zmm_mask);
+    assign_zmm(used_zmm_idx, &zmm_aux0);
+    assign_zmm(used_zmm_idx, &zmm_aux1);
+    assign_zmm(used_zmm_idx, &zmm_aux2);
+    assign_zmm(used_zmm_idx, &zmm_aux3);
+    assign_zmm(used_zmm_idx, &zmm_aux4);
+  }
+  void vector_compute(const Xbyak::Zmm& zmm_src) {
+    load_table_addr();
+    switch (elt_op) {
+      case EXP:
+        exp_compute_vector_fwd(zmm_src);
+        break;
+      case TANH:
+        tanh_compute_vector_fwd(zmm_src);
+        break;
+      case GELU:
+        gelu_compute_vector_fwd(zmm_src);
+        break;
+      case RELU:
+        relu_compute_vector_fwd(zmm_src);
+        break;
+      case LINEAR:
+        linear_compute_vector_fwd(zmm_src);
+        break;
+      case LOW_PRECISION_EXP:
+        low_precision_exp_compute_vector_fwd(zmm_src);
+        break;
+      case SWISH:
+        swish_compute_vector_fwd(zmm_src);
+        break;
+      default:
+        assert(false);
+        break;
+    }
+  }
+  void prepare_table() {
+    h->align(64);
+    h->L(l_table);
+    assert(sizeof(table_entry_val_t) == 4);  // sizeof(table_entry_val_t) should be 4
+    for (auto it = entry_map.begin(); it != entry_map.end(); it++) {
+      const auto& te = (*it).second;
+      const auto len = te.bcast ? 64u : sizeof(table_entry_val_t);
+      for (size_t d = 0; d < len; d += sizeof(table_entry_val_t)) h->dd(te.val);
+    }
+  }
+
+ private:
+  void gain_fin_const() {
+    switch (elt_op) {
+      case SWISH:
+        alpha_ *= -1;
+        break;
+      default:
+        break;
+    }
+  }
+  void reigster_table_entries() {
+    static const table_t common_values{{zero, {0x00000000, true}},      {half, {0x3f000000, true}},
+                                       {one, {0x3f800000, true}},       {two, {0x40000000, true}},
+                                       {minus_one, {0xbf800000, true}}, {minus_two, {0xc0000000, true}},
+                                       {ln2f, {0x3f317218, true}},      {positive_mask, {0x7fffffff, true}},
+                                       {sign_mask, {0x80000000, true}}, {exponent_bias, {0x0000007f, true}}};
+
+    static constexpr std::array<float, 3> exp_approx_f32_coeff{0.35815147f, 0.96963238f, 1.f};
+    static const table_t low_precision_exp_consts{
+        {low_precision_exp_const_v0, {bit_cast<uint32_t>(exp_approx_f32_coeff[0]), true}},
+        {low_precision_exp_const_v1, {bit_cast<uint32_t>(exp_approx_f32_coeff[1]), true}},
+        {low_precision_exp_const_v2, {bit_cast<uint32_t>(exp_approx_f32_coeff[2]), true}},
+    };
+
+    static const table_t exp_consts{{exp_log2ef, {0x3fb8aa3b, true}},
+                                    {exp_ln_flt_max_f, {0x42b17218, true}},
+                                    {exp_ln_flt_min_f, {0xc2aeac50, true}}};
+
+    static const table_t exp_polynomial{
+        // p0 = 1.0f
+        {exp_pol, {0x3f7ffffb, true}},  // p1 = 0.999999701f
+        {exp_pol, {0x3efffee3, true}},  // p2 = 0.499991506f
+        {exp_pol, {0x3e2aad40, true}},  // p3 = 0.166676521f
+        {exp_pol, {0x3d2b9d0d, true}},  // p4 = 0.0418978221f
+        {exp_pol, {0x3c07cfce, true}}   // p5 = 0.00828929059f
+    };
+
+    static const table_t gelu_tanh_const{{gelu_tanh_fitting_const, {0x3d372713, true}},
+                                         {gelu_tanh_fitting_const_times_three, {0x3e095d4f, true}},
+                                         {gelu_tanh_sqrt_two_over_pi, {0x3f4c422a, true}},
+                                         {gelu_tanh_flt_max_x, {0x4154C480, true}},
+                                         {gelu_tanh_flt_min_x, {0xC154C480, true}}};
+
+    // tanh(x) constants for four interval approximation
+    static const table_t tanh_consts{{tanh_idx_bias, {0x39800000, true}},
+                                     {tanh_idx_mask, {0xffc00000, true}},
+                                     {tanh_linear_ubound, {0x39ddb3d7, true}},
+                                     {tanh_saturation_lbound, {0x41102cb3, true}}};
+
+    // tanh(x) polynomial approximation
+    // For each coefficient, there is 32 entries
+    static const table_t tanh_polynomial_table{
+        // coefficients of degree 0
+        {tanh_pol_table, {0x00000000, false}},
+        {tanh_pol_table, {0x39bfffff, false}},
+        {tanh_pol_table, {0x39ffffff, false}},
+        {tanh_pol_table, {0x3a3ffffe, false}},
+        {tanh_pol_table, {0x3a7ffffb, false}},
+        {tanh_pol_table, {0x3abffff7, false}},
+        {tanh_pol_table, {0x3affffeb, false}},
+        {tanh_pol_table, {0x3b3fffdc, false}},
+        {tanh_pol_table, {0x3b7fffab, false}},
+        {tanh_pol_table, {0x3bbfff70, false}},
+        {tanh_pol_table, {0x3bfffeab, false}},
+        {tanh_pol_table, {0x3c3ffdc0, false}},
+        {tanh_pol_table, {0x3c7ffaab, false}},
+        {tanh_pol_table, {0x3cbff701, false}},
+        {tanh_pol_table, {0x3cffeaad, false}},
+        {tanh_pol_table, {0x3d3fdc08, false}},
+        {tanh_pol_table, {0x3d7faacd, false}},
+        {tanh_pol_table, {0x3dbf7081, false}},
+        {tanh_pol_table, {0x3dfeacc9, false}},
+        {tanh_pol_table, {0x3e3dc7fd, false}},
+        {tanh_pol_table, {0x3e7acbf5, false}},
+        {tanh_pol_table, {0x3eb77a9f, false}},
+        {tanh_pol_table, {0x3eec9a9f, false}},
+        {tanh_pol_table, {0x3f22991f, false}},
+        {tanh_pol_table, {0x3f42f7d6, false}},
+        {tanh_pol_table, {0x3f67b7cc, false}},
+        {tanh_pol_table, {0x3f76ca83, false}},
+        {tanh_pol_table, {0x3f7ebbe9, false}},
+        {tanh_pol_table, {0x3f7fd40c, false}},
+        {tanh_pol_table, {0x3f7fff32, false}},
+        {tanh_pol_table, {0x3f7ffffc, false}},
+        {tanh_pol_table, {0x3f800000, false}},
+        // coefficients of degree 1
+        {tanh_pol_table, {0x3f800000, false}},
+        {tanh_pol_table, {0x3f800018, false}},
+        {tanh_pol_table, {0x3f7fffe8, false}},
+        {tanh_pol_table, {0x3f7fffda, false}},
+        {tanh_pol_table, {0x3f7fffdc, false}},
+        {tanh_pol_table, {0x3f7fffdc, false}},
+        {tanh_pol_table, {0x3f7fffac, false}},
+        {tanh_pol_table, {0x3f7fff70, false}},
+        {tanh_pol_table, {0x3f7ffeec, false}},
+        {tanh_pol_table, {0x3f7ffdc0, false}},
+        {tanh_pol_table, {0x3f7ffbed, false}},
+        {tanh_pol_table, {0x3f7ff704, false}},
+        {tanh_pol_table, {0x3f7feff5, false}},
+        {tanh_pol_table, {0x3f7fdbca, false}},
+        {tanh_pol_table, {0x3f7fbfff, false}},
+        {tanh_pol_table, {0x3f7f7041, false}},
+        {tanh_pol_table, {0x3f7f009b, false}},
+        {tanh_pol_table, {0x3f7dc36c, false}},
+        {tanh_pol_table, {0x3f7c0aa8, false}},
+        {tanh_pol_table, {0x3f7734b8, false}},
+        {tanh_pol_table, {0x3f70a4de, false}},
+        {tanh_pol_table, {0x3f5f1fd8, false}},
+        {tanh_pol_table, {0x3f495493, false}},
+        {tanh_pol_table, {0x3f18b9ec, false}},
+        {tanh_pol_table, {0x3ed706cb, false}},
+        {tanh_pol_table, {0x3e390b06, false}},
+        {tanh_pol_table, {0x3d90b11f, false}},
+        {tanh_pol_table, {0x3c21a053, false}},
+        {tanh_pol_table, {0x3aaf7fdb, false}},
+        {tanh_pol_table, {0x37ccc1a3, false}},
+        {tanh_pol_table, {0x355c6733, false}},
+        {tanh_pol_table, {0x00000000, false}},
+        // coefficients of degree 2
+        {tanh_pol_table, {0x00000000, false}},
+        {tanh_pol_table, {0xbe4e0ff1, false}},
+        {tanh_pol_table, {0x3d25b1b1, false}},
+        {tanh_pol_table, {0x3d6b6dab, false}},
+        {tanh_pol_table, {0x3c9fb1d5, false}},
+        {tanh_pol_table, {0xbabff06f, false}},
+        {tanh_pol_table, {0x3c07b3f6, false}},
+        {tanh_pol_table, {0xbb3fc1bc, false}},
+        {tanh_pol_table, {0x3a9f5921, false}},
+        {tanh_pol_table, {0xbbbf06f2, false}},
+        {tanh_pol_table, {0xbbb0f402, false}},
+        {tanh_pol_table, {0xbc47db9e, false}},
+        {tanh_pol_table, {0xbc73d5e7, false}},
+        {tanh_pol_table, {0xbca25bda, false}},
+        {tanh_pol_table, {0xbcfca780, false}},
+        {tanh_pol_table, {0xbd40e07c, false}},
+        {tanh_pol_table, {0xbd7dab03, false}},
+        {tanh_pol_table, {0xbdbe4a0f, false}},
+        {tanh_pol_table, {0xbdfb14a5, false}},
+        {tanh_pol_table, {0xbe36cc8d, false}},
+        {tanh_pol_table, {0xbe6bd102, false}},
+        {tanh_pol_table, {0xbe9fe7c5, false}},
+        {tanh_pol_table, {0xbeba0f10, false}},
+        {tanh_pol_table, {0xbec206a8, false}},
+        {tanh_pol_table, {0xbea3c388, false}},
+        {tanh_pol_table, {0xbe277d62, false}},
+        {tanh_pol_table, {0xbd8b7960, false}},
+        {tanh_pol_table, {0xbc209f49, false}},
+        {tanh_pol_table, {0xbaad44ca, false}},
+        {tanh_pol_table, {0xb7c6eeac, false}},
+        {tanh_pol_table, {0xb663aa41, false}},
+        {tanh_pol_table, {0x00000000, false}},
+        // coefficients of degree 3
+        {tanh_pol_table, {0x00000000, false}},
+        {tanh_pol_table, {0x45b3ae96, false}},
+        {tanh_pol_table, {0xc414eb20, false}},
+        {tanh_pol_table, {0xc450e02e, false}},
+        {tanh_pol_table, {0xc3152b4e, false}},
+        {tanh_pol_table, {0xbead2f56, false}},
+        {tanh_pol_table, {0xc2162e02, false}},
+        {tanh_pol_table, {0xbeb4bd5a, false}},
+        {tanh_pol_table, {0xc11a59a4, false}},
+        {tanh_pol_table, {0xbed2f507, false}},
+        {tanh_pol_table, {0xc020d32c, false}},
+        {tanh_pol_table, {0x3dd0f506, false}},
+        {tanh_pol_table, {0xbf2a75e2, false}},
+        {tanh_pol_table, {0xbff950e3, false}},
+        {tanh_pol_table, {0xbed47334, false}},
+        {tanh_pol_table, {0xbe809b8c, false}},
+        {tanh_pol_table, {0xbeb64532, false}},
+        {tanh_pol_table, {0xbe961a5b, false}},
+        {tanh_pol_table, {0xbe9b63ac, false}},
+        {tanh_pol_table, {0xbea0d4b2, false}},
+        {tanh_pol_table, {0xbe828a77, false}},
+        {tanh_pol_table, {0xbe378612, false}},
+        {tanh_pol_table, {0xbdc20908, false}},
+        {tanh_pol_table, {0x3d2d3957, false}},
+        {tanh_pol_table, {0x3dd46e89, false}},
+        {tanh_pol_table, {0x3db3f629, false}},
+        {tanh_pol_table, {0x3d2c5e7b, false}},
+        {tanh_pol_table, {0x3bd20403, false}},
+        {tanh_pol_table, {0x3a59dfae, false}},
+        {tanh_pol_table, {0x3770af45, false}},
+        {tanh_pol_table, {0x372cc014, false}},
+        {tanh_pol_table, {0x00000000, false}},
+        // coefficients of degree 4
+        {tanh_pol_table, {0x00000000, false}},
+        {tanh_pol_table, {0xcc981a1b, false}},
+        {tanh_pol_table, {0x4a7edd3d, false}},
+        {tanh_pol_table, {0x4ab1007c, false}},
+        {tanh_pol_table, {0x48fedd9c, false}},
+        {tanh_pol_table, {0x41a557b5, false}},
+        {tanh_pol_table, {0x477ee32a, false}},
+        {tanh_pol_table, {0x422557f5, false}},
+        {tanh_pol_table, {0x45ff3ce4, false}},
+        {tanh_pol_table, {0x42a55641, false}},
+        {tanh_pol_table, {0x446e0867, false}},
+        {tanh_pol_table, {0xc33dc19a, false}},
+        {tanh_pol_table, {0x42915214, false}},
+        {tanh_pol_table, {0x43af4fad, false}},
+        {tanh_pol_table, {0x4110fe88, false}},
+        {tanh_pol_table, {0xc1099b75, false}},
+        {tanh_pol_table, {0x3fc8a8dc, false}},
+        {tanh_pol_table, {0xbfbeaef5, false}},
+        {tanh_pol_table, {0xbe365aad, false}},
+        {tanh_pol_table, {0x3f4d9652, false}},
+        {tanh_pol_table, {0x3ddfa08f, false}},
+        {tanh_pol_table, {0x3e34e9b8, false}},
+        {tanh_pol_table, {0x3e2d07a6, false}},
+        {tanh_pol_table, {0x3dc63567, false}},
+        {tanh_pol_table, {0x3cdaeb78, false}},
+        {tanh_pol_table, {0xbcd17537, false}},
+        {tanh_pol_table, {0xbc92829c, false}},
+        {tanh_pol_table, {0xbb43ab99, false}},
+        {tanh_pol_table, {0xb9b471dd, false}},
+        {tanh_pol_table, {0xb6baad5a, false}},
+        {tanh_pol_table, {0xb78bafc7, false}},
+        {tanh_pol_table, {0x00000000, false}},
+        // coefficients of degree 5
+        {tanh_pol_table, {0x00000000, false}},
+        {tanh_pol_table, {0x52f688d5, false}},
+        {tanh_pol_table, {0xd0505c72, false}},
+        {tanh_pol_table, {0xd08f98e3, false}},
+        {tanh_pol_table, {0xce505cc9, false}},
+        {tanh_pol_table, {0xc7162b8a, false}},
+        {tanh_pol_table, {0xcc5061d6, false}},
+        {tanh_pol_table, {0xc7162bdf, false}},
+        {tanh_pol_table, {0xca50b37f, false}},
+        {tanh_pol_table, {0xc7162a3a, false}},
+        {tanh_pol_table, {0xc8422086, false}},
+        {tanh_pol_table, {0x471a714e, false}},
+        {tanh_pol_table, {0xc5ece1f1, false}},
+        {tanh_pol_table, {0xc70e3d90, false}},
+        {tanh_pol_table, {0xc3eba94a, false}},
+        {tanh_pol_table, {0x43e0c424, false}},
+        {tanh_pol_table, {0xc21f4552, false}},
+        {tanh_pol_table, {0x42217cc8, false}},
+        {tanh_pol_table, {0x405e7dc4, false}},
+        {tanh_pol_table, {0xc10dd401, false}},
+        {tanh_pol_table, {0x3e96b602, false}},
+        {tanh_pol_table, {0xbd1a6d2f, false}},
+        {tanh_pol_table, {0xbd393883, false}},
+        {tanh_pol_table, {0xbd674682, false}},
+        {tanh_pol_table, {0xbd310016, false}},
+        {tanh_pol_table, {0xb961e269, false}},
+        {tanh_pol_table, {0x3ba32495, false}},
+        {tanh_pol_table, {0x3a7680d5, false}},
+        {tanh_pol_table, {0x38b3173c, false}},
+        {tanh_pol_table, {0x35a9deea, false}},
+        {tanh_pol_table, {0x375c3f2a, false}},
+        {tanh_pol_table, {0x00000000, false}},
+        // coefficients of degree 6
+        {tanh_pol_table, {0x00000000, false}},
+        {tanh_pol_table, {0xd8995ed1, false}},
+        {tanh_pol_table, {0x558285ea, false}},
+        {tanh_pol_table, {0x55b2cd69, false}},
+        {tanh_pol_table, {0x53028625, false}},
+        {tanh_pol_table, {0x4bc9991f, false}},
+        {tanh_pol_table, {0x5082898a, false}},
+        {tanh_pol_table, {0x4b4999b3, false}},
+        {tanh_pol_table, {0x4e02c07c, false}},
+        {tanh_pol_table, {0x4ac99764, false}},
+        {tanh_pol_table, {0x4b72c822, false}},
+        {tanh_pol_table, {0xca40c0e1, false}},
+        {tanh_pol_table, {0x489413e4, false}},
+        {tanh_pol_table, {0x49b12224, false}},
+        {tanh_pol_table, {0x46134c4e, false}},
+        {tanh_pol_table, {0xc60c2d57, false}},
+        {tanh_pol_table, {0x43c83910, false}},
+        {tanh_pol_table, {0xc3c872d1, false}},
+        {tanh_pol_table, {0xc186bc9e, false}},
+        {tanh_pol_table, {0x42325bc3, false}},
+        {tanh_pol_table, {0xbf2ffa4a, false}},
+        {tanh_pol_table, {0x3d9a203c, false}},
+        {tanh_pol_table, {0xbc545a43, false}},
+        {tanh_pol_table, {0xbae08fee, false}},
+        {tanh_pol_table, {0x3c80225d, false}},
+        {tanh_pol_table, {0x3b1fd1df, false}},
+        {tanh_pol_table, {0xba36b9d1, false}},
+        {tanh_pol_table, {0xb91de544, false}},
+        {tanh_pol_table, {0xb71f100f, false}},
+        {tanh_pol_table, {0xb408e2ed, false}},
+        {tanh_pol_table, {0xb685fec8, false}},
+        {tanh_pol_table, {0x00000000, false}},
+    };
+
+    auto push_arg_entry_of = [&](const key_t key, const table_entry_val_t val, const bool broadcast) {
+      mapped_table_entry_t te{0, val, broadcast};
+      entry_map.insert(std::make_pair(key, te));
+    };
+
+    auto push_entries_of = [&](const table_t& t) {
+      for (auto it = t.begin(); it != t.end(); it++) {
+        auto key = it->first;
+        auto te = it->second;
+        push_arg_entry_of(key, te.val, te.bcast);
+      }
+    };
+
+    auto set_table_term_offset = [&]() {
+      size_t off = 0;
+      for (auto it = entry_map.begin(); it != entry_map.end(); it++) {
+        auto& te = (*it).second;
+        te.off = off;
+        off += te.bcast ? 64u : sizeof(table_entry_val_t);
+      }
+    };
+
+    struct need_t {
+      explicit need_t(JBLAS_ELTWISEOP& op) {
+        if (op == EXP) exp_ = true;
+        if (op == TANH) tanh_ = true;
+        if (op == GELU) gelu_ = true;
+        if (op == SWISH) swish_ = true;
+        if (op == LOW_PRECISION_EXP) low_precision_exp_ = true;
+      }
+      bool bf16_ = false;
+      bool exp_ = false;
+      bool tanh_ = false;
+      bool gelu_ = false;
+      bool low_precision_exp_ = false;
+      bool swish_ = false;
+
+      bool bf16() const { return bf16_; }
+      bool exp() const { return exp_; }
+      bool tanh() const { return tanh_; }
+      bool gelu() const { return gelu_; }
+      bool low_precision_exp() { return low_precision_exp_; }
+      bool swish() const { return swish_; }
+    };
+
+    need_t need(elt_op);
+    push_entries_of(common_values);
+    mapped_table_entry_t alpha_entry{0, bit_cast<uint32_t, float>(alpha_), true};
+    mapped_table_entry_t beta_entry{0, bit_cast<uint32_t, float>(beta_), true};
+    mapped_table_entry_t gamma_entry{0, bit_cast<uint32_t, float>(gamma_), true};
+    if (elt_op == LINEAR) {
+      entry_map.insert(std::make_pair(alpha, alpha_entry));
+      entry_map.insert(std::make_pair(beta, beta_entry));
+    }
+    if (elt_op == RELU || elt_op == SWISH) {
+      entry_map.insert(std::make_pair(alpha, alpha_entry));
+    }
+
+    if (need.exp()) {
+      push_entries_of(exp_consts);
+      push_entries_of(exp_polynomial);
+    }
+    if (need.low_precision_exp() || need.swish()) {
+      push_entries_of(exp_consts);
+      push_entries_of(low_precision_exp_consts);
+    }
+    if (need.tanh() || need.gelu()) {
+      push_entries_of(tanh_consts);
+      push_entries_of(tanh_polynomial_table);
+    }
+    if (need.gelu()) push_entries_of(gelu_tanh_const);
+
+    set_table_term_offset();
+  }
+  void exp_compute_vector_fwd(const Xbyak::Zmm& zmm_src) {
+    /* exp code */
+    h->vcmpps(k_mask, zmm_src, table_val(exp_ln_flt_min_f), _cmp_lt_os);
+    h->vminps(zmm_src, zmm_src, table_val(exp_ln_flt_max_f));
+    h->vmaxps(zmm_src, zmm_src, table_val(exp_ln_flt_min_f));
+    h->vmovups(zmm_aux1, zmm_src);
+    h->vmulps(zmm_src, zmm_src, table_val(exp_log2ef));
+    h->vaddps(zmm_src, zmm_src, table_val(half));
+    h->vrndscaleps(zmm_aux2, zmm_src, _op_floor & 0x3);
+
+    // keep zmm_src = fx for further computations
+    h->vmovups(zmm_src, zmm_aux2);
+
+    // x = x - fx * ln2
+    h->vfnmadd231ps(zmm_aux1, zmm_aux2, table_val(ln2f));
+
+    // We do not count 2^n here, because n can reach 128 and 2^128 is not
+    // representable by fp32, so to get around this problem, instead of computing
+    // 2^n * exp(r) will be counted 2*2^(n-1)*exp(r), because 2^127
+    // and 2 are numbers representable in fp32.
+
+    // compute 2^(n-1)
+    h->vsubps(zmm_src, zmm_src, table_val(one));
+    h->vcvtps2dq(zmm_aux2, zmm_src);
+    h->vpaddd(zmm_aux2, zmm_aux2, table_val(exponent_bias));
+    h->vpslld(zmm_aux2, zmm_aux2, n_mantissa_bits);
+
+    // use zmm_src as tmp zmm_zero when applying mask
+    h->vxorps(zmm_src, zmm_src, zmm_src);
+
+    // set zeroes at those points which were < log(FLT_MIN)
+    h->vblendmps(zmm_aux2 | k_mask, zmm_aux2, zmm_src);
+
+    // compute polynomial
+    h->vmovups(zmm_src, table_val(exp_pol, 4));
+    h->vfmadd213ps(zmm_src, zmm_aux1, table_val(exp_pol, 3));
+    h->vfmadd213ps(zmm_src, zmm_aux1, table_val(exp_pol, 2));
+    h->vfmadd213ps(zmm_src, zmm_aux1, table_val(exp_pol, 1));
+    h->vfmadd213ps(zmm_src, zmm_aux1, table_val(exp_pol, 0));
+    h->vfmadd213ps(zmm_src, zmm_aux1, table_val(one));
+
+    // y = y * 2^n
+
+    h->vmulps(zmm_src, zmm_src, zmm_aux2);
+    h->vmulps(zmm_src, zmm_src, table_val(two));
+  }
+  void low_precision_exp_compute_vector_fwd(const Xbyak::Zmm& zmm_src) {
+    auto code = [&](Xbyak::CodeGenerator* h, const Zmm& dst, const Zmm& src, const Xbyak::Operand& log2e,
+                    const Xbyak::Operand& ln2, const Xbyak::Operand& coeff0, const Xbyak::Operand& coeff1,
+                    const Xbyak::Operand& coeff2, const std::array<Zmm, 2>& tmp) {
+      h->vmulps(tmp[0], src, log2e);        // x / ln2
+      h->vrndscaleps(tmp[0], tmp[0], 0x2);  // round up
+      const auto& z = tmp[0];
+      h->vmulps(tmp[1], tmp[0], ln2);
+      h->vsubps(tmp[1], src, tmp[1]);  // x mod ln2 (can we use fmsub?)
+      h->vmovaps(dst, coeff1);
+      h->vfmadd231ps(dst, tmp[1], coeff0);  // dst = f * c0 + c1
+      h->vfmadd213ps(dst, tmp[1], coeff2);  // dst = (f * c0 + c1) * f + c2
+      h->vscalefps(dst, dst, z);            // dst = exp(f) * 2^z
+    };
+    code(h, zmm_src, zmm_src, table_val(exp_log2ef), table_val(ln2f),  //
+         table_val(low_precision_exp_const_v0), table_val(low_precision_exp_const_v1),
+         table_val(low_precision_exp_const_v2), {zmm_aux1, zmm_aux2});
+  }
+  void swish_compute_vector_fwd(const Xbyak::Zmm& zmm_src) {
+    h->vmovups(zmm_aux0, zmm_src);
+    h->vmulps(zmm_aux0, zmm_aux0, table_val(alpha, 0));
+    low_precision_exp_compute_vector_fwd(zmm_aux0);
+    h->vaddps(zmm_aux0, zmm_aux0, table_val(one));
+    h->vrcp14ps(zmm_aux0, zmm_aux0);
+    h->vmulps(zmm_src, zmm_src, zmm_aux0);
+  }
+  void tanh_compute_vector_fwd(const Xbyak::Zmm& zmm_src) {
+    // register mapping
+    Zmm zmm_dst = zmm_aux1, zmm_src_shift = zmm_aux1, zmm_coeff = zmm_aux1, zmm_pol = zmm_aux2, zmm_indices = zmm_aux3,
+        zmm_src_original = zmm_aux4, zmm_sign = zmm_aux4;
+
+    const int tanh_n_polynomials = 32;
+
+    // We split the positive domain in 33 intervals:
+    // a) [0; linear_ubound]: in this interval tanh(x) = x
+    // b) [linear_ubound; 0x1.8p-12]: This interval spans part of a
+    //    half binade
+    // c) [0x1.8p-12; 0x1.0p-11], ..., [0x1.8p2; 0x1.0p3]:
+    //    one interval for each half binade, there are 29 of those
+    // d) [0x1.0p3; saturation_ubound]:
+    //    This interval spans part of a half binade
+    // e) [0x1.205966p3; saturation_ubound]: in this interval, tanh(x) = 1
+    // For b-d, we need 31 polynomials and will do a table lookup for those.
+    // To simplify the logic, we will also put a) in the table.
+    auto coeffs_address = [&](int coeff_off, int off = 0) {
+      return table_val(tanh_pol_table, coeff_off * tanh_n_polynomials + off);
+    };
+    auto gather_coefficient = [&](Zmm vmm_coeff, int coeff_idx, Zmm vmm_pol_idx) {
+      Zmm zmm_coeff(vmm_coeff.getIdx());
+      Zmm zmm_pol_idx(vmm_pol_idx.getIdx());
+      h->vmovups(zmm_coeff, coeffs_address(coeff_idx, 0));
+      h->vpermt2ps(zmm_coeff, zmm_pol_idx, coeffs_address(coeff_idx, 16));
+    };
+
+    // because tanh(x) = -tanh(-x), we extract sign to make x postive
+    // and reapply sign at the end
+    h->vmovups(zmm_src_original, zmm_src);
+    h->vpandd(zmm_src, zmm_src, table_val(positive_mask));
+
+    // We compute the indices for the table lookup
+    h->vmovups(zmm_indices, zmm_src);
+    h->vpsubd(zmm_indices, zmm_indices, table_val(tanh_idx_bias));
+    h->vpandd(zmm_indices, zmm_indices, table_val(tanh_idx_mask));
+    h->vpsrld(zmm_indices, zmm_indices, 22);
+
+    // we do the argument reduction
+    h->vmovups(zmm_src_shift, zmm_src);
+    h->vpandd(zmm_src_shift, zmm_src_shift, table_val(tanh_idx_mask));
+    h->vsubps(zmm_src, zmm_src, zmm_src_shift);
+
+    // we gather and evaluate the polynonials
+    gather_coefficient(zmm_pol, 6, zmm_indices);
+    for (int deg = 5; deg >= 0; --deg) {
+      gather_coefficient(zmm_coeff, deg, zmm_indices);
+      h->vfmadd213ps(zmm_pol, zmm_src, zmm_coeff);
+    }
+
+    // we restore src with cleared sign, and keep sign
+    h->vmovups(zmm_src, zmm_src_original);
+    h->vpandd(zmm_sign, zmm_sign, table_val(sign_mask));
+    h->vpandd(zmm_src, zmm_src, table_val(positive_mask));
+
+    // Now we blend the results
+    // [saturation_ubound; +inf[ : we return +/- 1
+    h->vmovups(zmm_dst, table_val(one));
+    // [linear_ubound; saturation_lbound] : we return +/- P(x)
+    h->vmovups(zmm_mask, table_val(tanh_saturation_lbound));
+    h->vcmpps(k_mask, zmm_mask, zmm_src, _cmp_nle_us);
+    h->vblendmps(zmm_dst | k_mask, zmm_dst, zmm_pol);
+    // [0; linear_ubound]  : we return x
+    h->vmovups(zmm_mask, table_val(tanh_linear_ubound));
+    h->vcmpps(k_mask, zmm_mask, zmm_src, _cmp_nle_us);
+    h->vblendmps(zmm_dst | k_mask, zmm_dst, zmm_src);
+
+    // We reapply the sign and return
+    h->vpxord(zmm_dst, zmm_dst, zmm_sign);
+    h->vmovups(zmm_src, zmm_dst);
+  }
+  void gelu_compute_vector_fwd(const Xbyak::Zmm& zmm_src) {
+    h->vmovups(zmm_aux0, zmm_src);
+    // compute G(x) = sqrt_root_two_over_pi * x * (1 + fitting_const * x * x)
+    h->vmulps(zmm_src, zmm_src, zmm_src);
+    h->vmovups(zmm_aux1, table_val(gelu_tanh_fitting_const));
+    h->vfmadd213ps(zmm_src, zmm_aux1, table_val(one));
+    h->vmulps(zmm_src, zmm_src, zmm_aux0);
+    h->vmulps(zmm_src, zmm_src, table_val(gelu_tanh_sqrt_two_over_pi));
+
+    // compute tanh(G(x))
+    tanh_compute_vector_fwd(zmm_src);
+
+    // compute 0.5 * x * (1 + tanh(G(x)))
+    h->vaddps(zmm_src, zmm_src, table_val(one));
+    h->vmulps(zmm_src, zmm_src, table_val(half));
+    h->vmulps(zmm_src, zmm_src, zmm_aux0);
+  }
+  void relu_compute_vector_fwd(const Xbyak::Zmm& zmm_src) {
+    h->vmovups(zmm_aux1, zmm_src);
+    h->vcmpps(k_mask, zmm_src, table_val(zero), _cmp_nle_us);
+    h->vmulps(zmm_src, zmm_src, table_val(alpha, 0));  // alpha=0 by default.
+    h->vblendmps(zmm_src | k_mask, zmm_src, zmm_aux1);
+  }
+  void linear_compute_vector_fwd(const Xbyak::Zmm& zmm_src) {
+    h->vmovups(zmm_aux0, table_val(alpha, 0));
+    h->vfmadd213ps(zmm_src, zmm_aux0, table_val(beta, 0));
+  }
+  void load_table_addr() { h->mov(p_table, l_table); }
+  void assign_zmm(const std::set<int>& used_zmm_idx, Zmm* zmm) {
+    constexpr int max_zmm_idx = 32;
+    for (int idx = 0; idx < max_zmm_idx; idx++) {
+      if (used_zmm_idx.count(idx) == 0 && assign_zmm_idx.count(idx) == 0) {
+        *zmm = Zmm(idx);
+        assign_zmm_idx.insert(idx);
+        break;
+      }
+    }
+  }
+
+ private:
+  Xbyak::CodeGenerator* h = nullptr;
+  JBLAS_ELTWISEOP elt_op;
+
+  /*const val*/
+  float alpha_, beta_, gamma_;
+
+  /*labels*/
+  Xbyak::Label l_table;
+
+  /*register for fwd*/
+  Xbyak::Reg64 p_table;
+  std::set<int> assign_zmm_idx;
+  Zmm zmm_mask, zmm_aux0, zmm_aux1, zmm_aux2, zmm_aux3, zmm_aux4;
+  Xbyak::Opmask k_mask;
+  static constexpr int n_mantissa_bits = 23;
+
+  enum {
+    _cmp_eq_oq = 0u,
+    _cmp_lt_os = 1u,
+    _cmp_le_os = 2u,
+    _cmp_neq_uq = 4u,
+    _cmp_nlt_us = 5u,
+    _cmp_nle_us = 6u,
+
+    _op_floor = 1u,
+    _op_mxcsr = 4u,
+  };
+
+  enum key_t {
+    gamma = 0,                            // scale argument
+    alpha,                                // alpha argument
+    beta,                                 // beta argument
+    zero,                                 // 0.f
+    half,                                 // 0.5f
+    one,                                  // 1.f  or  mask for exponent bits
+    two,                                  // 2.f
+    three,                                // 3.f
+    six,                                  // 6.f
+    minus_one,                            // -1.f  or  changes sign to opposite
+    minus_two,                            // -2.f
+    minus_three,                          // -3.f
+    ln2f,                                 // 0.69314718f
+    positive_mask,                        // changes sign to positive
+    sign_mask,                            // gets sign value
+    exponent_bias,                        // (127 = 2^7 - 1), gets exponent bits
+    exp_log2ef,                           // 1.44269502f - formula-based for approx
+    exp_ln_flt_max_f,                     // logf(FLT_MAX) - max normal value
+    exp_ln_flt_min_f,                     // logf(FLT_MIN) - min normal value
+    exp_pol,                              // see correspondent table for float values
+    gelu_tanh_fitting_const,              // 0.044715f
+    gelu_tanh_fitting_const_times_three,  // 0.134145f
+    gelu_tanh_sqrt_two_over_pi,           // sqrtf(2.f/pi) = 0.797884f
+    gelu_tanh_flt_max_x,
+    gelu_tanh_flt_min_x,
+    tanh_idx_bias,
+    tanh_idx_mask,
+    tanh_linear_ubound,
+    tanh_saturation_lbound,
+    tanh_pol_table,
+    low_precision_exp_const_v0,
+    low_precision_exp_const_v1,
+    low_precision_exp_const_v2,
+    undef_key,
+  };
+
+  size_t table_off(key_t key, size_t key_off_val_shift = 0) {
+    const auto it = entry_map.find(key);
+    assert(it != entry_map.end());  // "key is not in entry_map"
+    const auto& te = (*it).second;
+    const auto scale = te.bcast ? 64u : sizeof(table_entry_val_t);
+    return te.off + key_off_val_shift * scale;
+  }
+  Xbyak::Address table_val(key_t key, size_t key_off_val_shift = 0) {
+    auto off = table_off(key, key_off_val_shift);
+    return h->ptr[p_table + off];
+  }
+  using table_entry_val_t = uint32_t;
+  using table_entry_offset_t = size_t;  // offsets are in bytes wrt p_table
+  using table_entry_bcast_t = bool;
+
+  struct table_entry_t {
+    table_entry_val_t val;
+    table_entry_bcast_t bcast;
+  };
+  struct mapped_table_entry_t {
+    table_entry_offset_t off;
+    table_entry_val_t val;
+    table_entry_bcast_t bcast;
+  };
+  using table_t = std::multimap<key_t, table_entry_t>;
+  using mapped_table_t = std::multimap<key_t, mapped_table_entry_t>;
+  mapped_table_t entry_map = {};
+};
+}  // namespace jit_injector
+}  // namespace kernel
+}  // namespace jblas

--- a/intel_extension_for_transformers/backends/neural_engine/graph/jblas/jblas/kernel_wrapper.h
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/jblas/jblas/kernel_wrapper.h
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 #pragma once
+#include <array>
+
 #include "jit_blas_utils.h"
 #include "kernel_avx2.h"
 #include "kernel_avx512f.h"
@@ -23,12 +25,385 @@ namespace kernel {
 namespace wrapper {
 template <int NTile, int SrcBytes, int RowPack>
 class PaddingInterleaveMN {
+  // M x N ===> N/NTile x M/RowPack x NTile x RowPack (leading dim stride = NTile * dststride)
  public:
   template <JBLAS_ISA ISA_T>
   static JBLAS_CODE forward(void* srcptr, void* dstptr, int row, int col, int rowpad, int colpad, int srcstride,
                             int dststride) {
     return ref::padding_interleave(srcptr, dstptr, row, col, rowpad, colpad, srcstride, dststride, NTile, SrcBytes,
                                    RowPack);
+  }
+#if CompileBF16()
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-attributes"  // https://stackoverflow.com/a/49216021
+#endif
+  static void interleave_word(std::array<__m512i, 2>& dst) {
+    static constexpr uint32_t perm_idx_a[16]{
+        0 | 0,  1 | 0,  2 | 0,  3 | 0,   //
+        0 | 16, 1 | 16, 2 | 16, 3 | 16,  //
+        4 | 0,  5 | 0,  6 | 0,  7 | 0,   //
+        4 | 16, 5 | 16, 6 | 16, 7 | 16,  //
+    };
+    static constexpr uint32_t perm_idx_b[16]{
+        8 | 0,   9 | 0,   10 | 0,  11 | 0,   //
+        8 | 16,  9 | 16,  10 | 16, 11 | 16,  //
+        12 | 0,  13 | 0,  14 | 0,  15 | 0,   //
+        12 | 16, 13 | 16, 14 | 16, 15 | 16,  //
+    };
+    static const auto v_perm_idx_a = _mm512_loadu_epi32(perm_idx_a);
+    static const auto v_perm_idx_b = _mm512_loadu_epi32(perm_idx_b);
+
+    __m512i tmp[2];
+    tmp[0] = _mm512_unpacklo_epi16(dst[0], dst[1]);
+    tmp[1] = _mm512_unpackhi_epi16(dst[0], dst[1]);
+    dst[0] = _mm512_permutex2var_epi32(tmp[0], v_perm_idx_a, tmp[1]);
+    dst[1] = _mm512_permutex2var_epi32(tmp[0], v_perm_idx_b, tmp[1]);
+  }
+  template <int tail>
+  static std::array<__m512i, 2> load_fp16_bf16_interleave_word(const utils::fp16* a, size_t lda) {
+    static_assert(tail > 0 && tail <= 2, "Unexpected tail value.");
+    std::array<__m512i, 2> dst;
+    for (int i = 0; i < tail; ++i) {
+      dst[i] = (__m512i)(_mm512_cvtne2ps_pbh(                     //
+          _mm512_cvtph_ps(_mm256_loadu_epi16(a + i * lda + 16)),  //
+          _mm512_cvtph_ps(_mm256_loadu_epi16(a + i * lda + 0))));
+    }
+    for (int i = tail; i < 2; ++i) dst[i] = _mm512_setzero_epi32();
+    interleave_word(dst);
+    return dst;
+  }
+  template <int tail>
+  static std::array<__m512i, 2> load_maskz_fp16_bf16_interleave_word(const utils::fp16* a, size_t lda, uint32_t mask) {
+    static_assert(tail > 0 && tail <= 2, "Unexpected tail value.");
+
+    const auto mask_lo = mask;
+    const auto mask_hi = mask >> 16;
+    std::array<__m512i, 2> dst;
+    for (int i = 0; i < tail; ++i) {
+      dst[i] = (__m512i)(_mm512_cvtne2ps_pbh(                                    //
+          _mm512_cvtph_ps(_mm256_maskz_loadu_epi16(mask_hi, a + i * lda + 16)),  //
+          _mm512_cvtph_ps(_mm256_maskz_loadu_epi16(mask_lo, a + i * lda + 0))));
+    }
+    for (int i = tail; i < 2; ++i) dst[i] = _mm512_setzero_epi32();
+    interleave_word(dst);
+    return dst;
+  }
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+#endif
+  template <JBLAS_ISA ISA_T, typename T_SRC, typename T_DST = T_SRC>
+  static JBLAS_CODE forward_cvt(const T_SRC* src, T_DST* dst, int row, int col, int row_pad, int col_pad, int src_step,
+                                int dst_step) {
+    // TODO(Yi): can forward_cvt of same i/o replace forward?
+    static_assert(SrcBytes == sizeof(T_SRC), "SrcBytes should match T_SRC.");
+#if CompileBF16()   // && 0
+    if constexpr (  // TODO: avoid if constexpr
+        std::is_same<T_SRC, utils::fp16>::value && std::is_same<T_DST, utils::bf16>::value && SrcBytes * RowPack == 4 &&
+        RowPack == 2) {
+      int i = 0;
+      for (; i < row / RowPack * RowPack; i += RowPack) {
+        int j = 0;
+        for (; j < col / NTile * NTile; j += NTile) {
+          static_assert(NTile % 32 == 0);
+          for (int jj = 0; jj < NTile; jj += 32) {
+            const auto xss = load_fp16_bf16_interleave_word<2>(src + i * src_step + j + jj, src_step);
+            _mm512_storeu_si512(dst + i * NTile + j * dst_step + (jj + 0) * RowPack, xss[0]);
+            _mm512_storeu_si512(dst + i * NTile + j * dst_step + (jj + 16) * RowPack, xss[1]);
+          }
+        }
+        if (j < col) {  // j: tail processing
+          int jj = 0;
+          for (; j + jj < col / 32 * 32; jj += 32) {
+            const auto xss = load_fp16_bf16_interleave_word<2>(src + i * src_step + j + jj, src_step);
+            _mm512_storeu_si512(dst + i * NTile + j * dst_step + (jj + 0) * RowPack, xss[0]);
+            _mm512_storeu_si512(dst + i * NTile + j * dst_step + (jj + 16) * RowPack, xss[1]);
+          }
+          if (j + jj < col) {  // jj: tail processing
+            const uint32_t mask = (1U << (col - j - jj)) - 1;
+            const auto xss = load_maskz_fp16_bf16_interleave_word<2>(src + i * src_step + j + jj, src_step, mask);
+            _mm512_storeu_si512(dst + i * NTile + j * dst_step + (jj + 0) * RowPack, xss[0]);
+            _mm512_storeu_si512(dst + i * NTile + j * dst_step + (jj + 16) * RowPack, xss[1]);
+            jj += 32;
+          }
+          for (; jj < NTile; jj += 32) {  // jj: padding zero
+            memset(dst + i * NTile + j * dst_step + jj * RowPack, 0, sizeof(T_DST) * 32 * RowPack);
+          }
+          j += NTile;
+        }
+        for (; j < col_pad; j += NTile) {  // j: padding zero
+          memset(dst + i * NTile + j * dst_step, 0, sizeof(T_DST) * NTile * RowPack);
+        }
+      }
+      if (i < row) {                      // i: tail processing
+        static constexpr int tail_m = 1;  // must be 1
+        int j = 0;
+        for (; j < col / NTile * NTile; j += NTile) {
+          static_assert(NTile % 32 == 0);
+          for (int jj = 0; jj < NTile; jj += 32) {
+            const auto xss = load_fp16_bf16_interleave_word<tail_m>(src + i * src_step + j + jj, src_step);
+            _mm512_storeu_si512(dst + i * NTile + j * dst_step + (jj + 0) * RowPack, xss[0]);
+            _mm512_storeu_si512(dst + i * NTile + j * dst_step + (jj + 16) * RowPack, xss[1]);
+          }
+        }
+        if (j < col) {  // j: tail processing
+          int jj = 0;
+          for (; j + jj < col / 32 * 32; jj += 32) {
+            const auto xss = load_fp16_bf16_interleave_word<tail_m>(src + i * src_step + j + jj, src_step);
+            _mm512_storeu_si512(dst + i * NTile + j * dst_step + (jj + 0) * RowPack, xss[0]);
+            _mm512_storeu_si512(dst + i * NTile + j * dst_step + (jj + 16) * RowPack, xss[1]);
+          }
+          if (j + jj < col) {  // jj: tail processing
+            const uint32_t mask = (1U << (col - j - jj)) - 1;
+            const auto xss = load_maskz_fp16_bf16_interleave_word<tail_m>(src + i * src_step + j + jj, src_step, mask);
+            _mm512_storeu_si512(dst + i * NTile + j * dst_step + (jj + 0) * RowPack, xss[0]);
+            _mm512_storeu_si512(dst + i * NTile + j * dst_step + (jj + 16) * RowPack, xss[1]);
+            jj += 32;
+          }
+          for (; jj < NTile; jj += 32) {  // jj: padding zero
+            memset(dst + i * NTile + j * dst_step + jj * RowPack, 0, sizeof(T_DST) * 32 * RowPack);
+          }
+          j += NTile;
+        }
+        for (; j < col_pad; j += NTile) {  // j: padding zero
+          memset(dst + i * NTile + j * dst_step, 0, sizeof(T_DST) * NTile * RowPack);
+        }
+        i += RowPack;
+      }
+      for (; i < row_pad; i += RowPack) {  // i: padding zero
+        for (int j = 0; j < col_pad; j += NTile) {
+          memset(dst + i * NTile + j * dst_step, 0, sizeof(T_DST) * NTile * RowPack);
+        }
+      }
+    }
+    return JblasSuccess;
+#endif
+    return ref::padding_interleave(src, dst, row, col, row_pad, col_pad, src_step, dst_step, NTile, RowPack);
+  }
+};
+template <int MTile, int SrcBytes, int colPack>
+class PaddingTransInterleaveMN {
+  // row and cols are in terms of src
+  // M x N ===> M/MTile x N/colPack x MTile x colPack (leading dim stride = MTile * dststride)
+ public:
+  template <JBLAS_ISA ISA_T>
+  static JBLAS_CODE forward(void* src, void* dst, int row, int col, int row_pad, int col_pad, int src_stride,
+                            int dst_stride) {
+    return ref::padding_trans_interleave(src, dst, row, col, row_pad, col_pad, src_stride, dst_stride, MTile, SrcBytes,
+                                         colPack);
+  }
+
+#if CompileBF16()
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-attributes"  // https://stackoverflow.com/a/49216021
+#endif
+  static void tr_x16_dword(std::array<__m512i, 16>& dst) {
+    __m512i tmp[16];
+
+#pragma GCC unroll(8)
+    for (int i = 0; i < 8; ++i) {
+      tmp[2 * i] = _mm512_unpacklo_epi32(dst[2 * i], dst[2 * i + 1]);
+      tmp[2 * i + 1] = _mm512_unpackhi_epi32(dst[2 * i], dst[2 * i + 1]);
+    }
+
+#pragma GCC unroll(4)
+    for (int i = 0; i < 4; ++i) {
+      dst[4 * i] = _mm512_unpacklo_epi64(tmp[4 * i], tmp[4 * i + 2]);
+      dst[4 * i + 1] = _mm512_unpackhi_epi64(tmp[4 * i], tmp[4 * i + 2]);
+      dst[4 * i + 2] = _mm512_unpacklo_epi64(tmp[4 * i + 1], tmp[4 * i + 3]);
+      dst[4 * i + 3] = _mm512_unpackhi_epi64(tmp[4 * i + 1], tmp[4 * i + 3]);
+    }
+
+#pragma GCC unroll(2)
+    for (int i = 0; i < 2; ++i) {
+      tmp[8 * i + 0] = _mm512_shuffle_i32x4(dst[8 * i + 0], dst[8 * i + 4], 0x88);
+      tmp[8 * i + 1] = _mm512_shuffle_i32x4(dst[8 * i + 1], dst[8 * i + 5], 0x88);
+      tmp[8 * i + 2] = _mm512_shuffle_i32x4(dst[8 * i + 2], dst[8 * i + 6], 0x88);
+      tmp[8 * i + 3] = _mm512_shuffle_i32x4(dst[8 * i + 3], dst[8 * i + 7], 0x88);
+      tmp[8 * i + 4] = _mm512_shuffle_i32x4(dst[8 * i + 0], dst[8 * i + 4], 0xdd);
+      tmp[8 * i + 5] = _mm512_shuffle_i32x4(dst[8 * i + 1], dst[8 * i + 5], 0xdd);
+      tmp[8 * i + 6] = _mm512_shuffle_i32x4(dst[8 * i + 2], dst[8 * i + 6], 0xdd);
+      tmp[8 * i + 7] = _mm512_shuffle_i32x4(dst[8 * i + 3], dst[8 * i + 7], 0xdd);
+    }
+
+    dst[0] = _mm512_shuffle_i32x4(tmp[0], tmp[8], 0x88);
+    dst[1] = _mm512_shuffle_i32x4(tmp[1], tmp[9], 0x88);
+    dst[2] = _mm512_shuffle_i32x4(tmp[2], tmp[10], 0x88);
+    dst[3] = _mm512_shuffle_i32x4(tmp[3], tmp[11], 0x88);
+    dst[4] = _mm512_shuffle_i32x4(tmp[4], tmp[12], 0x88);
+    dst[5] = _mm512_shuffle_i32x4(tmp[5], tmp[13], 0x88);
+    dst[6] = _mm512_shuffle_i32x4(tmp[6], tmp[14], 0x88);
+    dst[7] = _mm512_shuffle_i32x4(tmp[7], tmp[15], 0x88);
+    dst[8] = _mm512_shuffle_i32x4(tmp[0], tmp[8], 0xdd);
+    dst[9] = _mm512_shuffle_i32x4(tmp[1], tmp[9], 0xdd);
+    dst[10] = _mm512_shuffle_i32x4(tmp[2], tmp[10], 0xdd);
+    dst[11] = _mm512_shuffle_i32x4(tmp[3], tmp[11], 0xdd);
+    dst[12] = _mm512_shuffle_i32x4(tmp[4], tmp[12], 0xdd);
+    dst[13] = _mm512_shuffle_i32x4(tmp[5], tmp[13], 0xdd);
+    dst[14] = _mm512_shuffle_i32x4(tmp[6], tmp[14], 0xdd);
+    dst[15] = _mm512_shuffle_i32x4(tmp[7], tmp[15], 0xdd);
+  }
+  template <int tail>
+  static std::array<__m512i, 16> load_fp16_bf16_tr_x16_dword(const utils::fp16* a, size_t lda) {
+    static_assert(tail > 0 && tail <= 16, "Unexpected tail value.");
+    std::array<__m512i, 16> dst;
+    for (int i = 0; i < tail; ++i) {
+      dst[i] = (__m512i)(_mm512_cvtne2ps_pbh(                     //
+          _mm512_cvtph_ps(_mm256_loadu_epi16(a + i * lda + 16)),  //
+          _mm512_cvtph_ps(_mm256_loadu_epi16(a + i * lda + 0))));
+    }
+    for (int i = tail; i < 16; ++i) dst[i] = _mm512_setzero_epi32();
+    tr_x16_dword(dst);
+    return dst;
+  }
+  static constexpr decltype(load_fp16_bf16_tr_x16_dword<1>)* load_fp16_bf16_tr_x16_dword_tbl[17]{
+      load_fp16_bf16_tr_x16_dword<1>,  load_fp16_bf16_tr_x16_dword<1>,  load_fp16_bf16_tr_x16_dword<2>,
+      load_fp16_bf16_tr_x16_dword<3>,  load_fp16_bf16_tr_x16_dword<4>,  load_fp16_bf16_tr_x16_dword<5>,
+      load_fp16_bf16_tr_x16_dword<6>,  load_fp16_bf16_tr_x16_dword<7>,  load_fp16_bf16_tr_x16_dword<8>,
+      load_fp16_bf16_tr_x16_dword<9>,  load_fp16_bf16_tr_x16_dword<10>, load_fp16_bf16_tr_x16_dword<11>,
+      load_fp16_bf16_tr_x16_dword<12>, load_fp16_bf16_tr_x16_dword<13>, load_fp16_bf16_tr_x16_dword<14>,
+      load_fp16_bf16_tr_x16_dword<15>, load_fp16_bf16_tr_x16_dword<16>,
+  };
+  template <int tail>
+  static std::array<__m512i, 16> load_maskz_fp16_bf16_tr_x16_dword(const utils::fp16* a, size_t lda, uint32_t mask) {
+    static_assert(tail > 0 && tail <= 16, "Unexpected tail value.");
+    std::array<__m512i, 16> dst;
+
+    const auto mask_lo = mask;
+    const auto mask_hi = mask >> 16;
+    for (int i = 0; i < tail; ++i) {
+      dst[i] = (__m512i)(_mm512_cvtne2ps_pbh(                                    //
+          _mm512_cvtph_ps(_mm256_maskz_loadu_epi16(mask_hi, a + i * lda + 16)),  //
+          _mm512_cvtph_ps(_mm256_maskz_loadu_epi16(mask_lo, a + i * lda + 0))));
+    }
+    for (int i = tail; i < 16; ++i) dst[i] = _mm512_setzero_epi32();
+    tr_x16_dword(dst);
+    return dst;
+  }
+  static constexpr decltype(load_maskz_fp16_bf16_tr_x16_dword<1>)* load_maskz_fp16_bf16_tr_x16_dword_tbl[17]{
+      load_maskz_fp16_bf16_tr_x16_dword<1>,  load_maskz_fp16_bf16_tr_x16_dword<1>,
+      load_maskz_fp16_bf16_tr_x16_dword<2>,  load_maskz_fp16_bf16_tr_x16_dword<3>,
+      load_maskz_fp16_bf16_tr_x16_dword<4>,  load_maskz_fp16_bf16_tr_x16_dword<5>,
+      load_maskz_fp16_bf16_tr_x16_dword<6>,  load_maskz_fp16_bf16_tr_x16_dword<7>,
+      load_maskz_fp16_bf16_tr_x16_dword<8>,  load_maskz_fp16_bf16_tr_x16_dword<9>,
+      load_maskz_fp16_bf16_tr_x16_dword<10>, load_maskz_fp16_bf16_tr_x16_dword<11>,
+      load_maskz_fp16_bf16_tr_x16_dword<12>, load_maskz_fp16_bf16_tr_x16_dword<13>,
+      load_maskz_fp16_bf16_tr_x16_dword<14>, load_maskz_fp16_bf16_tr_x16_dword<15>,
+      load_maskz_fp16_bf16_tr_x16_dword<16>,
+  };
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+#endif
+
+  // Note: rows/cols and i/j are in terms of src
+  template <JBLAS_ISA ISA_T, typename T_SRC, typename T_DST = T_SRC>
+  static JBLAS_CODE forward_cvt(const T_SRC* src, T_DST* dst, int row, int col, int row_pad, int col_pad, int src_step,
+                                int dst_step) {
+    // TODO(Yi): can forward_cvt of same i/o replace forward?
+    static_assert(SrcBytes == sizeof(T_SRC), "SrcBytes should match T_SRC.");
+#if CompileBF16()   // && 0
+    if constexpr (  // TODO: avoid if constexpr
+        std::is_same<T_SRC, utils::fp16>::value && std::is_same<T_DST, utils::bf16>::value && SrcBytes * colPack == 4) {
+      assert(row_pad % 16 == 0 && col_pad % 32 == 0);
+      int i = 0;
+      for (; i < row / MTile * MTile; i += MTile) {
+        assert(MTile % 16 == 0);
+        int j = 0;
+        for (; j < col / 32 * 32; j += 32) {
+          for (int ii = 0; ii < MTile; ii += 16) {
+            assert(MTile % 16 == 0);
+            const auto xss = load_fp16_bf16_tr_x16_dword<16>(src + (i + ii) * src_step + j, src_step);
+            for (int jj = 0; jj < 32; jj += 2) {
+              _mm512_storeu_si512(dst + i * dst_step + ii * colPack + (j + jj) * MTile, xss[jj / 2]);
+            }
+          }
+        }
+        if (j < col) {  // j: tail processing
+          for (int ii = 0; ii < MTile; ii += 16) {
+            assert(MTile % 16 == 0);
+            const uint32_t mask = (1U << (col - j)) - 1;
+            const auto xss = load_maskz_fp16_bf16_tr_x16_dword<16>(src + (i + ii) * src_step + j, src_step, mask);
+            for (int jj = 0; jj < 32; jj += 2) {
+              _mm512_storeu_si512(dst + i * dst_step + ii * colPack + (j + jj) * MTile, xss[jj / 2]);
+            }
+          }
+          j += 32;
+        }
+        for (; j < col_pad; j += 2) {  // j: padding zero
+          memset(dst + i * dst_step + j * MTile, 0, 2 * sizeof(T_DST) * MTile);
+        }
+      }
+      if (i < row) {  // i: tail processing
+        int ii = 0;
+        for (; i + ii < row / 16 * 16; ii += 16) {
+          int j = 0;
+          for (; j < col / 32 * 32; j += 32) {
+            assert(MTile % 16 == 0);
+            const auto xss = load_fp16_bf16_tr_x16_dword<16>(src + (i + ii) * src_step + j, src_step);
+            for (int jj = 0; jj < 32; jj += 2) {
+              _mm512_storeu_si512(dst + i * dst_step + ii * colPack + (j + jj) * MTile, xss[jj / 2]);
+            }
+          }
+          if (j < col) {  // j: tail processing
+            assert(MTile % 16 == 0);
+            const uint32_t mask = (1U << (col - j)) - 1;
+            const auto xss = load_maskz_fp16_bf16_tr_x16_dword<16>(src + (i + ii) * src_step + j, src_step, mask);
+            for (int jj = 0; jj < 32; jj += 2) {
+              _mm512_storeu_si512(dst + i * dst_step + ii * colPack + (j + jj) * MTile, xss[jj / 2]);
+            }
+            j += 32;
+          }
+          for (; j < col_pad; j += 2) {  // j: padding zero
+            memset(dst + i * dst_step + ii * colPack + j * MTile, 0, 2 * sizeof(T_DST) * 16);
+          }
+        }
+        if (i + ii < row) {  // ii: tail processing
+          const int tbl_idx = row - i - ii;
+          int j = 0;
+          for (; j < col / 32 * 32; j += 32) {
+            assert(MTile % 16 == 0);
+            const auto xss = load_fp16_bf16_tr_x16_dword_tbl[tbl_idx](src + (i + ii) * src_step + j, src_step);
+            for (int jj = 0; jj < 32; jj += 2) {
+              _mm512_storeu_si512(dst + i * dst_step + ii * colPack + (j + jj) * MTile, xss[jj / 2]);
+            }
+          }
+          if (j < col) {  // j: tail processing
+            assert(MTile % 16 == 0);
+            const uint32_t mask = (1U << (col - j)) - 1;
+            const auto xss =
+                load_maskz_fp16_bf16_tr_x16_dword_tbl[tbl_idx](src + (i + ii) * src_step + j, src_step, mask);
+            for (int jj = 0; jj < 32; jj += 2) {
+              _mm512_storeu_si512(dst + i * dst_step + ii * colPack + (j + jj) * MTile, xss[jj / 2]);
+            }
+            j += 32;
+          }
+          for (; j < col_pad; j += 2) {  // j: padding zero
+            memset(dst + i * dst_step + ii * colPack + j * MTile, 0, 2 * sizeof(T_DST) * 16);
+          }
+          ii += 16;
+        }
+        for (; ii < MTile; ii += 16) {  // ii: padding zero
+          for (int j = 0; j < col_pad; j += 2) {
+            memset(dst + i * dst_step + ii * colPack + j * MTile, 0, 2 * sizeof(T_DST) * 16);
+          }
+        }
+        assert(ii == MTile);
+        i += MTile;
+      }
+      assert(row_pad % MTile == 0);
+      for (; i < row_pad; i += MTile) {  // i: padding zero
+        for (int j = 0; j < col_pad; j += 2) {
+          memset(dst + i * dst_step + j * MTile, 0, 2 * sizeof(T_DST) * MTile);
+        }
+      }
+      return JblasSuccess;
+    }
+#endif
+    return ref::padding_trans_interleave(src, dst, row, col, row_pad, col_pad, src_step, dst_step, MTile, colPack);
   }
 };
 
@@ -43,7 +418,37 @@ class Memcpy2D {
 #endif
     return kernel::ref::memcpy2d(srcptr, dstptr, row, col, srcstride, dststride);
   }
+
+  template <JBLAS_ISA ISA_T>
+  static JBLAS_CODE forward_with_gelu(void* srcptr, void* dstptr, int row, int col, int srcstride, int dststride) {
+    if (utils::isa_base<ISA_T>::avx512f) {
+      return kernel::jit::JitMemcpy2DAvx512f::forward_with_gelu(srcptr, dstptr, row, col, srcstride, dststride);
+    }
+  }
 };
+
+class Memcpy2DFp32CvtBf16 {
+ public:
+  template <JBLAS_ISA ISA_T>
+  static JBLAS_CODE forward(void* srcptr, void* dstptr, int row, int col, int srcstride, int dststride) {
+#if 0
+    for (int i = 0; i < row; i++) {
+      for (int j = 0; j < col; j++) {
+        ((utils::bf16*)((char*)dstptr + i * dststride))[j] =
+            static_cast<utils::bf16>(((float*)((char*)srcptr + i * srcstride))[j]);
+      }
+    }
+    return JblasSuccess;
+#elif CompileAVX512F()
+    if (utils::isa_base<ISA_T>::avx512f) {
+      return kernel::avx512f::fp32_cvt_bf16_2D_write_back(srcptr, dstptr, row, col, srcstride, dststride);
+    }
+#else
+    return kernel::ref::memcpy2d_dw2highw(srcptr, dstptr, row, col, srcstride, dststride);
+#endif
+  }
+};
+
 template <int NTILE>
 class CompressS8S4 {
  public:
@@ -51,6 +456,16 @@ class CompressS8S4 {
   static inline JBLAS_CODE forward(int8_t* srcptr, jblas::utils::int4x2* dstptr, int row, int col, int ld_src,
                                    int ld_dst) {
     return ref::compress_s8_s4<NTILE>(srcptr, dstptr, row, col, ld_src, ld_dst);
+  }
+};
+
+template <int NTILE>
+class CompressFp4 {
+ public:
+  template <JBLAS_ISA ISA_T>
+  static inline JBLAS_CODE forward(int8_t* srcptr, jblas::utils::fp4x2* dstptr, int row, int col, int ld_src,
+                                   int ld_dst) {
+    return ref::compress_fp4<NTILE>(srcptr, dstptr, row, col, ld_src, ld_dst);
   }
 };
 
@@ -80,6 +495,17 @@ class QuantizeS8RowBlock {
   }
 };
 
+class QuantizeFp4RowBlock {
+ public:
+  template <JBLAS_ISA ISA_T>
+  static inline JBLAS_CODE forward(const float* srcptr, int8_t* dstptr, int row, int col, int ld_src, int ld_dst,
+                                   float* scales, int blocksize) {
+    if (row % blocksize != 0) {
+      return JblasNotSupport;
+    }
+    return ref::quantize_f32_fp4_rowblock(srcptr, dstptr, row, col, ld_src, ld_dst, scales, blocksize);
+  }
+};
 class QuantizeU8ColBlock {
  public:
   template <JBLAS_ISA ISA_T>
@@ -94,6 +520,21 @@ class QuantizeU8ColBlock {
     return ref::quantize_f32_u8_colblock(row, col, srcptr, ld_src, dstptr, ld_dst, scales, ld_scale, zps, blocksize);
   }
 };
+
+class QuantizeS8ColBlock {
+ public:
+  template <JBLAS_ISA ISA_T>
+  static inline JBLAS_CODE forward(int row, int col, const float* srcptr, int ld_src, int8_t* dstptr, int ld_dst,
+                                   float* scales, int ld_scale, int blocksize) {
+#if CompileAVX512F()
+    if (utils::isa_base<ISA_T>::avx512f) {
+      return avx512f::quantize_f32_s8_colblock(row, col, srcptr, ld_src, dstptr, ld_dst, scales, ld_scale, blocksize);
+    }
+#endif
+    return ref::quantize_f32_s8_colblock(row, col, srcptr, ld_src, dstptr, ld_dst, scales, ld_scale, blocksize);
+  }
+};
+
 class Broadcast {
  public:
   template <JBLAS_ISA ISA_T>
@@ -123,18 +564,34 @@ class AccumulateDequantizeS32F32 {
   }
 };
 
-class DecompressKBlockS4F32 {
+template <typename _DST_T>
+class DecompressKBlockS4FP {
  public:
   template <JBLAS_ISA ISA_T, typename _T>
-  static inline JBLAS_CODE forward(utils::int4x2* srcptr, float* dstptr, int row, int col, int ld_src, int ld_dst,
+  static inline JBLAS_CODE forward(utils::int4x2* srcptr, _DST_T* dstptr, int row, int col, int ld_src, int ld_dst,
                                    _T* scales, int k_offset, int kblock, int NPad) {
 #if CompileAVX512F()
     if (utils::isa_base<ISA_T>::avx512f) {
-      return avx512f::decompress_kblock_s4_f32(srcptr, dstptr, row, col, ld_src, ld_dst, scales, k_offset, kblock,
+      return avx512f::decompress_kblock_s4_fp(srcptr, dstptr, row, col, ld_src, ld_dst, scales, k_offset, kblock, NPad);
+    }
+#endif
+    return ref::decompress_kblock_s4_fp(srcptr, dstptr, row, col, ld_src, ld_dst, scales, k_offset, kblock, NPad);
+  }
+};
+
+template <typename _DST_T>
+class DecompressKBlockFp4Fp {
+ public:
+  template <JBLAS_ISA ISA_T, typename _T>
+  static inline JBLAS_CODE forward(utils::fp4x2* srcptr, _DST_T* dstptr, int row, int col, int ld_src, int ld_dst,
+                                   _T* scales, int k_offset, int kblock, int NPad) {
+#if CompileAVX512F()
+    if (utils::isa_base<ISA_T>::avx512f) {
+      return avx512f::decompress_kblock_fp4_fp(srcptr, dstptr, row, col, ld_src, ld_dst, scales, k_offset, kblock,
                                                NPad);
     }
 #endif
-    return ref::decompress_kblock_s4_f32(srcptr, dstptr, row, col, ld_src, ld_dst, scales, k_offset, kblock, NPad);
+    return ref::decompress_kblock_fp4_fp(srcptr, dstptr, row, col, ld_src, ld_dst, scales, k_offset, kblock, NPad);
   }
 };
 
@@ -142,6 +599,9 @@ class DecompressKBlockS4S8 {
  public:
   template <JBLAS_ISA ISA_T>
   static inline JBLAS_CODE forward(utils::int4x2* srcptr, int8_t* dstptr, int row, int col, int ld_src, int ld_dst) {
+    if (utils::isa_base<ISA_T>::avx512f) {
+      return jit::decompress_s4_s8(srcptr, dstptr, row, col, ld_src, ld_dst);
+    }
 #if CompileAVX512F()
     if (utils::isa_base<ISA_T>::avx512f) {
       return avx512f::decompress_s4_s8(srcptr, dstptr, row, col, ld_src, ld_dst);

--- a/intel_extension_for_transformers/backends/neural_engine/graph/models/gptj/gptj.h
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/models/gptj/gptj.h
@@ -29,7 +29,7 @@ enum gptj_model {
 static const model_scratch gptj_mem_req(int n_layers) {
   switch (n_layers) {
     case 28:
-      return {2048ull * MB, 2048ull * MB, 4096ull * MB, 3072ull * MB};
+      return {4 * 2048ull * MB, 4 * 2048ull * MB, 4 * 4096ull * MB, 4 * 3072ull * MB};
     // TODO(hengyu): add more variants besides 6B
     default:
       MODEL_ASSERT(false);

--- a/intel_extension_for_transformers/backends/neural_engine/graph/models/gptneox/gptneox.cpp
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/models/gptneox/gptneox.cpp
@@ -65,7 +65,7 @@ struct ne_tensor* gpt_neox_ff(const model_layer& layer, ne_context* ctx0, ne_ten
 //
 
 static bool gptneox_model_eval_internal(model_context& lctx, const model_token* tokens, const int n_tokens,
-                                     const int n_past, const int n_threads) {
+                                        const int n_past, const int n_threads) {
   // // enforce that the first token is BOS
   // if (n_past == 0 && tokens[0] != model_token_bos()) {
   //   fprintf(stderr, "%s: first token must be BOS\n", __func__);
@@ -123,7 +123,7 @@ static bool gptneox_model_eval_internal(model_context& lctx, const model_token* 
         cur = ne_norm(ctx0, inpL);
 
         cur = ne_add(ctx0, ne_mul(ctx0, ne_repeat(ctx0, model.layers[il].norm[0], cur), cur),
-                      ne_repeat(ctx0, model.layers[il].norm[1], cur));
+                     ne_repeat(ctx0, model.layers[il].norm[1], cur));
       }
 
       // compute QKV
@@ -148,11 +148,11 @@ static bool gptneox_model_eval_internal(model_context& lctx, const model_token* 
       {
         Vcur = ne_transpose(ctx0, ne_reshape_2d(ctx0, Vcur, n_embd, N));
 
-        struct ne_tensor* k = ne_view_1d(ctx0, kv_self.k, N * n_embd,
-                                          (ne_element_size(kv_self.k) * n_embd) * (il * n_ctx + n_past));
-        struct ne_tensor* v = ne_view_2d(
-            ctx0, kv_self.v, N, n_embd, (n_ctx)*ne_element_size(kv_self.v),
-            (il * n_ctx) * ne_element_size(kv_self.v) * n_embd + n_past * ne_element_size(kv_self.v));
+        struct ne_tensor* k =
+            ne_view_1d(ctx0, kv_self.k, N * n_embd, (ne_element_size(kv_self.k) * n_embd) * (il * n_ctx + n_past));
+        struct ne_tensor* v =
+            ne_view_2d(ctx0, kv_self.v, N, n_embd, (n_ctx)*ne_element_size(kv_self.v),
+                       (il * n_ctx) * ne_element_size(kv_self.v) * n_embd + n_past * ne_element_size(kv_self.v));
 
         ne_build_forward_expand(&gf, ne_cpy(ctx0, Kcur, k));
         ne_build_forward_expand(&gf, ne_cpy(ctx0, Vcur, v));
@@ -162,11 +162,11 @@ static bool gptneox_model_eval_internal(model_context& lctx, const model_token* 
 
       // K = Kmem.view(n_embd/n_head, n_head, n_past + N).permute(0, 2, 1, 3)
       struct ne_tensor* K = ne_permute(ctx0,
-                                        ne_reshape_3d(ctx0,
-                                                      ne_view_1d(ctx0, kv_self.k, (n_past + N) * n_embd,
+                                       ne_reshape_3d(ctx0,
+                                                     ne_view_1d(ctx0, kv_self.k, (n_past + N) * n_embd,
                                                                 il * n_ctx * ne_element_size(kv_self.k) * n_embd),
-                                                      n_embd / n_head, n_head, n_past + N),
-                                        0, 2, 1, 3);
+                                                     n_embd / n_head, n_head, n_past + N),
+                                       0, 2, 1, 3);
 
       // K * Q
       struct ne_tensor* KQ = ne_mul_mat(ctx0, K, Q);
@@ -181,10 +181,9 @@ static bool gptneox_model_eval_internal(model_context& lctx, const model_token* 
       struct ne_tensor* KQ_soft_max = ne_soft_max_inplace(ctx0, KQ_masked);
 
       // V_trans = Vmem.view(n_embd/n_head, n_head, n_past + N).permute(1, 2, 0, 3).contiguous()
-      struct ne_tensor* V =
-          ne_view_3d(ctx0, kv_self.v, n_past + N, n_embd / n_head, n_head, n_ctx * ne_element_size(kv_self.v),
-                      n_ctx * ne_element_size(kv_self.v) * n_embd / n_head,
-                      il * n_ctx * ne_element_size(kv_self.v) * n_embd);
+      struct ne_tensor* V = ne_view_3d(
+          ctx0, kv_self.v, n_past + N, n_embd / n_head, n_head, n_ctx * ne_element_size(kv_self.v),
+          n_ctx * ne_element_size(kv_self.v) * n_embd / n_head, il * n_ctx * ne_element_size(kv_self.v) * n_embd);
 
       // KQV = transpose(V) * KQ_soft_max
       struct ne_tensor* KQV = ne_mul_mat(ctx0, V, KQ_soft_max);
@@ -233,7 +232,8 @@ static bool gptneox_model_eval_internal(model_context& lctx, const model_token* 
     inpL = ne_norm(ctx0, inpL);
 
     // inpL = ln_f_g*inpL + ln_f_b
-    inpL = ne_add(ctx0, ne_mul(ctx0, ne_repeat(ctx0, model.others[1], inpL), inpL), ne_repeat(ctx0, model.others[2], inpL));
+    inpL = ne_add(ctx0, ne_mul(ctx0, ne_repeat(ctx0, model.others[1], inpL), inpL),
+                  ne_repeat(ctx0, model.others[2], inpL));
   }
 
   lctx.use_buf(ctx0, -1);

--- a/intel_extension_for_transformers/backends/neural_engine/graph/models/gptneox/gptneox_utils.cpp
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/models/gptneox/gptneox_utils.cpp
@@ -52,7 +52,7 @@ void model_load_internal(const std::string& fname, model_name name, model_contex
 }
 
 void GPTNEOX::init(const char* path_model, model_context& lctx, int n_ctx_, int n_gpu_layer_, ne_type memory_type_,
-                bool use_mmap_, bool use_mlock_, bool vocab_only_) {
+                   bool use_mmap_, bool use_mlock_, bool vocab_only_) {
   n_ctx = n_ctx_;
   n_gpu_layer = n_gpu_layer_;
   memory_type = memory_type_;
@@ -131,7 +131,7 @@ void GPTNEOX::load(model_context& lctx, model_progress_callback progress_callbac
     layer.norm[1] = ml->get_tensor(layers_i + ".input_layernorm.bias", {n_embd}, backend);
     layer.norm[2] = ml->get_tensor(layers_i + ".post_attention_layernorm.weight", {n_embd}, backend);
     layer.norm[3] = ml->get_tensor(layers_i + ".post_attention_layernorm.bias", {n_embd}, backend);
-  
+
     // qkv GEMM
     layer.attn[0] = ml->get_tensor(layers_i + ".attention.query_key_value.weight", {n_embd, 3 * n_embd}, backend);
     layer.attn[1] = ml->get_tensor(layers_i + ".attention.query_key_value.bias", {3 * n_embd}, backend);
@@ -145,12 +145,10 @@ void GPTNEOX::load(model_context& lctx, model_progress_callback progress_callbac
     layer.ffn[3] = ml->get_tensor(layers_i + ".mlp.dense_4h_to_h.bias", {n_embd}, backend);
 
     if (backend != NE_BACKEND_CPU) {
-      vram_total += ne_nbytes(layer.norm[0]) + ne_nbytes(layer.norm[1]) +
-                    ne_nbytes(layer.norm[2]) + ne_nbytes(layer.norm[3]) +
-                    ne_nbytes(layer.attn[0]) + ne_nbytes(layer.attn[1]) +
-                    ne_nbytes(layer.attn[2]) + ne_nbytes(layer.attn[3]) +
-                    ne_nbytes(layer.ffn[0]) + ne_nbytes(layer.ffn[1]) +
-                    ne_nbytes(layer.ffn[2]) + ne_nbytes(layer.ffn[3]);
+      vram_total += ne_nbytes(layer.norm[0]) + ne_nbytes(layer.norm[1]) + ne_nbytes(layer.norm[2]) +
+                    ne_nbytes(layer.norm[3]) + ne_nbytes(layer.attn[0]) + ne_nbytes(layer.attn[1]) +
+                    ne_nbytes(layer.attn[2]) + ne_nbytes(layer.attn[3]) + ne_nbytes(layer.ffn[0]) +
+                    ne_nbytes(layer.ffn[1]) + ne_nbytes(layer.ffn[2]) + ne_nbytes(layer.ffn[3]);
     }
   }
 

--- a/intel_extension_for_transformers/backends/neural_engine/graph/models/model_utils/arg_parse.cpp
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/models/model_utils/arg_parse.cpp
@@ -333,6 +333,20 @@ bool gpt_params_parse(int argc, char** argv, gpt_params& params) {
         break;
       }
       params.input_suffix = argv[i];
+    } else if (arg == "--batch_size") {  // TODO ambiguous with batch-size (n_batch)
+      if (++i >= argc) {
+        invalid_param = true;
+        break;
+      }
+      params.batch_size = std::stoi(argv[i]);
+    } else if (arg == "--beam_search") {
+      params.beam_search = true;
+    } else if (arg == "--beam_size") {
+      if (++i >= argc) {
+        invalid_param = true;
+        break;
+      }
+      params.beam_size = std::stoi(argv[i]);
     } else {
       fprintf(stderr, "error: unknown argument: %s\n", arg.c_str());
       gpt_print_usage(argc, argv, default_params);
@@ -442,5 +456,8 @@ void gpt_print_usage(int /*argc*/, char** argv, const gpt_params& params) {
           "  --lora-base FNAME     optional model to use as a base for the layers modified by the LoRA adapter\n");
   fprintf(stderr, "  -m FNAME, --model FNAME\n");
   fprintf(stderr, "                        model path (default: %s)\n", params.model.c_str());
+  fprintf(stderr, "  --batch_size 2        number batch of prompt\n");
+  fprintf(stderr, "  --beam_search         use beam search for text generation\n");
+  fprintf(stderr, "  --beam_size 4         number of beams for beam_search, only valid after --beam_search\n");
   fprintf(stderr, "\n");
 }

--- a/intel_extension_for_transformers/backends/neural_engine/graph/models/model_utils/model_config.h
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/models/model_utils/model_config.h
@@ -86,6 +86,9 @@ struct gpt_params {
   bool use_mlock = false;       // use mlock to keep model in memory
   bool mem_test = false;        // compute maximum memory usage
   bool verbose_prompt = false;  // print prompt tokens before generation
+  int batch_size = 1;           // number batch of prompt
+  bool beam_search = false;     // use beam_search or not
+  int beam_size = 1;            // only valid if use beam search
 };
 
 bool gpt_params_parse(int argc, char** argv, gpt_params& params);

--- a/intel_extension_for_transformers/backends/neural_engine/graph/models/model_utils/model_types.h
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/models/model_utils/model_types.h
@@ -99,10 +99,10 @@ struct model_hparams {
   uint32_t n_layer = 32;
   uint32_t n_rot = 64;
   enum ne_ftype ftype = NE_FTYPE_MOSTLY_F16;
-  int32_t max_seq_len = 0;  // for mpt
-  float alibi_bias_max = 0; // for mpt
-  float clip_qkv = 0;  // for mpt
-  int32_t par_res = 1;  // for neox 1 = true, 0 = false
+  int32_t max_seq_len = 0;   // for mpt
+  float alibi_bias_max = 0;  // for mpt
+  float clip_qkv = 0;        // for mpt
+  int32_t par_res = 1;       // for neox 1 = true, 0 = false
 
   bool operator!=(const model_hparams& other) const {
     return static_cast<bool>(memcmp(this, &other, sizeof(model_hparams)));
@@ -204,11 +204,15 @@ struct model_context {
 
   model_struct model;
   model_vocab vocab;
+  int batch_size = 1;
+  bool beam_search = false;
+  int beam_size = 1;
+  int kv_n_ctx_block = 1;
   std::vector<std::vector<std::string>> tensors_name;
 
   size_t mem_per_token = 0;
 
-  // decode output (2-dimensional array: [n_tokens][n_vocab])
+  // decode output (3-dimensional array: [batch_size] [n_tokens] [n_vocab])
   std::vector<float> logits;
   bool logits_all = false;
 
@@ -263,7 +267,7 @@ struct model_context {
   }
 };
 
-typedef int model_token;
+typedef model_vocab::id model_token;
 
 typedef struct model_token_data {
   model_token id;  // token id
@@ -290,6 +294,9 @@ struct model_context_params {
   bool use_mmap;     // use mmap if possible
   bool use_mlock;    // force system to keep model in RAM
   bool embedding;    // embedding mode only
+  int batch_size;    // batch_size of prompt
+  bool beam_search;  // beam search or not
+  int beam_size;     // number of beams for beam search
 
   // called with a progress value between 0 and 1, pass NULL to disable
   model_progress_callback progress_callback;

--- a/intel_extension_for_transformers/backends/neural_engine/graph/models/model_utils/quant_config.h
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/models/model_utils/quant_config.h
@@ -90,7 +90,7 @@ struct quant_params_internal {
   int32_t block_size = 32;
   quant_sdtype scale_dtype = quant_sdtype::fp16;
   quant_comp compute_type = quant_comp::ggml;
-  bool valid() const{
+  bool valid() const {
     return bits != quant_bits::count && alg != quant_alg::count && scale_dtype != quant_sdtype::count &&
            compute_type != quant_comp::count && block_size > 0;
   }

--- a/intel_extension_for_transformers/backends/neural_engine/graph/models/mpt/mpt.cpp
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/models/mpt/mpt.cpp
@@ -43,7 +43,7 @@
 //   - n_threads: number of threads to use
 //
 static bool mpt_model_eval_internal(model_context& lctx, const model_token* tokens, const int n_tokens,
-                                     const int n_past, const int n_threads) {
+                                    const int n_past, const int n_threads) {
   // // enforce that the first token is BOS
   // if (n_past == 0 && tokens[0] != model_token_bos()) {
   //   fprintf(stderr, "%s: first token must be BOS\n", __func__);
@@ -101,10 +101,10 @@ static bool mpt_model_eval_internal(model_context& lctx, const model_token* toke
 
       cur = ne_mul(ctx0, ne_repeat(ctx0, model.layers[il].norm[0], cur), cur);
     }
-    
+
     {
       cur = ne_mul_mat(ctx0, model.layers[il].attn[0], cur);
-      
+
       if (model.hparams.clip_qkv > 0.0f) {
         cur = ne_clamp(ctx0, cur, -model.hparams.clip_qkv, model.hparams.clip_qkv);
       }
@@ -116,11 +116,11 @@ static bool mpt_model_eval_internal(model_context& lctx, const model_token* toke
       {
         struct ne_tensor* Vcur =
             ne_transpose(ctx0, ne_view_2d(ctx0, cur, n_embd, N, cur->nb[1], 2 * sizeof(float) * n_embd));
-        struct ne_tensor* k = ne_view_1d(ctx0, kv_self.k, N * n_embd,
-                                          (ne_element_size(kv_self.k) * n_embd) * (il * n_ctx + n_past));
-        struct ne_tensor* v = ne_view_2d(
-            ctx0, kv_self.v, N, n_embd, (n_ctx)*ne_element_size(kv_self.v),
-            (il * n_ctx) * ne_element_size(kv_self.v) * n_embd + n_past * ne_element_size(kv_self.v));
+        struct ne_tensor* k =
+            ne_view_1d(ctx0, kv_self.k, N * n_embd, (ne_element_size(kv_self.k) * n_embd) * (il * n_ctx + n_past));
+        struct ne_tensor* v =
+            ne_view_2d(ctx0, kv_self.v, N, n_embd, (n_ctx)*ne_element_size(kv_self.v),
+                       (il * n_ctx) * ne_element_size(kv_self.v) * n_embd + n_past * ne_element_size(kv_self.v));
         // important: storing RoPE-ed version of K in the KV cache!
         ne_build_forward_expand(&gf, ne_cpy(ctx0, Kcur, k));
         ne_build_forward_expand(&gf, ne_cpy(ctx0, Vcur, v));
@@ -135,11 +135,11 @@ static bool mpt_model_eval_internal(model_context& lctx, const model_token* toke
       // K = Kmem.view(n_embd/n_head, n_head, n_past + N).permute(0, 2, 1,
       // 3) [64, n_past + N, 12]
       struct ne_tensor* K = ne_permute(ctx0,
-                                        ne_reshape_3d(ctx0,
-                                                      ne_view_1d(ctx0, kv_self.k, (n_past + N) * n_embd,
+                                       ne_reshape_3d(ctx0,
+                                                     ne_view_1d(ctx0, kv_self.k, (n_past + N) * n_embd,
                                                                 il * n_ctx * ne_element_size(kv_self.k) * n_embd),
-                                                      n_embd / n_head, n_head, n_past + N),
-                                        0, 2, 1, 3);
+                                                     n_embd / n_head, n_head, n_past + N),
+                                       0, 2, 1, 3);
       // K * Q
       struct ne_tensor* KQ = ne_mul_mat(ctx0, K, Q);
 
@@ -156,10 +156,9 @@ static bool mpt_model_eval_internal(model_context& lctx, const model_token* toke
 
       // V_trans = Vmem.view(n_embd/n_head, n_head, n_past + N).permute(1,
       // 2, 0, 3).contiguous() [n_past + N, 64, 12]
-      struct ne_tensor* V_trans =
-          ne_view_3d(ctx0, kv_self.v, n_past + N, n_embd / n_head, n_head, n_ctx * ne_element_size(kv_self.v),
-                      n_ctx * ne_element_size(kv_self.v) * n_embd / n_head,
-                      il * n_ctx * ne_element_size(kv_self.v) * n_embd);
+      struct ne_tensor* V_trans = ne_view_3d(
+          ctx0, kv_self.v, n_past + N, n_embd / n_head, n_head, n_ctx * ne_element_size(kv_self.v),
+          n_ctx * ne_element_size(kv_self.v) * n_embd / n_head, il * n_ctx * ne_element_size(kv_self.v) * n_embd);
 
       // KQV = transpose(V) * KQ_soft_max
       struct ne_tensor* KQV = ne_mul_mat(ctx0, V_trans, KQ_soft_max);

--- a/intel_extension_for_transformers/backends/neural_engine/graph/models/mpt/mpt_utils.cpp
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/models/mpt/mpt_utils.cpp
@@ -52,7 +52,7 @@ void model_load_internal(const std::string& fname, model_name name, model_contex
 }
 
 void MPT::init(const char* path_model, model_context& lctx, int n_ctx_, int n_gpu_layer_, ne_type memory_type_,
-                bool use_mmap_, bool use_mlock_, bool vocab_only_) {
+               bool use_mmap_, bool use_mlock_, bool vocab_only_) {
   n_ctx = n_ctx_;
   n_gpu_layer = n_gpu_layer_;
   memory_type = memory_type_;
@@ -127,7 +127,7 @@ void MPT::load(model_context& lctx, model_progress_callback progress_callback, v
     // norm: cur = ln_1_g*cur + ln_1_b
     layer.norm[0] = ml->get_tensor(layers_i + ".norm_1.weight", {n_embd}, backend);
     layer.norm[1] = ml->get_tensor(layers_i + ".norm_2.weight", {n_embd}, backend);
-  
+
     // qkv GEMM
     layer.attn[0] = ml->get_tensor(layers_i + ".attn.Wqkv.weight", {n_embd, 3 * n_embd}, backend);
     layer.attn[1] = ml->get_tensor(layers_i + ".attn.out_proj.weight", {n_embd, n_embd}, backend);
@@ -137,9 +137,8 @@ void MPT::load(model_context& lctx, model_progress_callback progress_callback, v
     layer.ffn[1] = ml->get_tensor(layers_i + ".ffn.down_proj.weight", {n_ff, n_embd}, backend);
 
     if (backend != NE_BACKEND_CPU) {
-      vram_total += ne_nbytes(layer.norm[0]) + ne_nbytes(layer.norm[1]) +
-                    ne_nbytes(layer.attn[0]) + ne_nbytes(layer.attn[1]) +
-                    ne_nbytes(layer.ffn[0]) + ne_nbytes(layer.ffn[1]);
+      vram_total += ne_nbytes(layer.norm[0]) + ne_nbytes(layer.norm[1]) + ne_nbytes(layer.attn[0]) +
+                    ne_nbytes(layer.attn[1]) + ne_nbytes(layer.ffn[0]) + ne_nbytes(layer.ffn[1]);
     }
   }
 

--- a/intel_extension_for_transformers/backends/neural_engine/graph/requirements.txt
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/requirements.txt
@@ -1,5 +1,5 @@
 torch
-transformers==4.30.2
+transformers
 numpy
 sentencepiece
 protobuf<3.20

--- a/intel_extension_for_transformers/backends/neural_engine/graph/vectors/cpu/vec_convert.cpp
+++ b/intel_extension_for_transformers/backends/neural_engine/graph/vectors/cpu/vec_convert.cpp
@@ -50,7 +50,7 @@ inline int32x16 maskz_cvt_roundfp32x16_int32x16(int mask, fp32x16 a) {
 inline bf16x16 cvt_fp32x16_bf16x16(fp32x16 a) {
 #if __AVX512F__
 #if __AVX512BF16__ && __GNUC__ > 11
-  return _mm512_cvtneps_pbh(a);
+  return _mm256_castph_si256((__m256h)_mm512_cvtneps_pbh(a));
 #else
   return _mm512_cvtepi32_epi16(_mm512_bsrli_epi128(_mm512_castps_si512(a), 2));
 #endif
@@ -65,7 +65,7 @@ inline bf16x16 cvt_fp32x16_bf16x16(fp32x16 a) {
 inline fp32x16 cvt_bf16x16_fp32x16(bf16x16 a) {
 #if __AVX512F__
 #if __AVX512BF16__ && __GNUC__ > 11
-  return _mm512_cvtpbh_ps(a);
+  return _mm512_cvtpbh_ps((__m256bh)_mm256_castsi256_ph(a));
 #else
   return _mm512_castsi512_ps(_mm512_bslli_epi128(_mm512_cvtepu16_epi32(a), 2));
 #endif
@@ -81,7 +81,7 @@ inline fp32x16 cvt_bf16x16_fp32x16(bf16x16 a) {
 inline fp32x16 maskz_cvt_bf16x16_fp32x16(int mask, bf16x16 a) {
 #if __AVX512F__
 #if __AVX512BF16__ && __GNUC__ > 11
-  return _mm512_maskz_cvtpbh_ps(mask, a);
+  return _mm512_maskz_cvtpbh_ps(mask, (__m256bh)a);
 #else
   return _mm512_castsi512_ps(_mm512_bslli_epi128(_mm512_maskz_cvtepu16_epi32(mask, a), 2));
 #endif


### PR DESCRIPTION
* update jblas to amx

add amx kernels quant path

init amx instruction

add qkv fusion for amxbf16

add amxint8+avx512f QKV fusion kernel

add print ISA

compatible with previous int4 models

add kblock size limitation  for amx_int8 kernel

fused gelu

gelu with vec

add switch

fix rebase

fix rebase

support gptj fusion

imporve performance

clang format

add amx_int8 version of gelu kernels

add ffn_add_gelu for amx_int8

enable vec version of gelu comput

inital beam_search movement

inital multi-batch inference movement

update the kv cache size for beam 4

add beam_search related args & parse and update model_init for memory

add beam_search example in main

enable amx_int8 when kblocksize is padded to 128

fix dynamic batch infer

enable multi thread for ops

disable multi thread for softmax/rope next token

fix memory

add the code

update the kv offset name

add non-transpose layout of V matrix

remove print

gelu fusion support bias boardcast

remove time print

fix threads limits

default disable beam and enlarge mem for beam 4

beam search support 2048

first token repeat without acc checkout

fix v cache memcpy

float version of ffn+gelu fusion

sample 2 for each beam

MHA draft

sync jblas 3724b3a

jblas mha draft w/ mask

support fp32_fp16_fp16_fp32

(cherry picked from commit b613de084bb387b36bcce353f39c71ea911f5f6b)

stash

integrate amx_bf16 flash attention

fixed the compilation issue

add explicit for data conversion

explicit

remove error code

fix crash

fix 'f' & "ggg"

enable mha for first token only

covert first token's Vcur to fp16

reshape Vcur before cpy

fixed the copy bug

add the code

enable omp for post process

add pybind check

Graph without repeat (#1255)

* fuse matmul+add

* broadcast add and mul

optimize parallel of fp32->fp16 copy

add new parallel strategy for permute1203 fp32->fp16 copy

revert transformers version

change soft max to n_threads

fix native on spr

NE_USE_RN_BF16FP16

mha: exp_2nd & reorderQ & reorderK

Graph gelu erf (#1256)

* erf gelu

* fix bug

fix the compile flags of bf16 conversion

enable new MHA

fix bf16 flag

revert transformer version limitation

gelu pass ut.

todo: replace gelu.

todo: check model-level acc.

fix src_cpy ptr.

sync to jblas a1dbde9 & update changes

fix last commit: remove confusing isa branching

fix jblas serialization

Revert "Graph gelu erf (#1256)"

This reverts commit ea8e3b75afca2262e5dcd3e9ba7b8c6dec3b6ce7.

cherry-pick #1228 and fix conflicts



fix mpt conflicts



let model file patch configurable in pybind_gptj
format all codes



* fix threads limits

* format code remove useless third-party



* disable ffn fusion in gpt-j



---------

## Type of Change

feature or bug fix or documentation or others
API changed or not

## Description

detail description 
JIRA ticket: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed