### PR TITLE
fix ordinals and conjunctions in tts normalizer

### DIFF
--- a/intel_extension_for_transformers/neural_chat/pipeline/plugins/audio/utils/english_normalizer.py
+++ b/intel_extension_for_transformers/neural_chat/pipeline/plugins/audio/utils/english_normalizer.py
@@ -81,7 +81,6 @@ class EnglishNormalizer:
             if word.isdigit(): # if word is positive integer, it must can be num2words
                 try:
                     potential_year = int(word)
-                    # We ignore the preposition here for demo TODO fix it in a more elegant way!
                     if prev.lower() in prepositions_year and potential_year < 2999 and potential_year > 1000 \
                           and potential_year % 1000 != 0:
                         word = num2words(word, to="year")

--- a/intel_extension_for_transformers/neural_chat/tests/audio/test_english_normalizer.py
+++ b/intel_extension_for_transformers/neural_chat/tests/audio/test_english_normalizer.py
@@ -40,7 +40,18 @@ class TestTTS(unittest.TestCase):
     def test_correct_year(self):
         text = "In 1986, there are more than 2000 people participating in that party."
         result = self.normalizer.correct_number(text)
-        self.assertEqual(result, "In nineteen eighty-six, there are more than two thousand people participating in that party.")
+        self.assertEqual(result, "In nineteen eightysix, there are more than two thousand people participating in that party.")
+
+    def test_correct_ordinal(self):
+        text = "1st 2nd 3rd 4th 5th 11th 12th 21st 22nd"
+        result = self.normalizer.correct_number(text)
+        self.assertEqual(result, "first second third fourth fifth eleventh twelfth twenty first twenty second.")
+
+    def test_correct_conjunctions(self):
+        text = "CVPR-15 ICML-21"
+        text = self.normalizer.correct_abbreviation(text)
+        result = self.normalizer.correct_number(text)
+        self.assertEqual(result, "cee vee pee ar fifteen I cee em el twenty-one.")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Type of Change

Bug fix

## Description

fix ordinals and conjunctions in tts normalizer

correctly handle following:
* conjunctions
CVPR-15 => cee vee pee ar fifteen
* ordinals
1st 2nd 3rd 4th 5th 11th 12th 21st 22nd => first second third fourth fifth eleventh twelfth twenty first twenty second


## Expected Behavior & Potential Risk

Make the normalizer more robust.

There still are some words such as `i7, ffmpeg, BTW` not spelled correctly and should be hardcoded maybe in an advanced Trie. Also, the potention number is only treated as a year when it has prepositions in front of it and between (1000,2999), which still is not an absolute mapping (e.g. in `Tom's 1986 report indicated that...`, 1986 should be a year but with no prepositions it is converted as cardinal number).

## How has this PR been tested?

add two UTs

## Dependency Change?

re should be built-in Python package