### PR TITLE
New avx512_vnni kernel

### DIFF
--- a/intel_extension_for_transformers/llm/library/jblas/jblas/jit_base.hpp
+++ b/intel_extension_for_transformers/llm/library/jblas/jblas/jit_base.hpp
@@ -90,6 +90,11 @@ class JitAvx2 : protected JitAvx {
  protected:
   static int constexpr VBits = 256;
   typedef Xbyak::Ymm vreg_t;
+
+  void loadbf16_f32(const Xbyak::Ymm& dst, const Xbyak::Address& addr) {
+    vpmovzxwd(dst, addr);
+    vpslld(dst, dst, 16);
+  }
 };
 
 class JitAvx512f : protected JitAvx2 {
@@ -186,6 +191,10 @@ class JitAvx512f : protected JitAvx2 {
 class JitAvx512_fp16 : protected JitAvx512f {};
 
 class JitAvx512vnni : protected JitAvx512f {
+ protected:
+};
+
+class JitAvxvnni : protected JitAvx2 {
  protected:
 };
 

--- a/intel_extension_for_transformers/llm/library/jblas/jblas/jit_blas.h
+++ b/intel_extension_for_transformers/llm/library/jblas/jblas/jit_blas.h
@@ -24,11 +24,12 @@ enum JBLAS_ISA {
   JblasNoSIMD = 10,
   JblasAVX = 11,
   JblasAVX2 = 12,
-  JblasAVX512F = 13,
-  JblasAVX512_VNNI = 14,
-  JblasAMX_BF16 = 15,
-  JblasAMX_INT8 = 16,
-  JblasAVX512_FP16 = 17,
+  JblasAVX_VNNI = 13,
+  JblasAVX512F = 14,
+  JblasAVX512_VNNI = 15,
+  JblasAMX_BF16 = 16,
+  JblasAMX_INT8 = 17,
+  JblasAVX512_FP16 = 18,
 };
 enum JBLAS_DTYPE {
   JblasF64 = 59,

--- a/intel_extension_for_transformers/llm/library/jblas/jblas/jit_blas_utils.h
+++ b/intel_extension_for_transformers/llm/library/jblas/jblas/jit_blas_utils.h
@@ -100,11 +100,9 @@ struct bf16 {
 #else
     bf16f32 tmp = {0.f};
     tmp.f32 = _v;
-#if 0
     // See document of VCVTNEPS2BF16 in Intel® 64 and IA-32 Architectures Software Developer’s Manual Volume 2
     const auto lsb = tmp.bf16[1] & 1;
     tmp.u += 0x7fff + lsb;
-#endif
     x = tmp.bf16[1];
 #endif
   }

--- a/intel_extension_for_transformers/llm/library/jblas/jblas/jit_blas_weight_compression.h
+++ b/intel_extension_for_transformers/llm/library/jblas/jblas/jit_blas_weight_compression.h
@@ -160,38 +160,19 @@ class StorageWeight4Bit {
   utils::aligned_vector<utils::bit4x2> mWeights;
 };
 
-template <typename SRC_T, typename DST_T>
+template <typename SRC_T, typename DST_T, typename RED_T>
 class StorageSimpleCorrection {
  public:
-  bool isSym = true;
   SRC_T* mSPtr = nullptr;
   DST_T* mZPtr = nullptr;
-  size_t mSSize;
+  RED_T* mRPtr = nullptr;
+  size_t mSSize = 0;
+  int mStep = 0;
 
-  StorageSimpleCorrection() : mSSize(0), isSym(true) {}
-  StorageSimpleCorrection(size_t _size, bool _is_sym, SRC_T src = SRC_T(0), DST_T dst = DST_T(0)) {
-    mSSize = _size;
+  void resize(int NPad, int KBlks, bool _is_sym = true, bool _has_reduce = true) {
     isSym = _is_sym;
-    mScales = utils::aligned_vector<SRC_T>(_size, src);
-    mSPtr = mScales.data();
-    if (!is_sym()) {
-      mZeroPoints = utils::aligned_vector<DST_T>(_size, dst);
-      mZPtr = mZeroPoints.data();
-    } else {
-      mZPtr = nullptr;
-    }
-  }
-
-  StorageSimpleCorrection(size_t _size, bool _is_sym, SRC_T* _scales, DST_T* _zeroPoints = nullptr, int memalloc = 0) {
-    static_assert(is_sym() && _zeroPoints == nullptr, "symmetric quantization means no zero points");
-    static_assert((!is_sym()) && (_zeroPoints != nullptr), "asymmetric quantization needs zero points");
-    isSym = _is_sym;
-    init_scales(_size, _scales, memalloc);
-    if (!is_sym()) init_zp(_size, _zeroPoints, memalloc);
-  }
-
-  void resize(int NPad, int KBlks, bool _is_sym = true) {
-    isSym = _is_sym;
+    hasReduce = _has_reduce;
+    mStep = NPad;
     mScales.resize((size_t)NPad * KBlks);
     mSPtr = mScales.data();
     if (!is_sym()) {
@@ -200,6 +181,12 @@ class StorageSimpleCorrection {
     } else {
       mZPtr = nullptr;
     }
+    if (has_reduce()) {
+      mReduce.resize((size_t)NPad * KBlks);
+      mRPtr = mReduce.data();
+    } else {
+      mRPtr = nullptr;
+    }
     mSSize = mScales.size();
   }
 
@@ -207,11 +194,9 @@ class StorageSimpleCorrection {
     if (memalloc) {
       mScales.resize(_size);
       std::memcpy(mScales.data(), _scales, _size * sizeof(SRC_T));
-      mSSize = mScales.size();
       mSPtr = mScales.data();
     } else {
       mSPtr = _scales;
-      mSSize = _size;
     }
   }
 
@@ -219,30 +204,46 @@ class StorageSimpleCorrection {
     if (memalloc) {
       mZeroPoints.resize(_size);
       std::memcpy(mZeroPoints.data(), _zeroPoints, _size * sizeof(DST_T));
-      mSSize = mZeroPoints.size();
       mZPtr = mZeroPoints.data();
     } else {
       mZPtr = _zeroPoints;
-      mSSize = _size;
+    }
+  }
+
+  void init_reduce(size_t _size, RED_T* _ptr, int memalloc = 0) {
+    if (memalloc) {
+      mReduce.resize(_size);
+      std::memcpy(mReduce.data(), _ptr, _size * sizeof(RED_T));
+      mRPtr = mReduce.data();
+    } else {
+      mRPtr = _ptr;
     }
   }
 
   constexpr bool is_sym() { return isSym; }
-  SRC_T* get_scales() { return mScales.data(); }
-  DST_T* get_zps() { return mZeroPoints.data(); }
-  inline size_t size() { return mScales.size() + mZeroPoints.size(); }
+  constexpr bool has_reduce() { return hasReduce; }
+  inline SRC_T* get_scales() { return mSPtr; }
+  inline DST_T* get_zps() { return mZPtr; }
+  inline RED_T* get_reduce() { return mRPtr; }
+  inline size_t size() { return mSSize; }
+  inline int get_step() { return mStep; }
 
  protected:
   size_t myDataSerializedSize() {
     size_t totalsize = 0;
     totalsize += sizeof(isSym);
+    totalsize += sizeof(hasReduce);
+    totalsize += sizeof(mStep);
     totalsize += sizeof(mSSize);
     totalsize += mSSize * sizeof(mSPtr[0]);
     if (!is_sym()) totalsize += mSSize * sizeof(mZPtr[0]);
+    if (has_reduce()) totalsize += mSSize * sizeof(mRPtr[0]);
     return totalsize;
   }
   void mySerializeDataToBuffer(int8_t*& wptr) {
     utils::serialize(wptr, isSym);
+    utils::serialize(wptr, hasReduce);
+    utils::serialize(wptr, mStep);
     utils::serialize(wptr, mSSize);
     for (size_t i = 0; i < mSSize; i++) {
       utils::serialize(wptr, mSPtr[i]);
@@ -252,95 +253,71 @@ class StorageSimpleCorrection {
         utils::serialize(wptr, mZPtr[i]);
       }
     }
+    if (has_reduce()) {
+      for (size_t i = 0; i < mSSize; i++) {
+        utils::serialize(wptr, mRPtr[i]);
+      }
+    }
   }
   void myDeserializeDataBuffer(int8_t*& rptr, int memalloc) {
     isSym = utils::deserialize<bool>(rptr);
-    size_t rsize = utils::deserialize<size_t>(rptr);
-    SRC_T* src_rptr = reinterpret_cast<SRC_T*>(rptr);
-    init_scales(rsize, src_rptr, memalloc);
-    rptr += rsize * sizeof(mScales[0]);
+    hasReduce = utils::deserialize<bool>(rptr);
+    mStep = utils::deserialize<int>(rptr);
+    mSSize = utils::deserialize<size_t>(rptr);
+    auto src_rptr = reinterpret_cast<SRC_T*>(rptr);
+    init_scales(mSSize, src_rptr, memalloc);
+    rptr += mSSize * sizeof(mScales[0]);
     if (!is_sym()) {
-      DST_T* dst_rptr = reinterpret_cast<DST_T*>(rptr);
-      init_zp(rsize, dst_rptr, memalloc);
-      rptr += rsize * sizeof(mZeroPoints[0]);
+      auto dst_rptr = reinterpret_cast<DST_T*>(rptr);
+      init_zp(mSSize, dst_rptr, memalloc);
+      rptr += mSSize * sizeof(mZeroPoints[0]);
+    }
+    if (has_reduce()) {
+      auto dst_rptr = reinterpret_cast<RED_T*>(rptr);
+      init_reduce(mSSize, dst_rptr, memalloc);
+      rptr += mSSize * sizeof(mZeroPoints[0]);
     }
   }
+  bool isSym = true;
+  bool hasReduce = false;
 
   utils::aligned_vector<SRC_T> mScales;
   utils::aligned_vector<DST_T> mZeroPoints;
-};
-
-template <typename T>
-class StorageWeightReduce {
- public:
-  T* mRPtr = NULL;
-  size_t mRSize = 0;
-
-  void resize(int NPad, int KBlks) {
-    mReduce.resize((size_t)NPad * KBlks);
-    mRPtr = mReduce.data();
-    mRSize = mReduce.size();
-  }
-
- protected:
-  size_t myDataSerializedSize() {
-    size_t totalsize = 0;
-    totalsize += sizeof(mRSize);
-    totalsize += mRSize * sizeof(mRPtr[0]);
-    return totalsize;
-  }
-  void mySerializeDataToBuffer(int8_t*& wptr) {
-    utils::serialize(wptr, mRSize);
-    for (size_t i = 0; i < mRSize; i++) {
-      utils::serialize(wptr, mRPtr[i]);
-    }
-  }
-  void myDeserializeDataBuffer(int8_t*& rptr, int memalloc) {
-    size_t rsize = utils::deserialize<size_t>(rptr);
-    if (memalloc) {
-      mReduce.resize(rsize);
-      std::memcpy(mReduce.data(), rptr, rsize * sizeof(mReduce[0]));
-      mRPtr = mReduce.data();
-      mRSize = mReduce.size();
-    } else {
-      mRPtr = (T*)rptr;
-      mRSize = rsize;
-    }
-    rptr += rsize * sizeof(mReduce[0]);
-  }
-  utils::aligned_vector<T> mReduce;
+  utils::aligned_vector<RED_T> mReduce;
 };
 
 class StorageWeightS8ScaleFp32 : public prologue::weight_comp::PackedWeightKBlock,
                                  public StorageWeight8Bit,
-                                 public StorageSimpleCorrection<float, int8_t> {
+                                 public StorageSimpleCorrection<float, int8_t, float> {
  public:
+  using QWeightType = StorageWeight8Bit;
+  using CorrectionType = StorageSimpleCorrection<float, int8_t, float>;
   StorageWeightS8ScaleFp32(jblas::gemm::GemmCoreType _type) : prologue::weight_comp::PackedWeightKBlock(_type) {
     mType = static_cast<int>(WeightCompType::WeightS8ScaleFp32);
   }
 
   void resize(int NPad, int KPad, int Block, bool IsSym = true) {
     PackedWeightKBlock::resize(NPad, KPad, Block);
-    StorageWeight8Bit::resize(NPad, KPad);
+    QWeightType::resize(NPad, KPad);
     int nk_scale = utils::updiv(KPad, Block);
-    StorageSimpleCorrection<float, int8_t>::resize(NPad, nk_scale, IsSym);
+    CorrectionType::resize(NPad, nk_scale, IsSym,
+                           true);  // create reduce space for weight which may use int8 compute type
   }
 
  protected:
   virtual size_t getDataSerializedSize() override {
-    size_t totalsize =
-        StorageWeight8Bit::myDataSerializedSize() + StorageSimpleCorrection<float, int8_t>::myDataSerializedSize();
+    size_t totalsize = QWeightType::myDataSerializedSize() + CorrectionType::myDataSerializedSize();
     return totalsize;
   }
   virtual void serializeDataToBuffer(void* buf) override {
     auto wptr = reinterpret_cast<int8_t*>(buf);
-    StorageWeight8Bit::mySerializeDataToBuffer(wptr);
-    StorageSimpleCorrection<float, int8_t>::mySerializeDataToBuffer(wptr);
+    QWeightType::mySerializeDataToBuffer(wptr);
+    CorrectionType::mySerializeDataToBuffer(wptr);
   }
   virtual void deserializeDataBuffer(void* buf, int memalloc) override {
     auto rptr = reinterpret_cast<int8_t*>(buf);
-    StorageWeight8Bit::myDeserializeDataBuffer(rptr, memalloc);
-    StorageSimpleCorrection<float, int8_t>::myDeserializeDataBuffer(rptr, memalloc);
+    QWeightType::myDeserializeDataBuffer(rptr, memalloc);
+    CorrectionType::myDeserializeDataBuffer(rptr, memalloc);
   }
 };
 
@@ -394,7 +371,8 @@ class WeightS8ScaleFp32 {
     auto ptr = dynamic_cast<PackedWeightKBlock*>(stor);
     if (ptr) {
       int nk_scale = utils::updiv(K, ptr->mBlockSize);
-      StorageSimpleCorrection<float, int8_t> corr(N * nk_scale, is_sym);
+      StorageSimpleCorrection<float, int8_t, float> corr;
+      corr.resize(N, nk_scale, is_sym, false);
       quantizeWeight(N, K, B, ldb, ptr->mBlockSize, tmpq.data(), corr.get_scales(), corr.get_zps());
       packQWeight(N, K, tmpq.data(), ldb, corr.get_scales(), corr.get_zps(), stor);
     }
@@ -472,7 +450,39 @@ class WeightS8ScaleFp32 {
           }
         }
       }
+
       reorderWeight(N, K, B, ldb, stor->mWPtr);
+      if (stor->has_reduce()) {
+        utils::avector<float> deq(K * N);
+        unpackWeight(N, K, stor, deq.data(), N);
+        reduceWeight(N, K, stor->mBlockSize, deq.data(), ldb, stor->mRPtr, stor->mNPad);
+      }
+    }
+  }
+
+  void reduceWeight(const int N, const int K, const int KBlock, const float* B, const int ldb, float* rptr,
+                    const int ldr) {
+    utils::parallel::Parallel2DRowMajor _para;
+    utils::CpuBase cb;
+    _para.update(K, N, KBlock, 16, cb.mNumThreads);
+    omp_set_num_threads(cb.mNumThreads);
+#pragma omp parallel
+    {
+      int tidx = omp_get_thread_num();
+      int colidx, rowidx, rowsize, colsize;
+      _para.getIndex(tidx, &rowidx, &colidx, &rowsize, &colsize);
+      if (rowsize > 0 && colsize > 0) {
+        int colremain = utils::remainsize(colidx, N, colsize);
+        const auto src = B + rowidx * ldb + colidx;
+        const auto dst = rptr + colidx + rowidx / KBlock * ldr;
+        using RowReduceSum = kernel::wrapper::RowReduceSum<float>;
+        for (int i = 0; i < rowsize; i += KBlock) {
+          int rowremain = utils::remainsize(rowidx + i, K, KBlock);
+          auto ret = RowReduceSum::template forward<ISA_T>(  //
+              src + i * ldb, ldb, rowremain, colremain, dst + i / KBlock * ldr);
+          assert(ret == JblasSuccess);
+        }
+      }
     }
   }
 
@@ -531,6 +541,20 @@ class WeightS8ScaleFp32 {
     }
     return JblasInvalidParam;
   }
+
+  virtual JBLAS_CODE getReduce(float** dstptr, int* dststep, int n_size, int k_size, int n_offset, int k_offset,
+                               const Param& _param) {
+    auto wptr = dynamic_cast<const StorageWeight*>(_param.packedW);
+    if (wptr) {
+      auto NPad = wptr->mNPad;
+      auto KPad = wptr->mKPad;
+      *dstptr = wptr->mRPtr + n_offset + k_offset / wptr->mBlockSize * NPad;
+      *dststep = NPad;
+      return JblasSuccess;
+    }
+    return JblasInvalidParam;
+  }
+
   virtual JBLAS_CODE getZp(int8_t** dstptr, int* dststep, int n_size, int k_size, int n_offset, int k_offset,
                            const Param& _param) {
     auto wptr = dynamic_cast<const StorageWeight*>(_param.packedW);
@@ -601,37 +625,17 @@ class WeightS8ScaleFp32 {
   }
 };
 
-class StorageWeightS8ScaleFp32PerChannelN : public StorageWeightS8ScaleFp32, public StorageWeightReduce<float> {
+class StorageWeightS8ScaleFp32PerChannelN : public StorageWeightS8ScaleFp32 {
  public:
+  using Parent = StorageWeightS8ScaleFp32;
   StorageWeightS8ScaleFp32PerChannelN(jblas::gemm::GemmCoreType _type) : StorageWeightS8ScaleFp32(_type) {
     mType = static_cast<int>(WeightCompType::WeightS8ScaleFp32PerChannelN);
   }
 
   void resize(int NPad, int KPad, int K, bool IsSym = true) {
-    PackedWeightKBlock::resize(NPad, KPad, K);  // kblock==K
+    PackedWeightKBlock::resize(NPad, KPad, K);
     StorageWeight8Bit::resize(NPad, KPad);
-    StorageSimpleCorrection<float, int8_t>::resize(NPad, 1, IsSym);
-    StorageWeightReduce<float>::resize(NPad, 1);
-  }
-
- protected:
-  virtual size_t getDataSerializedSize() override {
-    size_t totalsize = StorageWeight8Bit::myDataSerializedSize() +
-                       StorageSimpleCorrection<float, int8_t>::myDataSerializedSize() +
-                       StorageWeightReduce<float>::myDataSerializedSize();
-    return totalsize;
-  }
-  virtual void serializeDataToBuffer(void* buf) override {
-    auto wptr = reinterpret_cast<int8_t*>(buf);
-    StorageWeight8Bit::mySerializeDataToBuffer(wptr);
-    StorageSimpleCorrection<float, int8_t>::mySerializeDataToBuffer(wptr);
-    StorageWeightReduce<float>::mySerializeDataToBuffer(wptr);
-  }
-  virtual void deserializeDataBuffer(void* buf, int memalloc) override {
-    auto rptr = reinterpret_cast<int8_t*>(buf);
-    StorageWeight8Bit::myDeserializeDataBuffer(rptr, memalloc);
-    StorageSimpleCorrection<float, int8_t>::myDeserializeDataBuffer(rptr, memalloc);
-    StorageWeightReduce<float>::myDeserializeDataBuffer(rptr, memalloc);
+    Parent::CorrectionType::resize(NPad, 1, IsSym, true);  // force block number==1, updiv(KPad,K) may get 2
   }
 };
 
@@ -667,40 +671,16 @@ class WeightS8ScaleFp32PerChannelN : public WeightS8ScaleFp32<_GemmCore_T, ISA_T
       WeightS8ScaleFp32<_GemmCore_T, ISA_T>::reorderWeight(N, K, B, ldb, stor->mWPtr);
       utils::avector<float> deq(K * N);
       WeightS8ScaleFp32<_GemmCore_T, ISA_T>::unpackWeight(N, K, stor, deq.data(), N);
-      reduceWeight(N, K, deq.data(), ldb, stor->mRPtr);
-    }
-  }
-
- protected:
-  void reduceWeight(const int N, const int K, const float* B, const int ldb, float* rptr) {
-    utils::parallel::Parallel2DRowMajor _para;
-    utils::CpuBase cb;
-    _para.update(K, N, K, 16, cb.mNumThreads);
-    omp_set_num_threads(cb.mNumThreads);
-#pragma omp parallel
-    {
-      int tidx = omp_get_thread_num();
-      int colidx, rowidx, rowsize, colsize;
-      _para.getIndex(tidx, &rowidx, &colidx, &rowsize, &colsize);
-      if (rowsize > 0 && colsize > 0) {
-        int rowremain = utils::remainsize(rowidx, K,
-                                          rowsize);  // rowremain: src valid size. rowsize: padded size
-        int colremain = utils::remainsize(colidx, N, colsize);
-        const auto src = B + rowidx * ldb + colidx;
-        const auto dst = rptr + colidx;
-        using RowReduceSum = kernel::wrapper::RowReduceSum<float>;
-        auto ret = RowReduceSum::template forward<ISA_T>(  //
-            src, ldb, rowremain, colremain, dst);
-        assert(ret == JblasSuccess);
-      }
+      WeightS8ScaleFp32<_GemmCore_T, ISA_T>::reduceWeight(N, K, K, deq.data(), ldb, stor->mRPtr, stor->mNPad);
     }
   }
 };
 
 class StorageWeightS4ScaleFp32 : public prologue::weight_comp::PackedWeightKBlock,
                                  public StorageWeight4Bit,
-                                 public StorageSimpleCorrection<float, int8_t> {
+                                 public StorageSimpleCorrection<float, int8_t, float> {
  public:
+  using CorrectionType = StorageSimpleCorrection<float, int8_t, float>;
   StorageWeightS4ScaleFp32(jblas::gemm::GemmCoreType _gemm_core_type, JBLAS_SIGN_INT_TYPE _s4_type = S4_UNDEF)
       : prologue::weight_comp::PackedWeightKBlock(_gemm_core_type) {
     switch (_s4_type) {
@@ -719,24 +699,23 @@ class StorageWeightS4ScaleFp32 : public prologue::weight_comp::PackedWeightKBloc
     PackedWeightKBlock::resize(NPad, KPad, Block);
     StorageWeight4Bit::resize(NPad, KPad);
     int nk_scale = utils::updiv(KPad, Block);
-    StorageSimpleCorrection<float, int8_t>::resize(NPad, nk_scale, IsSym);
+    CorrectionType::resize(NPad, nk_scale, IsSym, true);
   }
 
  protected:
   virtual size_t getDataSerializedSize() override {
-    size_t totalsize =
-        StorageWeight4Bit::myDataSerializedSize() + StorageSimpleCorrection<float, int8_t>::myDataSerializedSize();
+    size_t totalsize = StorageWeight4Bit::myDataSerializedSize() + CorrectionType::myDataSerializedSize();
     return totalsize;
   }
   virtual void serializeDataToBuffer(void* buf) override {
     auto wptr = reinterpret_cast<int8_t*>(buf);
     StorageWeight4Bit::mySerializeDataToBuffer(wptr);
-    StorageSimpleCorrection<float, int8_t>::mySerializeDataToBuffer(wptr);
+    CorrectionType::mySerializeDataToBuffer(wptr);
   }
   virtual void deserializeDataBuffer(void* buf, int memalloc) override {
     auto rptr = reinterpret_cast<int8_t*>(buf);
     StorageWeight4Bit::myDeserializeDataBuffer(rptr, memalloc);
-    StorageSimpleCorrection<float, int8_t>::myDeserializeDataBuffer(rptr, memalloc);
+    CorrectionType::myDeserializeDataBuffer(rptr, memalloc);
   }
 };
 
@@ -783,6 +762,12 @@ class WeightS4ScaleFp32 : public WeightS8ScaleFp32<_GemmCore_T, ISA_T> {
       utils::avector<int8_t> reorded(stor->mKPad * stor->mNPad);
       WeightS8ScaleFp32<_GemmCore_T, ISA_T>::reorderWeight(N, K, B, ldb, reorded.data());
       compressWeight(stor->mNPad, stor->mKPad, reorded.data(), stor->mNPad, stor->mWPtr);
+      if (stor->has_reduce()) {
+        utils::avector<float> deq(K * N);
+        WeightS8ScaleFp32<_GemmCore_T, ISA_T>::unpackWeight(N, K, stor, deq.data(), N);
+        WeightS8ScaleFp32<_GemmCore_T, ISA_T>::reduceWeight(N, K, stor->mBlockSize, deq.data(), ldb, stor->mRPtr,
+                                                            stor->mNPad);
+      }
     }
   }
 
@@ -891,14 +876,27 @@ class WeightS4ScaleFp32 : public WeightS8ScaleFp32<_GemmCore_T, ISA_T> {
     return JblasInvalidParam;
   }
 
+  virtual JBLAS_CODE getReduce(float** dstptr, int* dststep, int n_size, int k_size, int n_offset, int k_offset,
+                               const Param& _param) override {
+    auto wptr = dynamic_cast<const StorageWeight*>(_param.packedW);
+    if (wptr) {
+      auto NPad = wptr->mNPad;
+      auto KPad = wptr->mKPad;
+      *dstptr = wptr->mRPtr + n_offset + k_offset / wptr->mBlockSize * NPad;
+      *dststep = NPad;
+      return JblasSuccess;
+    }
+    return JblasInvalidParam;
+  }
+
   virtual JBLAS_CODE getZp(int8_t** dstptr, int* dststep, int n_size, int k_size, int n_offset, int k_offset,
                            const Param& _param) override {
     auto wptr = dynamic_cast<const StorageWeight*>(_param.packedW);
     if (wptr) {
       auto NPad = wptr->mNPad;
       auto KPad = wptr->mKPad;
-      *dstptr = wptr->mZPtr == nullptr ? nullptr : wptr->mZPtr + n_offset + k_offset / wptr->mBlockSize * NPad;
-      *dststep = NPad;
+      *dstptr = wptr->mZPtr == nullptr ? nullptr : wptr->mZPtr + n_offset + k_offset / wptr->mBlockSize * wptr->mStep;
+      *dststep = wptr->mStep;
       return JblasSuccess;
     }
     assert(false);
@@ -913,8 +911,9 @@ class WeightS4ScaleFp32 : public WeightS8ScaleFp32<_GemmCore_T, ISA_T> {
   }
 };
 
-class StorageWeightS4ScaleFp32PerChannelN : public StorageWeightS4ScaleFp32, public StorageWeightReduce<float> {
+class StorageWeightS4ScaleFp32PerChannelN : public StorageWeightS4ScaleFp32 {
  public:
+  using Parent = StorageWeightS4ScaleFp32;
   StorageWeightS4ScaleFp32PerChannelN(jblas::gemm::GemmCoreType _type, JBLAS_SIGN_INT_TYPE _s4_type = S4_UNDEF)
       : StorageWeightS4ScaleFp32(_type) {
     switch (_s4_type) {
@@ -928,30 +927,9 @@ class StorageWeightS4ScaleFp32PerChannelN : public StorageWeightS4ScaleFp32, pub
   }
 
   void resize(int NPad, int KPad, int K, bool IsSym = true) {
-    PackedWeightKBlock::resize(NPad, KPad, K);  // kblock==K
+    PackedWeightKBlock::resize(NPad, KPad, K);
     StorageWeight4Bit::resize(NPad, KPad);
-    StorageSimpleCorrection<float, int8_t>::resize(NPad, 1, IsSym);
-    StorageWeightReduce<float>::resize(NPad, 1);
-  }
-
- protected:
-  virtual size_t getDataSerializedSize() override {
-    size_t totalsize = StorageWeight4Bit::myDataSerializedSize() +
-                       StorageSimpleCorrection<float, int8_t>::myDataSerializedSize() +
-                       StorageWeightReduce<float>::myDataSerializedSize();
-    return totalsize;
-  }
-  virtual void serializeDataToBuffer(void* buf) override {
-    auto wptr = reinterpret_cast<int8_t*>(buf);
-    StorageWeight4Bit::mySerializeDataToBuffer(wptr);
-    StorageSimpleCorrection<float, int8_t>::mySerializeDataToBuffer(wptr);
-    StorageWeightReduce<float>::mySerializeDataToBuffer(wptr);
-  }
-  virtual void deserializeDataBuffer(void* buf, int memalloc) override {
-    auto rptr = reinterpret_cast<int8_t*>(buf);
-    StorageWeight4Bit::myDeserializeDataBuffer(rptr, memalloc);
-    StorageSimpleCorrection<float, int8_t>::myDeserializeDataBuffer(rptr, memalloc);
-    StorageWeightReduce<float>::myDeserializeDataBuffer(rptr, memalloc);
+    Parent::CorrectionType::resize(NPad, 1, IsSym, true);  // force block number = 1
   }
 };
 
@@ -988,7 +966,7 @@ class WeightS4ScaleFp32PerChannelN : public WeightS8ScaleFp32PerChannelN<_GemmCo
       compressWeight(stor->mNPad, stor->mKPad, reorded.data(), stor->mNPad, stor->mWPtr);
       utils::avector<float> deq(K * N);
       WeightS8ScaleFp32<_GemmCore_T, ISA_T>::unpackWeight(N, K, stor, deq.data(), N);
-      Parent::reduceWeight(N, K, deq.data(), ldb, stor->mRPtr);
+      WeightS8ScaleFp32<_GemmCore_T, ISA_T>::reduceWeight(N, K, K, deq.data(), ldb, stor->mRPtr, stor->mNPad);
     }
   }
 
@@ -1074,8 +1052,9 @@ using WeightS4ClipScaleFp32PerN = WeightS4ScaleFp32PerChannelN<_GemmCore_T, ISA_
 
 class StorageWeightS4ScaleBf16 : public prologue::weight_comp::PackedWeightKBlock,
                                  public StorageWeight4Bit,
-                                 public StorageSimpleCorrection<utils::bf16, int8_t> {
+                                 public StorageSimpleCorrection<utils::bf16, int8_t, float> {
  public:
+  using CorrectionType = StorageSimpleCorrection<utils::bf16, int8_t, float>;
   StorageWeightS4ScaleBf16(jblas::gemm::GemmCoreType _gemm_core_type, JBLAS_SIGN_INT_TYPE _s4_type = S4_UNDEF)
       : prologue::weight_comp::PackedWeightKBlock(_gemm_core_type) {
     switch (_s4_type) {
@@ -1094,24 +1073,23 @@ class StorageWeightS4ScaleBf16 : public prologue::weight_comp::PackedWeightKBloc
     PackedWeightKBlock::resize(NPad, KPad, Block);
     StorageWeight4Bit::resize(NPad, KPad);
     int nk_scale = utils::updiv(KPad, Block);
-    StorageSimpleCorrection<utils::bf16, int8_t>::resize(NPad, nk_scale, IsSym);
+    CorrectionType::resize(NPad, nk_scale, IsSym, true);
   }
 
  protected:
   virtual size_t getDataSerializedSize() override {
-    size_t totalsize = StorageWeight4Bit::myDataSerializedSize() +
-                       StorageSimpleCorrection<utils::bf16, int8_t>::myDataSerializedSize();
+    size_t totalsize = StorageWeight4Bit::myDataSerializedSize() + CorrectionType::myDataSerializedSize();
     return totalsize;
   }
   virtual void serializeDataToBuffer(void* buf) override {
     auto wptr = reinterpret_cast<int8_t*>(buf);
     StorageWeight4Bit::mySerializeDataToBuffer(wptr);
-    StorageSimpleCorrection<utils::bf16, int8_t>::mySerializeDataToBuffer(wptr);
+    CorrectionType::mySerializeDataToBuffer(wptr);
   }
   virtual void deserializeDataBuffer(void* buf, int memalloc) override {
     auto rptr = reinterpret_cast<int8_t*>(buf);
     StorageWeight4Bit::myDeserializeDataBuffer(rptr, memalloc);
-    StorageSimpleCorrection<utils::bf16, int8_t>::myDeserializeDataBuffer(rptr, memalloc);
+    CorrectionType::myDeserializeDataBuffer(rptr, memalloc);
   }
 };
 
@@ -1263,6 +1241,13 @@ class StorageWeightF4ScaleFp32 : public StorageWeightS4ScaleFp32 {
       default:
         break;
     }
+  }
+
+  void resize(int NPad, int KPad, int Block, bool IsSym = true) {
+    PackedWeightKBlock::resize(NPad, KPad, Block);
+    StorageWeight4Bit::resize(NPad, KPad);
+    int nk_scale = utils::updiv(KPad, Block);
+    CorrectionType::resize(NPad, nk_scale, IsSym, false);
   }
 };
 
@@ -1528,6 +1513,109 @@ class GemmSLauncherKBlockPackWeight {
         mGemmCore.forward(aptr_cache, bptr_cache, cptr_cache, azp_ptr, ascale_ptr, ascale_step, wscale_ptr, wscale_step,
                           m_remain, n_padded, k_padded, blkptr->mBlockSize, acache_step * sizeof(AType), bcache_stride,
                           _config.NStep * sizeof(CType), iterk);
+      }
+    }
+    mEpilogue.forward(c_block_ptr, _config.NStep, (_config.rowidx + blk_m), _config.colidx + blk_n, blk_msize,
+                      blk_nsize, _param.paramC, ops...);
+  }
+};
+
+template <JBLAS_ISA _RT_ISA_T, class _GemmCore_T, template <class _T, JBLAS_ISA> class _PrologueA_T,
+          template <class _T, JBLAS_ISA> class _PrologueB_T, template <JBLAS_ISA> class _Epilogue_T>
+class GemmLauncherKBlock {
+ public:
+  static JBLAS_ISA constexpr RT_ISA = _RT_ISA_T;
+  using GemmCore = _GemmCore_T;
+  using PrologueA = _PrologueA_T<GemmCore, _RT_ISA_T>;
+  using PrologueB = _PrologueB_T<GemmCore, _RT_ISA_T>;
+  using Epilogue = _Epilogue_T<_RT_ISA_T>;
+  using AType = typename GemmCore::AType;
+  using AParam = typename PrologueA::Param;
+  using QuanAParam = typename PrologueA::QParam;
+  using BType = typename GemmCore::BType;
+  using BParam = typename PrologueB::Param;
+  using BSType = typename PrologueB::SType;
+  using CType = typename GemmCore::CType;
+  using EpiParam = typename Epilogue::Param;
+  static_assert(GemmCore::ISA <= _RT_ISA_T, "RunTime ISA should cover GEMM's ISA");
+  struct Param {
+    const int M, N, K;
+    const AParam paramA;
+    const BParam paramB;
+    const EpiParam paramC;
+    void* workspace;
+  };
+  struct ParallelConfig {
+    const int rowidx, colidx;
+    const int rowsize, colsize;
+    const int MStep, NStep, KStep;
+    const size_t StackSize;
+  };
+  GemmCore mGemmCore;
+  PrologueA mProA;
+  PrologueB mProB;
+  Epilogue mEpilogue;
+
+  template <typename... Eltops>
+  void launch(const ParallelConfig& _config, const Param& _param, Eltops... ops) {
+    auto blkptr = dynamic_cast<const prologue::weight_comp::PackedWeightKBlock*>(_param.paramB.packedW);
+    if (blkptr == nullptr) {
+      return;
+    }
+    int rowremain = utils::remainsize(_config.rowidx, _param.M, _config.rowsize);
+    int colremain = utils::remainsize(_config.colidx, _param.N, _config.colsize);
+    auto StackTmp = alloca(_config.StackSize);
+    auto tmpB = (BType*)(StackTmp);
+    auto tmpA = (AType*)(tmpB + _config.NStep * _config.KStep);
+    auto tmpC = (CType*)(tmpA + GemmCore::MTILE * _config.KStep);
+    for (int itern = 0; itern < colremain; itern += _config.NStep) {
+      int n_remain = utils::remainsize(itern, colremain, _config.NStep);
+      for (int iterm = 0; iterm < rowremain; iterm += _config.MStep) {
+        int m_remain = utils::remainsize(iterm, rowremain, _config.MStep);
+        run_block(_config, _param, blkptr, iterm, itern, m_remain, n_remain, tmpA, tmpB, tmpC, ops...);
+      }
+    }
+  }
+
+ protected:
+  template <typename... Eltops>
+  void run_block(const ParallelConfig& _config, const Param& _param,
+                 const prologue::weight_comp::PackedWeightKBlock* blkptr, int blk_m, int blk_n, int blk_msize,
+                 int blk_nsize, AType* tmpA, BType* tmpB, CType* tmpC, Eltops... ops) {
+    int n_padded = utils::padto(blk_nsize, GemmCore::NTILE);
+    auto c_tile_ptr = tmpC;
+    auto c_block_ptr = (float*)(c_tile_ptr + GemmCore::NTILE * GemmCore::MTILE);
+    for (int iterk = 0; iterk < _param.K; iterk += _config.KStep) {
+      int k_remain = utils::remainsize(iterk, _param.K, _config.KStep);
+      int k_padded = utils::padto(k_remain, GemmCore::KTILE);
+      auto bptr_cache = tmpB;
+      int bcache_step = 0;
+      mProB.getWeight(&bptr_cache, &bcache_step, k_padded, n_padded, iterk, _config.colidx + blk_n, _param.paramB);
+      BSType* wscale_ptr = nullptr;
+      int wscale_step = 0;
+      mProB.getScale(&wscale_ptr, &wscale_step, n_padded, k_padded, (blk_n + _config.colidx), iterk, _param.paramB);
+      float* reduce_ptr = nullptr;
+      mProB.getReduce(&reduce_ptr, &wscale_step, n_padded, k_padded, (blk_n + _config.colidx), iterk, _param.paramB);
+      int bcache_stride = bcache_step * sizeof(BType);
+      for (int i = 0; i < blk_msize; i += GemmCore::MTILE) {
+        int m_remain = utils::remainsize(i, blk_msize, GemmCore::MTILE);
+        auto cptr_cache = c_block_ptr + i * _config.NStep;
+        int ccache_stride = _config.NStep * sizeof(CType);
+
+        AType* aptr_cache = nullptr;
+        int acache_step = 0;
+        mProA.getActivation(&aptr_cache, &acache_step, _param.paramA, m_remain, k_padded, (blk_m + i + _config.rowidx),
+                            iterk);
+        float* ascale_ptr = nullptr;
+        int ascale_step = 0;
+        mProA.getScale(&ascale_ptr, &ascale_step, _param.paramA, m_remain, k_padded, (blk_m + i + _config.rowidx),
+                       iterk);
+        AType* azp_ptr = tmpA;
+        int azp_step = _config.KStep;
+        mProA.getZp(&azp_ptr, &azp_step, _param.paramA, m_remain, k_padded, (blk_m + i + _config.rowidx), iterk);
+        mGemmCore.forward(aptr_cache, bptr_cache, cptr_cache, azp_ptr, ascale_ptr, ascale_step, wscale_ptr, reduce_ptr,
+                          wscale_step, m_remain, n_padded, k_padded, blkptr->mBlockSize, acache_step * sizeof(AType),
+                          bcache_stride, _config.NStep * sizeof(CType), iterk);
       }
     }
     mEpilogue.forward(c_block_ptr, _config.NStep, (_config.rowidx + blk_m), _config.colidx + blk_n, blk_msize,

--- a/intel_extension_for_transformers/llm/library/jblas/jblas/jit_blas_wrapper.h
+++ b/intel_extension_for_transformers/llm/library/jblas/jblas/jit_blas_wrapper.h
@@ -209,6 +209,28 @@ class GemmInterfaceParallelAB {
 namespace gemm_default {
 template <class T>
 using DefaultParallel = jblas::utils::parallel::Parallel2DGemm<T>;
+namespace avx2 {
+JBLAS_ISA constexpr DefaultISA = JblasAVX2;
+using GemmKernel = jblas::wrapper::gemm_pack_weight::GemmInterfacePackWeight<
+    jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<  //
+        DefaultISA,                                            //
+        jblas::gemm::GemmCore_Row_NN_4x24_AVX2,             //
+        jblas::prologue::gemm::ActivationBase,                 //
+        jblas::prologue::gemm::WeightPack,                     //
+        jblas::epilogue::gemm::AccumulatorWriteBackFp32>,
+    DefaultParallel>;
+}
+namespace avx_vnni {
+JBLAS_ISA constexpr DefaultISA = JblasAVX_VNNI;
+using GemmKernel48 = jblas::wrapper::gemm_pack_weight::GemmInterfacePackWeight<
+    jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<  //
+        DefaultISA,                                            //
+        jblas::gemm::GemmCore_Row_NN_2x48_AVX_VNNI,         //
+        jblas::prologue::gemm::ActivationBase,                 //
+        jblas::prologue::gemm::WeightPack,                     //
+        jblas::epilogue::gemm::AlphaBetaProcessS32U8>,
+    DefaultParallel>;
+}
 namespace avx512f {
 JBLAS_ISA constexpr DefaultISA = JblasAVX512F;
 using GemmKernel = jblas::wrapper::gemm_pack_weight::GemmInterfacePackWeight<
@@ -237,7 +259,7 @@ using GemmKernelDynamicU8 = jblas::wrapper::gemm_pack_weight::GemmInterfaceParal
         jblas::gemm::GemmCore_Row_NN_8x48_AVX512_VNNI,         //
         jblas::prologue::gemm::ActivationFp32AsymU8Quantize,   //
         jblas::prologue::gemm::WeightPack,                     //
-        jblas::epilogue::gemm::DequantInt32ToFp32>,
+        jblas::epilogue::gemm::ZpDequantInt32ToFp32>,
     DefaultParallel>;
 }  // namespace avx512_vnni
 

--- a/intel_extension_for_transformers/llm/library/jblas/jblas/kernel_avx2.h
+++ b/intel_extension_for_transformers/llm/library/jblas/jblas/kernel_avx2.h
@@ -111,10 +111,12 @@ JBLAS_CODE dequant_kblock_s8_f32_fwd(int8_t* srcptr, float* dstptr, int row, int
     auto sptr = scales + kpos * NPad;
     int j = 0;
     for (; j < simd_process_num; j += Vlen) {
-      auto s8_ymm_v = _mm_loadl_epi64(reinterpret_cast<__m128i_u*>( srcptr + i * ld_src + j));
+      auto s8_ymm_v = _mm_loadl_epi64(reinterpret_cast<__m128i*>(srcptr + i * ld_src + j));
       auto s32_ymm_v = _mm256_cvtepi8_epi32(s8_ymm_v);
       if constexpr (WITH_ZP) {
-        s32_ymm_v = _mm256_sub_epi32(s32_ymm_v, _mm256_cvtepi8_epi32(_mm_loadl_epi64(reinterpret_cast<__m128i_u*>( zero_points + kpos * NPad + j))));
+        s32_ymm_v = _mm256_sub_epi32(
+            s32_ymm_v,
+            _mm256_cvtepi8_epi32(_mm_loadl_epi64(reinterpret_cast<__m128i*>(zero_points + kpos * NPad + j))));
       }
       auto f32_ymm_v = _mm256_cvtepi32_ps(s32_ymm_v);
       f32_ymm_v = _mm256_mul_ps(f32_ymm_v, _mm256_loadu_ps(sptr + j));
@@ -398,6 +400,49 @@ static inline JBLAS_CODE bf16_cvt_fp32_2D_write_back(const utils::bf16* src_ptr,
       *(dst + j) = (src + j)->tofloat();
     }
     if (zeropadding && npadding) std::memset(dst + col, 0, npadding);
+  }
+  return JblasSuccess;
+}
+
+static const uint8_t avx2_bf16_convert_maigc_num[32] = {
+    0x02, 0x03, 0x06, 0x07, 0x0a, 0x0b, 0x0e, 0x0f, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
+    0x02, 0x03, 0x06, 0x07, 0x0a, 0x0b, 0x0e, 0x0f, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80};
+
+static inline __m128i cvt_fp32_to_bf16(const __m256 src, __m256i* and_helper, __m256i* add_helper) {
+  auto shuffle_v = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(avx2_bf16_convert_maigc_num));
+  auto round_bias = _mm256_castps_si256(src);
+  round_bias = _mm256_and_si256(*and_helper, _mm256_srli_si256(round_bias, 2));
+  round_bias = _mm256_add_epi32(round_bias, *add_helper);
+  auto round_fp32_v = _mm256_add_epi32(_mm256_castps_si256(src), round_bias);
+  __m256i trunc_elements = _mm256_shuffle_epi8(round_fp32_v, shuffle_v);
+  __m256i ordered = _mm256_permute4x64_epi64(trunc_elements, 0x58);
+  return _mm256_castsi256_si128(ordered);
+}
+
+static inline JBLAS_CODE fp32_cvt_bf16_2D_write_back(const void* raw_srcptr, void* raw_dstptr, int row, int col,
+                                                     int srcstride, int dststride, bool zeropadding) {
+  char* srcptr = (char*)raw_srcptr;
+  char* dstptr = (char*)raw_dstptr;
+  constexpr int simd_proc_elt = 8;
+  auto bf16_and_helper = _mm256_set1_epi32(0X00000001);
+  auto bf16_add_helper = _mm256_set1_epi32(0x00007FFF);
+  auto col_body_loop = col / simd_proc_elt * simd_proc_elt;
+  int npadding = dststride - col * sizeof(utils::bf16);
+  for (int i = 0; i < row; i++) {
+    auto src = srcptr + i * srcstride;
+    auto dst = dstptr + i * dststride;
+    int j = 0;
+    for (; j < col_body_loop; j += simd_proc_elt) {
+      auto pack_bf16_value =
+          cvt_fp32_to_bf16(_mm256_loadu_ps(reinterpret_cast<float*>(src) + j), &bf16_and_helper, &bf16_add_helper);
+      _mm_storeu_si128((__m128i*)(dst + j * sizeof(jblas::utils::bf16)), pack_bf16_value);
+    }
+    for (; j < col; j++) {
+      (reinterpret_cast<jblas::utils::bf16*>(dst) + j)->fromfloat(*(reinterpret_cast<float*>(src) + j));
+    }
+    if (zeropadding && npadding) {
+      std::memset(dst + col * sizeof(utils::bf16), 0, npadding);
+    }
   }
   return JblasSuccess;
 }

--- a/intel_extension_for_transformers/llm/library/jblas/jblas/kernel_avx512_bf16.h
+++ b/intel_extension_for_transformers/llm/library/jblas/jblas/kernel_avx512_bf16.h
@@ -1,0 +1,84 @@
+//  Copyright (c) 2023 Intel Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+#pragma once
+#include <immintrin.h>
+#include "kernel_avx512f.h"
+#include "jit_blas_utils.h"
+
+namespace jblas {
+namespace kernel {
+namespace avx512_bf16 {
+
+static inline JBLAS_CODE bf16_cvt_fp32_2D_write_back(const utils::bf16* src_ptr, float* dst_ptr, int row, int col,
+                                                     int src_step, int dst_step, bool zeropadding) {
+#if CompileBF16()
+  const int npadding = (dst_step - col) * sizeof(float);
+  constexpr int simd_proc_elt = 16;
+  auto col_body = col / simd_proc_elt * simd_proc_elt;
+  auto col_tail = col % simd_proc_elt;
+  const auto tail_mask = _cvtu32_mask16((1U << col_tail) - 1);
+  for (int i = 0; i < row; i++) {
+    auto src = const_cast<utils::bf16*>(src_ptr + i * src_step);
+    auto dst = dst_ptr + i * dst_step;
+    int j = 0;
+    for (; j < col_body; j += simd_proc_elt)
+      _mm512_storeu_ps(dst + j, _mm512_cvtpbh_ps((__m256bh)_mm256_loadu_ps(reinterpret_cast<float*>(src + j))));
+    if (col_tail > 0)
+      _mm512_mask_storeu_ps(dst + j, tail_mask,
+                            _mm512_cvtpbh_ps((__m256bh)_mm256_loadu_ps(reinterpret_cast<float*>(src + j))));
+    if (zeropadding && npadding) std::memset(dst + col, 0, npadding);
+  }
+  return JblasSuccess;
+#endif
+  return avx512f::bf16_cvt_fp32_2D_write_back(src_ptr, dst_ptr, row, col, src_step, dst_step, zeropadding);
+}
+
+static inline JBLAS_CODE fp32_cvt_bf16_2D_write_back(const void* raw_srcptr, void* raw_dstptr, int row, int col,
+                                                     int srcstride, int dststride, bool zeropadding) {
+#if CompileBF16()
+  char* srcptr = (char*)raw_srcptr;
+  char* dstptr = (char*)raw_dstptr;
+  constexpr int simd_proc_elt = 32;
+  auto col_body_loop = col / simd_proc_elt;
+  auto col_tail = col % simd_proc_elt;
+  const uint32_t tail_mask = (1U << col_tail) - 1;
+  int npadding = dststride - col * sizeof(utils::bf16);
+  for (int i = 0; i < row; i++) {
+    auto src = srcptr + i * srcstride;
+    auto dst = dstptr + i * dststride;
+    int j = 0;
+    for (; j < col_body_loop; j++) {
+      _mm512_storeu_epi16(
+          (dst + (j * simd_proc_elt) * sizeof(jblas::utils::bf16)),
+          (__m512i)_mm512_cvtne2ps_pbh(_mm512_loadu_ps(src + sizeof(float) * simd_proc_elt * j + sizeof(float) * 16),
+                                       _mm512_loadu_ps(src + sizeof(float) * simd_proc_elt * j + sizeof(float) * 0)));
+    }
+    if (col_tail > 0) {
+      _mm512_mask_storeu_epi16(
+          (dst + (j * simd_proc_elt) * sizeof(jblas::utils::bf16)), tail_mask,  //
+          (__m512i)_mm512_cvtne2ps_pbh(
+              _mm512_maskz_loadu_ps(tail_mask >> 16, src + sizeof(float) * simd_proc_elt * j + sizeof(float) * 16),
+              _mm512_maskz_loadu_ps(tail_mask >> 0, src + sizeof(float) * simd_proc_elt * j + sizeof(float) * 0)));
+    }
+    if (zeropadding && npadding) {
+      std::memset(dst + col * sizeof(utils::bf16), 0, npadding);
+    }
+  }
+#endif
+  return avx512f::fp32_cvt_bf16_2D_write_back(raw_srcptr, raw_dstptr, row, col, srcstride, dststride, zeropadding);
+}
+
+}  // namespace avx512_bf16
+}  // namespace kernel
+}  // namespace jblas

--- a/intel_extension_for_transformers/llm/library/jblas/jblas/kernel_avx512f.h
+++ b/intel_extension_for_transformers/llm/library/jblas/jblas/kernel_avx512f.h
@@ -910,51 +910,31 @@ static inline JBLAS_CODE fp32_cvt_bf16_2D_write_back(const void* raw_srcptr, voi
                                                      int srcstride, int dststride, bool zeropadding) {
   char* srcptr = (char*)raw_srcptr;
   char* dstptr = (char*)raw_dstptr;
-#if CompileBF16()
-  constexpr int simd_proc_elt = 32;
-  auto col_body_loop = col / simd_proc_elt;
-  auto col_tail = col % simd_proc_elt;
-  const uint32_t tail_mask = (1U << col_tail) - 1;
-  int npadding = dststride - col * sizeof(utils::bf16);
-  for (int i = 0; i < row; i++) {
-    auto src = srcptr + i * srcstride;
-    auto dst = dstptr + i * dststride;
-    int j = 0;
-    for (; j < col_body_loop; j++) {
-      _mm512_storeu_epi16(
-          (dst + (j * simd_proc_elt) * sizeof(jblas::utils::bf16)),
-          (__m512i)_mm512_cvtne2ps_pbh(_mm512_loadu_ps(src + sizeof(float) * simd_proc_elt * j + sizeof(float) * 16),
-                                       _mm512_loadu_ps(src + sizeof(float) * simd_proc_elt * j + sizeof(float) * 0)));
-    }
-    if (col_tail > 0) {
-      _mm512_mask_storeu_epi16(
-          (dst + (j * simd_proc_elt) * sizeof(jblas::utils::bf16)), tail_mask,  //
-          (__m512i)_mm512_cvtne2ps_pbh(
-              _mm512_maskz_loadu_ps(tail_mask >> 16, src + sizeof(float) * simd_proc_elt * j + sizeof(float) * 16),
-              _mm512_maskz_loadu_ps(tail_mask >> 0, src + sizeof(float) * simd_proc_elt * j + sizeof(float) * 0)));
-    }
-    if (zeropadding && npadding) {
-      std::memset(dst + col * sizeof(utils::bf16), 0, npadding);
-    }
-  }
-#else
   constexpr int simd_proc_elt = 16;
   auto col_body_loop = col / simd_proc_elt;
   auto col_tail = col % simd_proc_elt;
   auto tail_mask = _cvtu32_mask16(0xffff >> (16 - col_tail));
   int npadding = dststride - col * sizeof(utils::bf16);
+  auto bf16_and_helper = _mm512_set1_epi32(0x00000001);
+  auto bf16_add_helper = _mm512_set1_epi32(0X00007FFF);
   for (int i = 0; i < row; i++) {
     auto src = srcptr + i * srcstride;
     auto dst = dstptr + i * dststride;
     int j = 0;
     for (; j < col_body_loop; j++) {
-      auto pack_bf16_value =
-          _mm512_cvtepi32_epi16(_mm512_srli_epi32(_mm512_loadu_si512(src + sizeof(float) * simd_proc_elt * j), 16));
+      auto round_bias = _mm512_loadu_si512(src + sizeof(float) * simd_proc_elt * j);
+      round_bias = _mm512_and_epi32(bf16_and_helper, _mm512_bsrli_epi128(round_bias, 2));
+      round_bias = _mm512_add_epi32(round_bias, bf16_add_helper);
+      auto round_fp32_v = _mm512_add_epi32(round_bias, _mm512_loadu_si512(src + sizeof(float) * simd_proc_elt * j));
+      auto pack_bf16_value = _mm512_cvtepi32_epi16(_mm512_srli_epi32(round_fp32_v, 16));
       _mm256_storeu_si256((__m256i*)(dst + (j * simd_proc_elt) * sizeof(jblas::utils::bf16)), pack_bf16_value);
     }
     if (col_tail > 0) {
-      auto pack_bf16_tail = _mm512_cvtepi32_epi16(
-          _mm512_srli_epi32(_mm512_maskz_loadu_epi32(tail_mask, src + sizeof(float) * simd_proc_elt * j), 16));
+      auto round_bias = _mm512_loadu_si512(src + sizeof(float) * simd_proc_elt * j);
+      round_bias = _mm512_and_epi32(bf16_and_helper, _mm512_bsrli_epi128(round_bias, 2));
+      round_bias = _mm512_add_epi32(round_bias, bf16_add_helper);
+      auto round_fp32_v = _mm512_add_epi32(round_bias, _mm512_loadu_si512(src + sizeof(float) * simd_proc_elt * j));
+      auto pack_bf16_tail = _mm512_cvtepi32_epi16(_mm512_srli_epi32(round_fp32_v, 16));
       _mm256_mask_storeu_epi16((__m256i*)(dst + (j * simd_proc_elt) * sizeof(jblas::utils::bf16)), tail_mask,
                                pack_bf16_tail);
     }
@@ -962,7 +942,6 @@ static inline JBLAS_CODE fp32_cvt_bf16_2D_write_back(const void* raw_srcptr, voi
       std::memset(dst + col * sizeof(utils::bf16), 0, npadding);
     }
   }
-#endif
   return JblasSuccess;
 }
 
@@ -1022,7 +1001,6 @@ static inline JBLAS_CODE fp16_cvt_fp32_2D_write_back(const utils::fp16* src_ptr,
 
 static inline JBLAS_CODE bf16_cvt_fp32_2D_write_back(const utils::bf16* src_ptr, float* dst_ptr, int row, int col,
                                                      int src_step, int dst_step, bool zeropadding) {
-#if CompileBF16()
   const int npadding = (dst_step - col) * sizeof(float);
   constexpr int simd_proc_elt = 16;
   auto col_body = col / simd_proc_elt * simd_proc_elt;
@@ -1033,16 +1011,18 @@ static inline JBLAS_CODE bf16_cvt_fp32_2D_write_back(const utils::bf16* src_ptr,
     auto dst = dst_ptr + i * dst_step;
     int j = 0;
     for (; j < col_body; j += simd_proc_elt)
-      _mm512_storeu_ps(dst + j, _mm512_cvtpbh_ps((__m256bh)_mm256_loadu_ps(reinterpret_cast<float*>(src + j))));
+      _mm512_storeu_ps(
+          dst + j,
+          _mm512_castsi512_ps(_mm512_bslli_epi128(
+              _mm512_cvtepu16_epi32(_mm256_castps_si256(_mm256_loadu_ps(reinterpret_cast<float*>(src + j)))), 2)));
     if (col_tail > 0)
-      _mm512_mask_storeu_ps(dst + j, tail_mask,
-                            _mm512_cvtpbh_ps((__m256bh)_mm256_loadu_ps(reinterpret_cast<float*>(src + j))));
+      _mm512_mask_storeu_ps(
+          dst + j, tail_mask,
+          _mm512_castsi512_ps(_mm512_bslli_epi128(
+              _mm512_cvtepu16_epi32(_mm256_castps_si256(_mm256_loadu_ps(reinterpret_cast<float*>(src + j)))), 2)));
     if (zeropadding && npadding) std::memset(dst + col, 0, npadding);
   }
   return JblasSuccess;
-#else
-  return JblasNotSupport;
-#endif
 }
 
 #ifdef __GNUC__

--- a/intel_extension_for_transformers/llm/library/jblas/jblas/kernel_ref.h
+++ b/intel_extension_for_transformers/llm/library/jblas/jblas/kernel_ref.h
@@ -276,8 +276,8 @@ inline JBLAS_CODE decompress_kblock_s4_fp(utils::int4x2* srcptr, _DST_T* dstptr,
         scale1 = sptr[s1_idx];
       }
       if (zero_points != nullptr) {
-        dst0 = (float(get_s8<S4_T>(tmp.x)) - float((zero_points + kpos * NPad)[j + 0])) * scale0;
-        dst1 = (float(get_s8<S4_T>(tmp.y)) - float((zero_points + kpos * NPad)[j + 1])) * scale1;
+        dst0 = (float(get_s8<S4_T>(tmp.x)) - float((zero_points + kpos * NPad)[s0_idx])) * scale0;
+        dst1 = (float(get_s8<S4_T>(tmp.y)) - float((zero_points + kpos * NPad)[s1_idx])) * scale1;
       } else {
         dst0 = float(get_s8<S4_T>(tmp.x)) * scale0;
         dst1 = float(get_s8<S4_T>(tmp.y)) * scale1;

--- a/intel_extension_for_transformers/llm/operator/cscr/dispatcher/src/jblas_weightonly_dispatcher.cpp
+++ b/intel_extension_for_transformers/llm/operator/cscr/dispatcher/src/jblas_weightonly_dispatcher.cpp
@@ -422,8 +422,8 @@ void parse_gemm_core_offline(qbits_config_param* p, qbits_runtime_ctx* ctx) {
   auto blocksize = wbtmp->mBlockSize;
   ctx->blocksize = blocksize;
   switch (gemm_core_type) {
-    case jblas::gemm::GemmCoreType::AMX_INT8_16X48_KBLOCK:
-    case jblas::gemm::GemmCoreType::AVX512_VNNI_3X48_KBLOCK:
+    case jblas::gemm::GemmCoreType::AMX_INT8_16x48_KBLOCK:
+    case jblas::gemm::GemmCoreType::AVX512_VNNI_3x48_KBLOCK:
       assert(p->compute_type == "int8");
       if (check_amx() && blocksize % (jblas::gemm::kblock::GemmCore_Row_NN_16x48_AMX_INT8_KBLOCK::KTILE * 2) == 0) {
         return parse_weight<TASK, jblas::wrapper::gemm_kblock::GemmInterfaceKBlockPackWeight,
@@ -440,7 +440,7 @@ void parse_gemm_core_offline(qbits_config_param* p, qbits_runtime_ctx* ctx) {
       TORCH_CHECK(false, "Qbits: Illegal config in int8 compute_type: blocksize:", blocksize,
                   " ISA largger than vnni:", check_avx512_vnni());
       break;
-    case jblas::gemm::GemmCoreType::AVX512F_8X48:
+    case jblas::gemm::GemmCoreType::AVX512F_8x48:
       assert(p->compute_type == "fp32");
       if (check_avx512f()) {
         return parse_weight<TASK, jblas::wrapper::gemm_pack_weight::GemmInterfacePackWeight,
@@ -469,7 +469,7 @@ void parse_gemm_core_offline(qbits_config_param* p, qbits_runtime_ctx* ctx) {
                             JblasAMX_BF16>(p, ctx);
       }
       TORCH_CHECK(false, "Qbits: device ISA must support AMX-BF16 when compute_type==bf16");
-    case jblas::gemm::GemmCoreType::AVX512_VNNI_8X48:
+    case jblas::gemm::GemmCoreType::AVX512_VNNI_8x48:
       assert(p->compute_type == "int8");
       if (check_avx512_vnni())
         return parse_weight<TASK, jblas::wrapper::gemm_pack_weight::GemmInterfaceParallelAB,

--- a/intel_extension_for_transformers/llm/operator/cscr/qbits_ut/weightonly_test.py
+++ b/intel_extension_for_transformers/llm/operator/cscr/qbits_ut/weightonly_test.py
@@ -17,7 +17,7 @@
 import torch
 import inspect
 from functools import wraps
-torch.ops.load_library("../build/libQBits.so")
+torch.ops.load_library("../build/libqbits.so")
 
 
 def capture_args(f):

--- a/intel_extension_for_transformers/llm/runtime/graph/core/layers/inner_product.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/layers/inner_product.cpp
@@ -78,6 +78,13 @@ using KBlockFp32Fp32 = jblas::wrapper::gemm_kblock::GemmInterfaceKBlockPackWeigh
     jblas::utils::parallel::Parallel2DGemmKBlockFixed>;
 
 template <template <class GC, JBLAS_ISA ISA> class ProB>
+using KBlockFp32Fp32Next = jblas::wrapper::gemm_kblock::GemmInterfaceKBlockPackWeight<
+    jblas::wrapper::gemm_kblock::GemmSLauncherKBlockPackWeight<
+        DefaultISA, jblas::gemm::kblock::GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK,
+        jblas::prologue::gemm::ActivationF32U8KBlockQuantize, ProB, jblas::epilogue::gemm::AccumulatorWriteBackFp32>,
+    jblas::utils::parallel::Parallel2DGemmKBlockFixed>;
+
+template <template <class GC, JBLAS_ISA ISA> class ProB>
 using PerNFp32Fp32 = jblas::wrapper::gemm_pack_weight::GemmInterfaceParallelAB<
     jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<DefaultISA, jblas::gemm::GemmCore_Row_NN_8x48_AVX512_VNNI,
                                                              jblas::prologue::gemm::ActivationFp32AsymU8Quantize, ProB,
@@ -98,12 +105,20 @@ static JBLAS_CODE jblas_s4fp32kblock_f32f32_forward(float* activation, SS4Fp32* 
       auto quanA = kernel.getActivationPtr()->createStorage(_m, _k, weiptr->mBlockSize, (int8_t*)workspace);
       ret = kernel.compute({_m, _n, _k, activation, lda, quanA, weiptr, output, ldo});
       delete quanA;
-    } else if (_cd->AVX512_VNNI()) {
-      using GemmKernel = avx512_vnni::KBlockFp32Fp32<WeiS4ClipFp32>;
-      static GemmKernel kernel;
-      auto quanA = kernel.getActivationPtr()->createStorage(_m, _k, weiptr->mBlockSize, (int8_t*)workspace);
-      ret = kernel.compute({_m, _n, _k, activation, lda, quanA, weiptr, output, ldo});
-      delete quanA;
+    } else if (_cd->AVX512_VNNI() && weiptr->mBlockSize % 8 == 0) {
+      if (_m <= 32) {
+        using GemmKernel = avx512_vnni::KBlockFp32Fp32Next<WeiS4ClipFp32>;
+        static GemmKernel kernel;
+        auto quanA = kernel.getActivationPtr()->createStorage(_m, _k, weiptr->mBlockSize, (int8_t*)workspace);
+        ret = kernel.compute({_m, _n, _k, activation, lda, quanA, weiptr, output, ldo});
+        delete quanA;
+      } else {
+        using GemmKernel = avx512_vnni::KBlockFp32Fp32<WeiS4ClipFp32>;
+        static GemmKernel kernel;
+        auto quanA = kernel.getActivationPtr()->createStorage(_m, _k, weiptr->mBlockSize, (int8_t*)workspace);
+        ret = kernel.compute({_m, _n, _k, activation, lda, quanA, weiptr, output, ldo});
+        delete quanA;
+      }
     }
   } else if (weiptr->mCoreType == GcCompFp32::TYPE) {
     if (_cd->AVX512F()) {
@@ -261,14 +276,24 @@ JBLAS_CODE jblas_fusion_add_s4fp32_f32f32_forward(float* activation, SS4Fp32* we
       auto quanA = kernel.getActivationPtr()->createStorage(_m, _k, weiptr->mBlockSize, (int8_t*)workspace);
       ret = kernel.compute({_m, _n, _k, activation, lda, quanA, weiptr, output, bias, ldo, broadcast_bias ? 0 : ldo});
       delete quanA;
-    } else if (_cd->AVX512_VNNI()) {
-      using GemmKernel = jblas::wrapper::gemm_kblock::GemmInterfaceKBlockPackWeight<
-          custom::wrapper::kblock::avx512_vnni::AddGemmSKernelDynamicS4KBlock,
-          jblas::utils::parallel::Parallel2DGemmKBlockFixed>;
-      static GemmKernel kernel;
-      auto quanA = kernel.getActivationPtr()->createStorage(_m, _k, weiptr->mBlockSize, (int8_t*)workspace);
-      ret = kernel.compute({_m, _n, _k, activation, lda, quanA, weiptr, output, bias, ldo, broadcast_bias ? 0 : ldo});
-      delete quanA;
+    } else if (_cd->AVX512_VNNI() && weiptr->mBlockSize % 8 == 0) {
+      if (_m <= 32) {
+        using GemmKernel = jblas::wrapper::gemm_kblock::GemmInterfaceKBlockPackWeight<
+            custom::wrapper::kblock::avx512_vnni::AddGemmSKernelDynamicS4KBlockNext,
+            jblas::utils::parallel::Parallel2DGemmKBlockFixed>;
+        static GemmKernel kernel;
+        auto quanA = kernel.getActivationPtr()->createStorage(_m, _k, weiptr->mBlockSize, (int8_t*)workspace);
+        ret = kernel.compute({_m, _n, _k, activation, lda, quanA, weiptr, output, bias, ldo, broadcast_bias ? 0 : ldo});
+        delete quanA;
+      } else {
+        using GemmKernel = jblas::wrapper::gemm_kblock::GemmInterfaceKBlockPackWeight<
+            custom::wrapper::kblock::avx512_vnni::AddGemmSKernelDynamicS4KBlock,
+            jblas::utils::parallel::Parallel2DGemmKBlockFixed>;
+        static GemmKernel kernel;
+        auto quanA = kernel.getActivationPtr()->createStorage(_m, _k, weiptr->mBlockSize, (int8_t*)workspace);
+        ret = kernel.compute({_m, _n, _k, activation, lda, quanA, weiptr, output, bias, ldo, broadcast_bias ? 0 : ldo});
+        delete quanA;
+      }
     }
   }
   return ret;

--- a/intel_extension_for_transformers/llm/runtime/graph/core/layers/inner_product.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/layers/inner_product.cpp
@@ -72,8 +72,8 @@ JBLAS_ISA constexpr DefaultISA = JblasAVX512_VNNI;
 
 template <template <class GC, JBLAS_ISA ISA> class ProB>
 using KBlockFp32Fp32 = jblas::wrapper::gemm_kblock::GemmInterfaceKBlockPackWeight<
-    jblas::wrapper::gemm_kblock::GemmSLauncherKBlockPackWeight<
-        DefaultISA, jblas::gemm::kblock::GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK,
+    jblas::wrapper::gemm_kblock::GemmLauncherKBlock<
+        DefaultISA, jblas::gemm::kblock::GemmCore_Row_NN_4x48_AVX512_VNNI_KBLOCK,
         jblas::prologue::gemm::ActivationF32U8KBlockQuantize, ProB, jblas::epilogue::gemm::AccumulatorWriteBackFp32>,
     jblas::utils::parallel::Parallel2DGemmKBlockFixed>;
 

--- a/intel_extension_for_transformers/llm/runtime/graph/core/layers/ip_fusion_ffn.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/layers/ip_fusion_ffn.cpp
@@ -323,8 +323,8 @@ bool jblas_fusion_FFN_Add_GeLu_f32f32_support(void* w1ptr, void* w2ptr, int seq,
         if (w1tmp->mType == int(WeightCompType::WeightS4ClipScaleFp32) ||
             w1tmp->mType == int(WeightCompType::WeightS8ScaleFp32)) {
           constexpr jblas::gemm::GemmCoreType cores[] = {
-              jblas::gemm::GemmCoreType::AMX_INT8_16X48_KBLOCK, jblas::gemm::GemmCoreType::AVX512_VNNI_3X48_KBLOCK,
-              jblas::gemm::GemmCoreType::AVX512F_8X48, jblas::gemm::GemmCoreType::AMX_BF16_16x48};
+              jblas::gemm::GemmCoreType::AMX_INT8_16x48_KBLOCK, jblas::gemm::GemmCoreType::AVX512_VNNI_3x48_KBLOCK,
+              jblas::gemm::GemmCoreType::AVX512F_8x48, jblas::gemm::GemmCoreType::AMX_BF16_16x48};
           constexpr size_t EleNum = sizeof(cores) / sizeof(cores[0]);
           support = contains(w1tmp->mCoreType, cores, EleNum);
           support &= hasISA(cores, EleNum);

--- a/intel_extension_for_transformers/llm/runtime/graph/core/layers/ip_fusion_ffn.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/layers/ip_fusion_ffn.cpp
@@ -82,7 +82,7 @@ JBLAS_CODE jblas_fusion_FFN_SiLu_s4fp32_f32f32_forward(float* activation, SS4Fp3
       delete quanA2;
 
     } else if (_cd->AVX512_VNNI() && w1ptr->mBlockSize % 8 == 0) {
-      if (seq<=32) {
+      if (seq <= 32) {
         using GemmKernel = custom::wrapper::kblock::avx512_vnni::GemmSKernelDynamicS4KBlockNext;
         using SiluGemmKernel = custom::wrapper::kblock::avx512_vnni::SiluGemmSKernelDynamicS4KBlockNext;
         using FusedInter = custom::wrapper::transformer::FFNFusedInterface<SiluGemmKernel, GemmKernel>;

--- a/intel_extension_for_transformers/llm/runtime/graph/core/layers/ip_fusion_ffn.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/layers/ip_fusion_ffn.cpp
@@ -81,24 +81,46 @@ JBLAS_CODE jblas_fusion_FFN_SiLu_s4fp32_f32f32_forward(float* activation, SS4Fp3
       delete quanA1;
       delete quanA2;
 
-    } else if (_cd->AVX512_VNNI() && w1ptr->mBlockSize % 4 == 0) {
-      using GemmKernel = custom::wrapper::kblock::avx512_vnni::GemmSKernelDynamicS4KBlock;
-      using SiluGemmKernel = custom::wrapper::kblock::avx512_vnni::SiluGemmSKernelDynamicS4KBlock;
-      using FusedInter = custom::wrapper::transformer::FFNFusedInterface<SiluGemmKernel, GemmKernel>;
-      using DQuantParam = GemmKernel::PrologueA::QParam;
-      static FusedInter finter;
-      int lda = fin;
-      int ldtmp1 = fmid;
-      int ldtmp2 = fmid;
-      int ldo = fout;
+    } else if (_cd->AVX512_VNNI() && w1ptr->mBlockSize % 8 == 0) {
+      if (seq<=32) {
+        using GemmKernel = custom::wrapper::kblock::avx512_vnni::GemmSKernelDynamicS4KBlockNext;
+        using SiluGemmKernel = custom::wrapper::kblock::avx512_vnni::SiluGemmSKernelDynamicS4KBlockNext;
+        using FusedInter = custom::wrapper::transformer::FFNFusedInterface<SiluGemmKernel, GemmKernel>;
+        using DQuantParam = GemmKernel::PrologueA::QParam;
+        static FusedInter finter;
+        int lda = fin;
+        int ldtmp1 = fmid;
+        int ldtmp2 = fmid;
+        int ldo = fout;
 
-      auto quanA1 = finter.getActivationPtr()->createStorage(seq, fin, w1ptr->mBlockSize, (int8_t*)workspace);
-      auto offset = workspace == NULL ? 0 : finter.getActivationPtr()->getWorkSpaceSize(seq, fin, w1ptr->mBlockSize);
-      auto quanA2 = finter.getActivationPtr()->createStorage(seq, fmid, w2ptr->mBlockSize, (int8_t*)workspace + offset);
-      ret = finter.compute({seq,   fin,   fmid, fout,   activation, lda, quanA1, tmp1, ldtmp1, quanA2, w1ptr,
-                            w2ptr, w3ptr, tmp1, ldtmp1, output,     ldo, NULL,   tmp2, ldtmp2, NULL});
-      delete quanA1;
-      delete quanA2;
+        auto quanA1 = finter.getActivationPtr()->createStorage(seq, fin, w1ptr->mBlockSize, (int8_t*)workspace);
+        auto offset = workspace == NULL ? 0 : finter.getActivationPtr()->getWorkSpaceSize(seq, fin, w1ptr->mBlockSize);
+        auto quanA2 =
+            finter.getActivationPtr()->createStorage(seq, fmid, w2ptr->mBlockSize, (int8_t*)workspace + offset);
+        ret = finter.compute({seq,   fin,   fmid, fout,   activation, lda, quanA1, tmp1, ldtmp1, quanA2, w1ptr,
+                              w2ptr, w3ptr, tmp1, ldtmp1, output,     ldo, NULL,   tmp2, ldtmp2, NULL});
+        delete quanA1;
+        delete quanA2;
+      } else {
+        using GemmKernel = custom::wrapper::kblock::avx512_vnni::GemmSKernelDynamicS4KBlock;
+        using SiluGemmKernel = custom::wrapper::kblock::avx512_vnni::SiluGemmSKernelDynamicS4KBlock;
+        using FusedInter = custom::wrapper::transformer::FFNFusedInterface<SiluGemmKernel, GemmKernel>;
+        using DQuantParam = GemmKernel::PrologueA::QParam;
+        static FusedInter finter;
+        int lda = fin;
+        int ldtmp1 = fmid;
+        int ldtmp2 = fmid;
+        int ldo = fout;
+
+        auto quanA1 = finter.getActivationPtr()->createStorage(seq, fin, w1ptr->mBlockSize, (int8_t*)workspace);
+        auto offset = workspace == NULL ? 0 : finter.getActivationPtr()->getWorkSpaceSize(seq, fin, w1ptr->mBlockSize);
+        auto quanA2 =
+            finter.getActivationPtr()->createStorage(seq, fmid, w2ptr->mBlockSize, (int8_t*)workspace + offset);
+        ret = finter.compute({seq,   fin,   fmid, fout,   activation, lda, quanA1, tmp1, ldtmp1, quanA2, w1ptr,
+                              w2ptr, w3ptr, tmp1, ldtmp1, output,     ldo, NULL,   tmp2, ldtmp2, NULL});
+        delete quanA1;
+        delete quanA2;
+      }
     }
   }
   return ret;

--- a/intel_extension_for_transformers/llm/runtime/graph/core/layers/ip_fusion_qkv.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/layers/ip_fusion_qkv.cpp
@@ -119,7 +119,7 @@ JBLAS_CODE jblas_QKVs4fp32_f32f32_forward(float* activation, SS4Fp32* wqptr, SS4
   auto ret = JblasRuntimeError;
   if (wqptr->mCoreType == GcCompInt8KBlock::TYPE) {
     if (_cd->AMX_INT8() && wqptr->mBlockSize % 128 == 0) {
-      using GemmKernel = jblas::wrapper::transformer_default::weight_comp::amx_int8::QKVGemmDynamicS4Fp32KBlock;
+      using GemmKernel = transformer::amx_int8::QKVGemmDynamicS4Fp32KBlock;
       static GemmKernel kernel;
       GemmKernel::WeightType::Param wparams[3]{
           wqptr,
@@ -135,7 +135,7 @@ JBLAS_CODE jblas_QKVs4fp32_f32f32_forward(float* activation, SS4Fp32* wqptr, SS4
       ret = kernel.compute({_m, _n, _k, 3, activation, lda, quanA, wparams, oparams, NULL});
       delete quanA;
     } else if (_cd->AVX512_VNNI()) {
-      using GemmKernel = jblas::wrapper::transformer_default::weight_comp::avx512_vnni::QKVGemmDynamicS4Fp32KBlock;
+      using GemmKernel = transformer::avx512_vnni::QKVGemmDynamicS4Fp32KBlock;
       static GemmKernel kernel;
       GemmKernel::WeightType::Param wparams[3]{
           wqptr,

--- a/intel_extension_for_transformers/llm/runtime/graph/core/layers/ip_fusion_qkv.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/layers/ip_fusion_qkv.cpp
@@ -29,15 +29,15 @@ namespace transformer {
 namespace avx512_vnni {
 static JBLAS_ISA constexpr DefaultISA = JblasAVX512_VNNI;
 using QKVGemmDynamicS4Fp32KBlock = jblas::wrapper::transformer::QKVGemmInterfaceKBlockPackWeight<
-    jblas::wrapper::gemm_kblock::GemmSLauncherKBlockPackWeight<
-        DefaultISA, jblas::gemm::kblock::GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK,
+    jblas::wrapper::gemm_kblock::GemmLauncherKBlock<
+        DefaultISA, jblas::gemm::kblock::GemmCore_Row_NN_4x48_AVX512_VNNI_KBLOCK,
         jblas::prologue::gemm::ActivationF32U8KBlockQuantize,
         jblas::prologue::weight_comp::gemm_kblcok::WeightS4ClipScaleFp32,
         jblas::epilogue::gemm::AccumulatorWriteBackFp32>,
     jblas::utils::parallel::Parallel2DGemmKBlockFixed>;
 using QKVGemmDynamicS8Fp32KBlock = jblas::wrapper::transformer::QKVGemmInterfaceKBlockPackWeight<
-    jblas::wrapper::gemm_kblock::GemmSLauncherKBlockPackWeight<
-        DefaultISA, jblas::gemm::kblock::GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK,
+    jblas::wrapper::gemm_kblock::GemmLauncherKBlock<
+        DefaultISA, jblas::gemm::kblock::GemmCore_Row_NN_4x48_AVX512_VNNI_KBLOCK,
         jblas::prologue::gemm::ActivationF32U8KBlockQuantize,
         jblas::prologue::weight_comp::gemm_kblcok::WeightS8ScaleFp32, jblas::epilogue::gemm::AccumulatorWriteBackFp32>,
     jblas::utils::parallel::Parallel2DGemmKBlockFixed>;

--- a/intel_extension_for_transformers/llm/runtime/graph/core/layers/ip_fusion_qkv.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/layers/ip_fusion_qkv.cpp
@@ -29,11 +29,11 @@ namespace transformer {
 namespace avx512_vnni {
 static JBLAS_ISA constexpr DefaultISA = JblasAVX512_VNNI;
 using QKVGemmDynamicS4Fp32KBlock = jblas::wrapper::transformer::QKVGemmInterfaceKBlockPackWeight<
-    jblas::wrapper::gemm_kblock::GemmLauncherKBlock<
-        DefaultISA, jblas::gemm::kblock::GemmCore_Row_NN_4x48_AVX512_VNNI_KBLOCK,
-        jblas::prologue::gemm::ActivationF32U8KBlockQuantize,
-        jblas::prologue::weight_comp::gemm_kblcok::WeightS4ClipScaleFp32,
-        jblas::epilogue::gemm::AccumulatorWriteBackFp32>,
+    jblas::wrapper::gemm_kblock::GemmLauncherKBlock<DefaultISA,
+                                                    jblas::gemm::kblock::GemmCore_Row_NN_4x48_AVX512_VNNI_KBLOCK,
+                                                    jblas::prologue::gemm::ActivationF32U8KBlockQuantize,
+                                                    jblas::prologue::weight_comp::gemm_kblcok::WeightS4ClipScaleFp32,
+                                                    jblas::epilogue::gemm::AccumulatorWriteBackFp32>,
     jblas::utils::parallel::Parallel2DGemmKBlockFixed>;
 using QKVGemmDynamicS8Fp32KBlock = jblas::wrapper::transformer::QKVGemmInterfaceKBlockPackWeight<
     jblas::wrapper::gemm_kblock::GemmLauncherKBlock<

--- a/intel_extension_for_transformers/llm/runtime/graph/core/layers/jblas_common.hpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/layers/jblas_common.hpp
@@ -40,7 +40,7 @@ static bool hasISA(const jblas::gemm::GemmCoreType* set, size_t len) {
   bool support = false;
   for (size_t i = 0; i < len; i++) {
     switch (set[i]) {
-      case jblas::gemm::GemmCoreType::AMX_INT8_16X48_KBLOCK:
+      case jblas::gemm::GemmCoreType::AMX_INT8_16x48_KBLOCK:
       case jblas::gemm::GemmCoreType::AMX_INT8_16x48:
       case jblas::gemm::GemmCoreType::AMX_INT8_16x64:
       case jblas::gemm::GemmCoreType::AMX_INT8_16x48_SS:
@@ -50,19 +50,24 @@ static bool hasISA(const jblas::gemm::GemmCoreType* set, size_t len) {
       case jblas::gemm::GemmCoreType::AMX_BF16_16x64:
         support |= _cd->AMX_BF16();
         break;
-      case jblas::gemm::GemmCoreType::AVX512_VNNI_3X48_KBLOCK:
-      case jblas::gemm::GemmCoreType::AVX512_VNNI_8X48:
+      case jblas::gemm::GemmCoreType::AVX512_VNNI_3x48_KBLOCK:
+      case jblas::gemm::GemmCoreType::AVX512_VNNI_4x48_KBLOCK:
+      case jblas::gemm::GemmCoreType::AVX512_VNNI_8x48:
         support |= _cd->AVX512_VNNI();
         break;
       case jblas::gemm::GemmCoreType::AVX512_FP16_8x64:
       case jblas::gemm::GemmCoreType::AVX512_FP16_8x96:
         support |= _cd->AVX512_FP16();
         break;
-      case jblas::gemm::GemmCoreType::AVX512F_8X48:
+      case jblas::gemm::GemmCoreType::AVX512F_8x48:
         support |= _cd->AVX512F();
         break;
       case jblas::gemm::GemmCoreType::AVX2_4X24:
         support |= _cd->AVX2();
+        break;
+      case jblas::gemm::GemmCoreType::AVX_VNNI_1x48_KBLOCK:
+      case jblas::gemm::GemmCoreType::AVX_VNNI_2x48:
+        support |= _cd->AVX_VNNI();
         break;
       default:
         break;
@@ -114,11 +119,11 @@ using GcCompBf16 = jblas::gemm::GemmCore_Row_NN_16x64_AMX_BF16;
 using GcCompFp16 = jblas::gemm::GemmCore_Row_NN_8x64_AVX512_FP16;
 using GcCompInt8 = jblas::gemm::GemmCore_Row_NN_8x48_AVX512_VNNI;
 
-constexpr jblas::gemm::GemmCoreType GcCompInt8KBlockSet[] = {jblas::gemm::GemmCoreType::AMX_INT8_16X48_KBLOCK,
-                                                             jblas::gemm::GemmCoreType::AVX512_VNNI_3X48_KBLOCK};
+constexpr jblas::gemm::GemmCoreType GcCompInt8KBlockSet[] = {jblas::gemm::GemmCoreType::AMX_INT8_16x48_KBLOCK,
+                                                             jblas::gemm::GemmCoreType::AVX512_VNNI_3x48_KBLOCK};
 
 constexpr jblas::gemm::GemmCoreType GcCompInt8Set[] = {jblas::gemm::GemmCoreType::AMX_INT8_16x48_SS,
-                                                       jblas::gemm::GemmCoreType::AVX512_VNNI_8X48};
+                                                       jblas::gemm::GemmCoreType::AVX512_VNNI_8x48};
 
 namespace custom {
 namespace epilogue {

--- a/intel_extension_for_transformers/llm/runtime/graph/core/layers/jblas_common.hpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/layers/jblas_common.hpp
@@ -773,9 +773,10 @@ class FpGeluFusedInterface {
 namespace kblock {
 namespace avx512_vnni {
 template <template <class GC, JBLAS_ISA ISA> class ProB, template <JBLAS_ISA ISA> class Epi>
-using DynamicGemm = jblas::wrapper::gemm_kblock::GemmSLauncherKBlockPackWeight<
-    JblasAVX512_VNNI, jblas::gemm::kblock::GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK,
-    jblas::prologue::gemm::ActivationF32U8KBlockQuantize, ProB, Epi>;
+using DynamicGemm =
+    jblas::wrapper::gemm_kblock::GemmLauncherKBlock<JblasAVX512_VNNI,
+                                                    jblas::gemm::kblock::GemmCore_Row_NN_4x48_AVX512_VNNI_KBLOCK,
+                                                    jblas::prologue::gemm::ActivationF32U8KBlockQuantize, ProB, Epi>;
 template <template <class GC, JBLAS_ISA ISA> class ProB, template <JBLAS_ISA ISA> class Epi>
 using DynamicGemmPerN = jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<
     JblasAVX512_VNNI, jblas::gemm::GemmCore_Row_NN_8x48_AVX512_VNNI,

--- a/intel_extension_for_transformers/llm/runtime/graph/core/layers/jblas_common.hpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/layers/jblas_common.hpp
@@ -779,10 +779,9 @@ using DynamicGemm =
                                                     jblas::prologue::gemm::ActivationF32U8KBlockQuantize, ProB, Epi>;
 
 template <template <class GC, JBLAS_ISA ISA> class ProB, template <JBLAS_ISA ISA> class Epi>
-using DynamicGemmNext =
-    jblas::wrapper::gemm_kblock::GemmSLauncherKBlockPackWeight<JblasAVX512_VNNI,
-                                                    jblas::gemm::kblock::GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK,
-                                                    jblas::prologue::gemm::ActivationF32U8KBlockQuantize, ProB, Epi>;
+using DynamicGemmNext = jblas::wrapper::gemm_kblock::GemmSLauncherKBlockPackWeight<
+    JblasAVX512_VNNI, jblas::gemm::kblock::GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK,
+    jblas::prologue::gemm::ActivationF32U8KBlockQuantize, ProB, Epi>;
 
 template <template <class GC, JBLAS_ISA ISA> class ProB, template <JBLAS_ISA ISA> class Epi>
 using DynamicGemmPerN = jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<

--- a/intel_extension_for_transformers/llm/runtime/graph/core/layers/jblas_common.hpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/layers/jblas_common.hpp
@@ -777,6 +777,13 @@ using DynamicGemm =
     jblas::wrapper::gemm_kblock::GemmLauncherKBlock<JblasAVX512_VNNI,
                                                     jblas::gemm::kblock::GemmCore_Row_NN_4x48_AVX512_VNNI_KBLOCK,
                                                     jblas::prologue::gemm::ActivationF32U8KBlockQuantize, ProB, Epi>;
+
+template <template <class GC, JBLAS_ISA ISA> class ProB, template <JBLAS_ISA ISA> class Epi>
+using DynamicGemmNext =
+    jblas::wrapper::gemm_kblock::GemmSLauncherKBlockPackWeight<JblasAVX512_VNNI,
+                                                    jblas::gemm::kblock::GemmCore_Row_NN_3x48_AVX512_VNNI_KBLOCK,
+                                                    jblas::prologue::gemm::ActivationF32U8KBlockQuantize, ProB, Epi>;
+
 template <template <class GC, JBLAS_ISA ISA> class ProB, template <JBLAS_ISA ISA> class Epi>
 using DynamicGemmPerN = jblas::wrapper::gemm_pack_weight::GemmLauncherPackWeight<
     JblasAVX512_VNNI, jblas::gemm::GemmCore_Row_NN_8x48_AVX512_VNNI,
@@ -787,6 +794,12 @@ using SiluGemmSKernelDynamicS4KBlock = DynamicGemm<WeiS4ClipFp32, custom::epilog
 using GeluGemmSKernelDynamicS4KBlock = DynamicGemm<WeiS4ClipFp32, custom::epilogue::GeluFp32>;
 using AddGeluGemmSKernelDynamicS4KBlock = DynamicGemm<WeiS4ClipFp32, custom::epilogue::Add_GeluFp32>;
 using AddGemmSKernelDynamicS4KBlock = DynamicGemm<WeiS4ClipFp32, custom::epilogue::AddFp32>;
+
+using GemmSKernelDynamicS4KBlockNext = DynamicGemmNext<WeiS4ClipFp32, jblas::epilogue::gemm::AccumulatorWriteBackFp32>;
+using SiluGemmSKernelDynamicS4KBlockNext = DynamicGemmNext<WeiS4ClipFp32, custom::epilogue::SiluFp32>;
+using GeluGemmSKernelDynamicS4KBlockNext = DynamicGemmNext<WeiS4ClipFp32, custom::epilogue::GeluFp32>;
+using AddGeluGemmSKernelDynamicS4KBlockNext = DynamicGemmNext<WeiS4ClipFp32, custom::epilogue::Add_GeluFp32>;
+using AddGemmSKernelDynamicS4KBlockNext = DynamicGemmNext<WeiS4ClipFp32, custom::epilogue::AddFp32>;
 
 using GemmSKernelDynamicS8KBlock = DynamicGemm<WeiS8Fp32, jblas::epilogue::gemm::AccumulatorWriteBackFp32>;
 using SiluGemmSKernelDynamicS8KBlock = DynamicGemm<WeiS8Fp32, custom::epilogue::SiluFp32>;


### PR DESCRIPTION
## Type of Change

1. update jblas
2. Use the new avx512_vnni kernel to get a higher first token perf.


## How has this PR been tested?

llama-7B bits=4 group_size=128, 32 comp_type=int8
