### PR TITLE
[CPP Graph] Fix Graph Model quantization on AVX2-only Platforms

### DIFF
--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_utils.cpp
@@ -59,7 +59,7 @@ static bool kv_cache_init(const struct model_hparams& hparams, struct model_kv_c
   const int n_layer = hparams.n_layer;
 
   const int64_t n_mem = n_layer * n_ctx;
-  const int64_t n_elements = n_head_kv > 0? n_head_kv * head_dim * n_mem : n_embd * n_mem;
+  const int64_t n_elements = n_head_kv > 0 ? n_head_kv * head_dim * n_mem : n_embd * n_mem;
 
   cache.buf.resize(2u * n_elements * ne_type_size(wtype) + 2u * MB);
 
@@ -783,7 +783,7 @@ size_t jblas_quantize(const float* f32ptr, void* dstpr, const quant_params_inter
         using Kernel = WeiS4ClipFp32<GcCompInt8KBlock, JblasAVX512F>;
         using KernelRef = WeiS4ClipFp32<GcCompInt8KBlock, JblasNoSIMD>;
         static Kernel kernel;
-        static Kernel kernelref;
+        static KernelRef kernelref;
         packedw = kernel.createStorage(n, k, params.block_size);
         if (cd->AVX512F()) {
           kernel.packTransposeWeight(n, k, f32ptr, k, packedw);

--- a/intel_extension_for_transformers/llm/runtime/graph/vectors/cpu/vec_arithmetic.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/vectors/cpu/vec_arithmetic.cpp
@@ -12,6 +12,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+#include <cassert>
+
 #include "vec_arithmetic.hpp"
 
 inline fp32x16 sub_fp32x16(fp32x16 x, fp32x16 y) {

--- a/intel_extension_for_transformers/llm/runtime/graph/vectors/cpu/vec_base.hpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/vectors/cpu/vec_base.hpp
@@ -17,6 +17,7 @@
 
 #include <immintrin.h>
 #include <cstdint>
+#include <utility>
 
 #if __AVX512F__
 typedef __m512 fp32x16;

--- a/intel_extension_for_transformers/llm/runtime/graph/vectors/cpu/vec_store.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/vectors/cpu/vec_store.cpp
@@ -13,6 +13,7 @@
 //  limitations under the License.
 
 #include "vec_store.hpp"
+#include "vec_convert.hpp"
 
 inline void store_int8x16(void* mem_addr, int8x16 a) { _mm_storeu_si128(reinterpret_cast<__m128i*>(mem_addr), a); }
 inline void mask_store_int8x16(void* mem_addr, const int mask, int8x16 a) {


### PR DESCRIPTION
## Type of Change: bug fix

API not changed

## Description
Fixed a few problems that prevent the code compile and run on AVX2 platforms (with Windows11 in my case). Therefore, I can prepare / update quantized models on my local windows machine and saving disk space on servers~

## Expected Behavior & Potential Risk
N/A

## How has this PR been tested?
`cmake -GNinja -DNE_AVX512=OFF -DNE_AVX512_VBMI=OFF -DNE_AVX512_VNNI=OFF ..`. Commands for model conversion / quantization are the same as that in README.

## Dependency Change?
N/A