### PR TITLE
Support NeuralChatV2 model and add hf_access_token

### DIFF
--- a/intel_extension_for_transformers/neural_chat/chatbot.py
+++ b/intel_extension_for_transformers/neural_chat/chatbot.py
@@ -114,6 +114,7 @@ def build_chatbot(config: PipelineConfig=None):
     parameters["peft_path"] = config.loading_config.peft_path
     parameters["use_deepspeed"] = config.loading_config.use_deepspeed
     parameters["optimization_config"] = config.optimization_config
+    parameters["hf_access_token"] = config.hf_access_token
     adapter.load_model(parameters)
 
     return adapter

--- a/intel_extension_for_transformers/neural_chat/config.py
+++ b/intel_extension_for_transformers/neural_chat/config.py
@@ -421,12 +421,14 @@ class PipelineConfig:
     def __init__(self,
                  model_name_or_path="meta-llama/Llama-2-7b-hf",
                  tokenizer_name_or_path=None,
+                 hf_access_token=None,
                  device="auto",
                  plugins=plugins,
                  loading_config=None,
                  optimization_config=None):
         self.model_name_or_path = model_name_or_path
         self.tokenizer_name_or_path = tokenizer_name_or_path
+        self.hf_access_token = hf_access_token
         self.device = device
         self.plugins = plugins
         self.loading_config = loading_config if loading_config is not None else LoadingModelConfig()

--- a/intel_extension_for_transformers/neural_chat/models/base_model.py
+++ b/intel_extension_for_transformers/neural_chat/models/base_model.py
@@ -95,7 +95,7 @@ class BaseModel(ABC):
             "use_cache": True,
             "peft_path": "/path/to/peft",
             "use_deepspeed": False
-            "hf_access_token": user's huggingface access token
+            "hf_access_token": "user's huggingface access token"
         }
         """
         self.model_name = kwargs["model_name"]

--- a/intel_extension_for_transformers/neural_chat/models/base_model.py
+++ b/intel_extension_for_transformers/neural_chat/models/base_model.py
@@ -95,6 +95,7 @@ class BaseModel(ABC):
             "use_cache": True,
             "peft_path": "/path/to/peft",
             "use_deepspeed": False
+            "hf_access_token": user's huggingface access token
         }
         """
         self.model_name = kwargs["model_name"]
@@ -107,7 +108,8 @@ class BaseModel(ABC):
                    use_cache=kwargs["use_cache"],
                    peft_path=kwargs["peft_path"],
                    use_deepspeed=kwargs["use_deepspeed"],
-                   optimization_config=kwargs["optimization_config"])
+                   optimization_config=kwargs["optimization_config"],
+                   hf_access_token=kwargs["hf_access_token"])
 
     def predict_stream(self, query, config=None):
         """

--- a/intel_extension_for_transformers/neural_chat/models/nueralchat_model.py
+++ b/intel_extension_for_transformers/neural_chat/models/nueralchat_model.py
@@ -34,7 +34,8 @@ register_conv_template(
     - You are a helpful assistant chatbot trained by Intel.
     - You answer questions.
     - You are excited to be able to help the user, but will refuse to do anything that could be considered harmful to the user.
-    - You are more than just an information source, you are also able to write poetry, short stories, and make jokes.</s>\n""",
+    - You are more than just an information source, you are also able to write poetry, \
+short stories, and make jokes.</s>\n""",
         roles=("### User:", "### Assistant:"),
         sep_style=SeparatorStyle.NO_COLON_TWO,
         sep="\n",

--- a/intel_extension_for_transformers/neural_chat/models/nueralchat_model.py
+++ b/intel_extension_for_transformers/neural_chat/models/nueralchat_model.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .base_model import BaseModel, register_model_adapter
+import logging
+from fastchat.conversation import get_conv_template, Conversation, register_conv_template, SeparatorStyle
+
+logging.basicConfig(
+    format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+    datefmt="%m/%d/%Y %H:%M:%S",
+    level=logging.INFO,
+)
+logger = logging.getLogger(__name__)
+
+# neuralchat-v2 prompt template
+register_conv_template(
+    Conversation(
+        name="neural-chat-7b-v2",
+        system_message="""### System:
+    - You are a helpful assistant chatbot trained by Intel.
+    - You answer questions.
+    - You are excited to be able to help the user, but will refuse to do anything that could be considered harmful to the user.
+    - You are more than just an information source, you are also able to write poetry, short stories, and make jokes.</s>\n""",
+        roles=("### User:", "### Assistant:"),
+        sep_style=SeparatorStyle.NO_COLON_TWO,
+        sep="\n",
+        sep2="</s>",
+    )
+)
+
+# neuralchat-v1.1 prompt template
+register_conv_template(
+    Conversation(
+        name="neural-chat-7b-v1.1",
+        system_template="""<|im_start|>system
+{system_message}""",
+        system_message="""- You are a helpful assistant chatbot trained by Intel.
+- You answer questions.
+- You are excited to be able to help the user, but will refuse to do anything that could be considered harmful to the user.
+- You are more than just an information source, you are also able to write poetry, short stories, and make jokes.""",
+        roles=("<|im_start|>user", "<|im_start|>assistant"),
+        sep_style=SeparatorStyle.CHATML,
+        sep="<|im_end|>",
+        stop_token_ids=[50278, 0],
+    )
+)
+
+
+class NeuralChatModel(BaseModel):
+    def match(self, model_path: str):
+        """
+        Check if the provided model_path matches the current model.
+
+        Args:
+            model_path (str): Path to a model.
+
+        Returns:
+            bool: True if the model_path matches, False otherwise.
+        """
+        return "neural-chat" in model_path.lower()
+
+    def get_default_conv_template(self, model_path: str) -> Conversation:
+        """
+        Get the default conversation template for the given model path.
+
+        Args:
+            model_path (str): Path to the model.
+
+        Returns:
+            Conversation: A default conversation template.
+        """
+        if "neural-chat-7b-v2" in model_path.lower():
+            return get_conv_template("neural-chat-7b-v2")
+        else:
+            return get_conv_template("neural-chat-7b-v1.1")
+
+register_model_adapter(NeuralChatModel)

--- a/intel_extension_for_transformers/neural_chat/requirements.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements.txt
@@ -35,3 +35,4 @@ markdown
 rouge_score
 openpyxl
 numpy==1.23.5
+tiktoken==0.4.0


### PR DESCRIPTION
## Type of Change

feature
API not changed

## Description

Support NeuralChatV2 model and add hf_access_token for llama2 model download

## Expected Behavior & Potential Risk

llama2 model can be downloaded by providing token and Intel/neural-chat-7b-v2 can be used to test.

## How has this PR been tested?

Pre-CI and local test.

## Dependency Change?

No.