### PR TITLE
fix speaker embedding path issue

### DIFF
--- a/intel_extension_for_transformers/neural_chat/pipeline/plugins/audio/tts.py
+++ b/intel_extension_for_transformers/neural_chat/pipeline/plugins/audio/tts.py
@@ -62,9 +62,11 @@ class TextToSpeech():
         elif os.path.exists('spk_embed_default.pt'):
             default_speaker_embedding_path = 'spk_embed_default.pt'
         else:
-            print("Warning! Need to prepare speaker_embeddings")
+            print("Warning! Need to prepare speaker_embeddings, will use the backup embedding.")
+            default_speaker_embedding_path = None
         # load the default speaker embedding
-        self.default_speaker_embedding = torch.load(default_speaker_embedding_path)
+        self.default_speaker_embedding = torch.load(default_speaker_embedding_path) if default_speaker_embedding_path \
+            else None
 
         # preload the demo model in case of time-consuming runtime loading
         self.demo_model = None
@@ -77,6 +79,8 @@ class TextToSpeech():
             self.male_speaker_embeddings = torch.load(pat_speaker_embedding_path)
         elif os.path.exists(os.path.join(asset_path, 'speaker_embeddings/spk_embed_male.pt')):
             self.male_speaker_embeddings = torch.load(os.path.join(asset_path, 'speaker_embeddings/spk_embed_male.pt'))
+
+        self.backup_speaker_embedding = torch.ones((1, 512))
 
         self.normalizer = EnglishNormalizer()
 
@@ -98,17 +102,21 @@ class TextToSpeech():
       asset_path="/intel-extension-for-transformers/intel_extension_for_transformers/neural_chat/assets"):
         script_dir = os.path.dirname(os.path.abspath(__file__))
         if os.path.exists(f"speaker_embeddings/spk_embed_{voice}.pt") == False:
-            print("No customized speaker embedding is found! Use the default one")
             if os.path.exists(os.path.join(script_dir, '../../../assets/speaker_embeddings/spk_embed_default.pt')):
                 default_speaker_embedding_path = os.path.join(script_dir,
                                                     '../../../assets/speaker_embeddings/spk_embed_default.pt')
             elif os.path.exists(os.path.join(asset_path, 'speaker_embeddings/spk_embed_default.pt')):
-                default_speaker_embedding_path = (asset_path, 'speaker_embeddings/spk_embed_default.pt')
-            return default_speaker_embedding_path
+                print("No customized speaker embedding is found! Use the default one")
+                default_speaker_embedding_path = os.path.join(asset_path, 'speaker_embeddings/spk_embed_default.pt')
+            else:   # pragma: no cover
+                print("No customized speaker embedding or default embedding are found! Use the backup one")
+                return self.backup_speaker_embedding
+            print("No customized speaker embedding is found! Use the default one")
+            return torch.load(default_speaker_embedding_path)
         else:
             specific_speaker_embedding_path = os.path.join(script_dir,
                                         f"../../../assets/speaker_embeddings/spk_embed_{voice}.pt")
-            return specific_speaker_embedding_path
+            return torch.load(specific_speaker_embedding_path)
 
     def _batch_long_text(self, text, batch_length):
         """Batch the long text into sequences of shorter sentences."""
@@ -155,7 +163,8 @@ class TextToSpeech():
             texts = [text]
         print(texts)
         model = self.original_model
-        speaker_embeddings = self.default_speaker_embedding
+        speaker_embeddings = self.default_speaker_embedding if self.default_speaker_embedding is not None else \
+            self.backup_speaker_embedding
         if voice == "male":
             if self.demo_model == None:
                 print("Finetuned model is not found! Use the default one")
@@ -166,7 +175,7 @@ class TextToSpeech():
             else:
                 speaker_embeddings = self.male_speaker_embeddings
         elif voice != "default":
-            speaker_embeddings = torch.load(self._lookup_voice_embedding(voice))
+            speaker_embeddings = self._lookup_voice_embedding(voice)
         all_speech = np.array([])
         for text_in in texts:
             inputs = self.processor(text=text_in, return_tensors="pt")


### PR DESCRIPTION
## Type of Change

bug fix

## Description

https://github.com/intel/intel-extension-for-transformers/blob/main/intel_extension_for_transformers/neural_chat/pipeline/plugins/audio/tts.py#L106 this line is incorrect, fixed.

Add another backup speaker embedding when users do not have default_speaker_embedding.pt in their assets

## Expected Behavior & Potential Risk

Increase Usability

## How has this PR been tested?

You can delete intel-extension-for-transformers/intel_extension_for_transformers/neural_chat/assets/speaker_embeddings and trigger UT to reproduce. We cannot test it by creating another UT because it exists in our default environment. So I just skip coverage check

## Dependency Change?

None