### PR TITLE
Support streaming mode for neuralchat server

### DIFF
--- a/.github/workflows/unit-test-neuralchat.yml
+++ b/.github/workflows/unit-test-neuralchat.yml
@@ -4,9 +4,12 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - intel_extension_for_transformers/neural_chat/tests/**
       - .github/workflows/unit-test-neuralchat.yml
       - .github/workflows/script/unitTest/**
+      - intel_extension_for_transformers/neural_chat/
+      - intel_extension_for_transformers/llm/finetuning/
+      - intel_extension_for_transformers/llm/quantization/
+      - intel_extension_for_transformers/transformers/
   workflow_dispatch:
 
 # If there is a new commit, the previous jobs will be canceled
@@ -30,8 +33,8 @@ jobs:
         include:
           - test_branch: ${{ github.ref }}
             test_name: "PR-test"
-          # - test_branch: "main"
-          #   test_name: "baseline"
+          - test_branch: "main"
+            test_name: "baseline"
     steps:
       - name: podman Clean Up
         run: |

--- a/intel_extension_for_transformers/neural_chat/server/neuralchat_client.py
+++ b/intel_extension_for_transformers/neural_chat/server/neuralchat_client.py
@@ -78,6 +78,11 @@ class TextChatClientExecutor(BaseCommandExecutor):
             type=int,
             default=128,
             help='The maximum number of new tokens to generate, the value should be set between 32 and 2048')
+        self.parser.add_argument(
+            '--stream',
+            type=bool,
+            default=False,
+            help='support streaming output')
 
 
     def execute(self, argv: List[str]) -> bool:
@@ -91,6 +96,7 @@ class TextChatClientExecutor(BaseCommandExecutor):
         top_k = args.top_k
         repetition_penalty = args.repetition_penalty
         max_new_tokens = args.max_new_tokens
+        stream = args.stream
 
         try:
             time_start = time.time()
@@ -103,7 +109,8 @@ class TextChatClientExecutor(BaseCommandExecutor):
                 top_p=top_p,
                 top_k=top_k,
                 repetition_penalty=repetition_penalty,
-                max_new_tokens=max_new_tokens)
+                max_new_tokens=max_new_tokens,
+                stream=stream)
             time_end = time.time()
             time_consume = time_end - time_start
             response_dict = res.json()
@@ -125,7 +132,8 @@ class TextChatClientExecutor(BaseCommandExecutor):
                  top_p: float=0.75,
                  top_k: int=1,
                  repetition_penalty: float=1.1,
-                 max_new_tokens: int=128):
+                 max_new_tokens: int=128,
+                 stream: bool=False):
         """
         Python API to call an executor.
         """
@@ -138,7 +146,8 @@ class TextChatClientExecutor(BaseCommandExecutor):
             "top_p": top_p,
             "top_k": top_k,
             "repetition_penalty": repetition_penalty,
-            "max_new_tokens": max_new_tokens
+            "max_new_tokens": max_new_tokens,
+            "stream": stream
         }
 
         res = requests.post(url, json.dumps(request))
@@ -183,7 +192,7 @@ class VoiceChatClientExecutor(BaseCommandExecutor):
             logger.error("Failed to generate text response.")
             logger.error(e)
             return False
-        
+
     def __call__(self,
                  server_ip: str="127.0.0.1",
                  port: int=8000,
@@ -239,7 +248,7 @@ class FinetuningClientExecutor(BaseCommandExecutor):
             logger.error("Failed to finetune.")
             logger.error(e)
             return False
-        
+
     def __call__(self,
                  server_ip: str="127.0.0.1",
                  port: int=8000,

--- a/intel_extension_for_transformers/neural_chat/server/restful/openai_protocol.py
+++ b/intel_extension_for_transformers/neural_chat/server/restful/openai_protocol.py
@@ -35,6 +35,7 @@ class ChatCompletionRequest(BaseModel):
     top_k: Optional[int] = 1
     repetition_penalty: Optional[float] = 1.0
     max_new_tokens: Optional[int] = 128
+    stream: Optional[bool] = False
 
 
 class ChatCompletionResponse(BaseModel):
@@ -42,4 +43,3 @@ class ChatCompletionResponse(BaseModel):
     object: str = "chat.completion"
     created: int = Field(default_factory=lambda: int(time.time()))
     response: str
-

--- a/intel_extension_for_transformers/neural_chat/tests/server/test_textchat_server.py
+++ b/intel_extension_for_transformers/neural_chat/tests/server/test_textchat_server.py
@@ -19,7 +19,7 @@ import subprocess
 import unittest
 import time
 import os
-import signal
+import json
 from intel_extension_for_transformers.neural_chat.server import TextChatClientExecutor
 
 class UnitTest(unittest.TestCase):
@@ -48,6 +48,17 @@ class UnitTest(unittest.TestCase):
             server_ip="127.0.0.1",
             port=7000)
         self.assertEqual(result.status_code, 200)
+        print(json.loads(result.text))
+
+        result = self.client_executor(
+            prompt="Tell me about Intel Xeon processors.",
+            server_ip="127.0.0.1",
+            port=7000,
+            stream=True)
+        self.assertEqual(result.status_code, 200)
+        for chunk in result.iter_lines(decode_unicode=False, delimiter=b"\0"):
+            print(chunk)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/intel_extension_for_transformers/neural_chat/tests/server/test_textchat_with_retrieval_server.py
+++ b/intel_extension_for_transformers/neural_chat/tests/server/test_textchat_with_retrieval_server.py
@@ -19,7 +19,6 @@ import subprocess
 import unittest
 import time
 import os
-import signal
 from intel_extension_for_transformers.neural_chat.server import TextChatClientExecutor
 
 class UnitTest(unittest.TestCase):

--- a/intel_extension_for_transformers/neural_chat/tests/server/test_voicechat_server.py
+++ b/intel_extension_for_transformers/neural_chat/tests/server/test_voicechat_server.py
@@ -19,7 +19,6 @@ import subprocess
 import unittest
 import os
 import time
-import signal
 from intel_extension_for_transformers.neural_chat.server import VoiceChatClientExecutor
 
 class UnitTest(unittest.TestCase):


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

Support streaming mode for neuralchat server.

## Expected Behavior & Potential Risk

Users can use model.generate streaming mode when deploy neuralchat server.

## How has this PR been tested?

Pre-CI and local test.

## Dependency Change?

No.