### PR TITLE
Fix Habana finetuning issues

### DIFF
--- a/intel_extension_for_transformers/llm/finetuning/finetuning.py
+++ b/intel_extension_for_transformers/llm/finetuning/finetuning.py
@@ -274,9 +274,9 @@ class Finetuning:
 
         config = self.load_model_config(self.model_args)
         if config.architectures[0].endswith("ForCausalLM"):
-            self.finetune_clm(model_args, data_args, training_args, finetune_args)
+            self.finetune_clm(model_args, data_args, training_args, finetune_args, config)
         elif config.architectures[0].endswith("ForConditionalGeneration"):
-            self.finetune_seq2seq(model_args, data_args, training_args, finetune_args)
+            self.finetune_seq2seq(model_args, data_args, training_args, finetune_args, config)
         else:
             raise NotImplementedError(
                 "Unsupported architecture {}, only support CausalLM (CLM) \
@@ -303,8 +303,8 @@ class Finetuning:
             lora_module_names.remove('lm_head')
         return list(lora_module_names)
 
-    def finetune_clm(self, model_args, data_args, training_args, finetune_args):
-        if finetune_args.device == 'habana':
+    def finetune_clm(self, model_args, data_args, training_args, finetune_args, config):
+        if finetune_args.device == 'hpu':
             if not is_optimum_habana_available():
                 raise ImportError(
                     "optimum habana is not installed. refer https://github.com/huggingface/optimum-habana"
@@ -315,8 +315,7 @@ class Finetuning:
         # Distributed training:
         # The .from_pretrained methods guarantee that only one local process can concurrently
         # download model & vocab.
-        config = self.load_model_config(model_args)
-        
+
         # set use_fast_tokenizer to False for Llama series models
         if "llama" in config.model_type:
             model_args.use_fast_tokenizer = False
@@ -502,7 +501,7 @@ class Finetuning:
                 model = model.to(model_dtype)
             model.print_trainable_parameters()
 
-            if finetune_args.device != 'habana':
+            if finetune_args.device != 'hpu':
                 # Initialize our Trainer
                 trainer = Trainer(
                     model=model,
@@ -565,7 +564,7 @@ class Finetuning:
                             training_args, gen_kwargs)
                     self.logger.info(results)
 
-    def finetune_seq2seq(self, model_args, data_args, training_args, finetune_args):
+    def finetune_seq2seq(self, model_args, data_args, training_args, finetune_args, config):
         # Detecting last checkpoint.
         last_checkpoint = None
         if os.path.isdir(training_args.output_dir) \
@@ -711,7 +710,6 @@ class Finetuning:
         
         if training_args.do_train:
             # download model & vocab.
-            config = self.load_model_config(model_args)
 
             # Load model
             if model_args.model_name_or_path:

--- a/intel_extension_for_transformers/neural_chat/docker/Dockerfile
+++ b/intel_extension_for_transformers/neural_chat/docker/Dockerfile
@@ -59,11 +59,11 @@ RUN conda init bash && \
     unset -f conda && \
     export PATH=$CONDA_DIR/bin/:${PATH} && \
     conda config --add channels intel && \
-    conda create -yn chatbot-finetuning python=3.9 && \
-    echo "conda activate chatbot-finetuning" >> ~/.bashrc && \
+    conda create -yn neuralchat python=3.9 && \
+    echo "conda activate neuralchat" >> ~/.bashrc && \
     source ~/.bashrc
 
-RUN source activate && conda activate chatbot-finetuning && pip install oneccl_bind_pt -f https://developer.intel.com/ipex-whl-stable-cpu && \
+RUN source activate && conda activate neuralchat && pip install oneccl_bind_pt -f https://developer.intel.com/ipex-whl-stable-cpu && \
     conda install astunparse ninja pyyaml mkl mkl-include setuptools cmake cffi typing_extensions future six requests dataclasses -y && \
     conda install jemalloc gperftools -c conda-forge -y && \
     pip install datasets torch accelerate SentencePiece evaluate nltk rouge_score protobuf==3.20.1 tokenizers einops && \
@@ -72,7 +72,7 @@ RUN source activate && conda activate chatbot-finetuning && pip install oneccl_b
     cd ./intel_extension_for_transformers/neural_chat/examples/instruction_tuning && pip install -r requirements.txt && \
     cd /intel-extension-for-transformers/intel-extension-for-transformers/intel_extension_for_transformers/neural_chat && pip install -r requirements_cpu.txt
 
-# Enable passwordless ssh for mpirun^M
+# Enable passwordless ssh for mpirun
 RUN mkdir /var/run/sshd
 RUN passwd -d root
 RUN sed -i'' -e's/^#PermitRootLogin prohibit-password$/PermitRootLogin yes/' /etc/ssh/sshd_config \

--- a/intel_extension_for_transformers/neural_chat/server/neuralchat_client.py
+++ b/intel_extension_for_transformers/neural_chat/server/neuralchat_client.py
@@ -158,7 +158,7 @@ class VoiceChatClientExecutor(BaseCommandExecutor):
             '--audio_input_path', type=str, default=None, help='Input aduio path.')
         self.parser.add_argument(
             '--audio_output_path', type=str, default=None, help='Output aduio path.')
-        
+
     def execute(self, argv: List[str]) -> bool:
         args = self.parser.parse_args(argv)
         server_ip = args.server_ip
@@ -194,7 +194,7 @@ class VoiceChatClientExecutor(BaseCommandExecutor):
         with open(audio_input_path, "rb") as wav_file:
             files = {
                 "file": ("audio.wav", wav_file, "audio/wav"),
-                "voice": (None, "pat"),
+                "voice": (None, "default"),
                 "audio_output_path": (None, outpath)
             }
             res = requests.post(url, files=files)


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

Fix load model config two times issue;
Fix device hpu issue

## Expected Behavior & Potential Risk

Users will not see two times load model config when do finetuning.
Users set device set to 'hpu' to run finetuning on Habana.

## How has this PR been tested?

Pre-CI and local test.

## Dependency Change?
No.