### PR TITLE
[CPP Graph] Fix models without jblas-based kvcache support

### DIFF
--- a/intel_extension_for_transformers/llm/runtime/graph/models/gptj/gptj.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/gptj/gptj.cpp
@@ -230,7 +230,6 @@ static bool gptj_model_eval_internal(model_context& lctx, const model_token* tok
                                n_ctx * ne_element_size(kv_self.v) * n_embd,
                                ((il * n_ctx) * ne_element_size(kv_self.v) * n_embd * kv_n_ctx_block +
                                 i * n_ctx * n_embd * ne_element_size(kv_self.v) + n_past * ne_element_size(kv_self.v)));
-          ne_build_forward_expand(&gf, ne_cpy(ctx0, Vcur_bs[i], v_bs[i]));
         }
         ne_build_forward_expand(&gf, ne_cpy(ctx0, Kcur_bs[i], k_bs[i]));
         ne_build_forward_expand(&gf, ne_cpy(ctx0, Vcur_bs[i], v_bs[i]));

--- a/intel_extension_for_transformers/llm/runtime/graph/models/gptj/gptj_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/gptj/gptj_utils.cpp
@@ -48,6 +48,7 @@ void model_load_internal(const std::string& fname, model_archs arch, model_conte
   ms->init(fname.c_str(), lctx, n_ctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
 
+  lctx.support_jblas_kv = true;
   lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 

--- a/intel_extension_for_transformers/llm/runtime/graph/models/llama/llama_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/llama/llama_utils.cpp
@@ -48,6 +48,7 @@ void model_load_internal(const std::string& fname, model_archs arch, model_conte
   ms->init(fname.c_str(), lctx, n_ctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
 
+  lctx.support_jblas_kv = true;
   lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_types.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_types.h
@@ -240,6 +240,7 @@ struct model_context {
   model_vocab vocab;
   int batch_size = 1;
   bool beam_search = false;
+  bool support_jblas_kv = false;  // whether the model graph supports jblas-kvcache
   int beam_size = 1;
   int kv_n_ctx_block = 1;
   generation_config generation_conf;


### PR DESCRIPTION
## Type of Change: fix
API not changed.

## Description
After #179, JBLAS-managed kv-cache is used on platforms with ISA support if compiled with a compiler of high enough version. However, it forgets to check if the model supports MHA fusion.

## Expected Behavior & Potential Risk
Models without MHA-fusion implemented should be able run without `--memory-f16` flag on SPR with GCC13.

## How has this PR been tested?
GPTJ ext test (internal access required): TODO

## Dependency Change?
N/A