### PR TITLE
Add dnnl_dim_t cast to fix executor windows failure

### DIFF
--- a/intel_extension_for_transformers/llm/library/jblas/jblas/jit_blas_weight_compression.h
+++ b/intel_extension_for_transformers/llm/library/jblas/jblas/jit_blas_weight_compression.h
@@ -1713,6 +1713,7 @@ class GemmInterfaceKblockParallelAB {
       }
       if constexpr (_LaunchA || _LaunchB) {
 #pragma omp barrier
+        (void)(0);  // make msvc happy
       }
       int colidx, rowidx, rowsize, colsize;
       para.getIndex(tidx, &rowidx, &colidx, &rowsize, &colsize);

--- a/intel_extension_for_transformers/llm/library/jblas/jblas/jit_blas_wrapper.h
+++ b/intel_extension_for_transformers/llm/library/jblas/jblas/jit_blas_wrapper.h
@@ -190,6 +190,7 @@ class GemmInterfaceParallelAB {
       }
       if constexpr (_LaunchA || _LaunchB) {
 #pragma omp barrier
+        (void)(0);  // make msvc happy
       }
       int colidx, rowidx, rowsize, colsize;
       para.getIndex(tidx, &rowidx, &colidx, &rowsize, &colsize);

--- a/intel_extension_for_transformers/llm/operator/cscr/dispatcher/CMakeLists.txt
+++ b/intel_extension_for_transformers/llm/operator/cscr/dispatcher/CMakeLists.txt
@@ -13,7 +13,10 @@
 ##  limitations under the License.
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 project(jblas_dispatcher LANGUAGES C CXX)
-set(CMAKE_CXX_FLAGS "-fPIC -Wno-narrowing -fconcepts")
+set_property(GLOBAL PROPERTY POSITION_INDEPENDENT_CODE ON)
+if(NOT WIN32)
+set(CMAKE_CXX_FLAGS "-Wno-narrowing -fconcepts")
+endif()
 file(GLOB SOURCES 
     ${PROJECT_SOURCE_DIR}/src/*.cpp
 )
@@ -24,6 +27,11 @@ file(GLOB HEADERS
 add_subdirectory(../../../library/jblas jblas_out)
 
 add_library(jblas_dispatcher STATIC ${HEADERS} ${SOURCES})
+if(WIN32)
+# MSVC does not allow sth like -fconcepts
+set_target_properties(jblas_dispatcher PROPERTIES C_STANDARD 20 C_STANDARD_REQUIRED ON C_EXTENSIONS OFF)
+set_target_properties(jblas_dispatcher PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF)
+endif()
 
 set_target_properties(jblas_dispatcher PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(jblas_dispatcher "${TORCH_LIBRARIES}" jblas::jblas)

--- a/intel_extension_for_transformers/llm/operator/cscr/dispatcher/CMakeLists.txt
+++ b/intel_extension_for_transformers/llm/operator/cscr/dispatcher/CMakeLists.txt
@@ -13,7 +13,6 @@
 ##  limitations under the License.
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 project(jblas_dispatcher LANGUAGES C CXX)
-set_property(GLOBAL PROPERTY POSITION_INDEPENDENT_CODE ON)
 if(NOT WIN32)
 set(CMAKE_CXX_FLAGS "-Wno-narrowing -fconcepts")
 endif()
@@ -33,6 +32,7 @@ set_target_properties(jblas_dispatcher PROPERTIES C_STANDARD 20 C_STANDARD_REQUI
 set_target_properties(jblas_dispatcher PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF)
 endif()
 
+set_target_properties(jblas_dispatcher PROPERTIES POSITION_INDEPENDENT_CODE ON)
 set_target_properties(jblas_dispatcher PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(jblas_dispatcher "${TORCH_LIBRARIES}" jblas::jblas)
 set_property(TARGET torch_cpu PROPERTY INTERFACE_COMPILE_OPTIONS "")

--- a/intel_extension_for_transformers/llm/operator/cscr/dispatcher/src/jblas_weightonly_dispatcher.cpp
+++ b/intel_extension_for_transformers/llm/operator/cscr/dispatcher/src/jblas_weightonly_dispatcher.cpp
@@ -112,9 +112,9 @@ void qbits_dequantize(qbits_config_param* p, qbits_runtime_ctx* ctx) {
   auto parse_wei = dynamic_cast<typename PrologueB::StorageWeight*>(ctx->deseries_wei);
   TORCH_CHECK(parse_wei != nullptr, "Qbits: unresolved compressed weight.");
   if (ctx->transpose)
-    decompress_kernel.unpackTransposeWeight(ctx->n, ctx->k, parse_wei, ctx->output->data_ptr<float>(), ctx->k);
+    decompress_kernel.unpackTransposeWeight(int(ctx->n), int(ctx->k), parse_wei, ctx->output->data_ptr<float>(), int(ctx->k));
   else
-    decompress_kernel.unpackWeight(ctx->n, ctx->k, parse_wei, ctx->output->data_ptr<float>(), ctx->n);
+    decompress_kernel.unpackWeight(int(ctx->n), int(ctx->k), parse_wei, ctx->output->data_ptr<float>(), int(ctx->n));
 }
 
 template <class KERNEL, class ParamA, class ParamC>
@@ -122,9 +122,9 @@ void do_compute(qbits_config_param* p, qbits_runtime_ctx* ctx, const ParamA para
   if (initer.verbose) timer.start();
   static KERNEL gemm_kernel;
   if constexpr (!perchannel_Gemmcore<typename KERNEL::GemmCore>)
-    gemm_kernel.compute({ctx->m, ctx->n, ctx->k, param_a, ctx->deseries_wei, param_c});
+    gemm_kernel.compute({int(ctx->m), int(ctx->n), int(ctx->k), param_a, ctx->deseries_wei, param_c});
   else
-    gemm_kernel.template compute<true, false>({ctx->m, ctx->n, ctx->k, param_a, ctx->deseries_wei, param_c});
+    gemm_kernel.template compute<true, false>({int(ctx->m), int(ctx->n), int(ctx->k), param_a, ctx->deseries_wei, param_c});
   if (initer.verbose) {
     timer.stop();
     auto cost_time = timer.get_elapsed_time();

--- a/intel_extension_for_transformers/llm/runtime/deprecated/executor/src/operators/convolution.cpp
+++ b/intel_extension_for_transformers/llm/runtime/deprecated/executor/src/operators/convolution.cpp
@@ -228,30 +228,32 @@ void ConvolutionOperator::Prepare(const vector<Tensor*>& input, const vector<Ten
     for (int i = 0; i < weight_scales_.size(); i++) weight_scales_[i] = 1.0 / weight_scales_[i];
     for (int i = 0; i < dst_scales_.size(); i++) dst_scales_[i] = 1.0 / dst_scales_[i];
     attr_.set_scales_mask(DNNL_ARG_SRC, /* mask */ 0);
-    auto src_scale_md = memory::desc({src_scales_.size()}, memory::data_type::f32, memory::format_tag::x);
+    auto src_scale_md = memory::desc({dnnl_dim_t(src_scales_.size())}, memory::data_type::f32, memory::format_tag::x);
     auto src_scales_m = memory(src_scale_md, eng_, reinterpret_cast<void*>(src_scales_.data()));
     memory_args_[DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC] = src_scales_m;
 
     if (src_->dtype() == "u8") {
       attr_.set_zero_points_mask(DNNL_ARG_SRC, /* mask */ 0);
-      auto src_zps_md = memory::desc({src_zps_.size()}, memory::data_type::s32, memory::format_tag::x);
+      auto src_zps_md = memory::desc({dnnl_dim_t(src_zps_.size())}, memory::data_type::s32, memory::format_tag::x);
       auto src_zps_m_ = memory(src_zps_md, eng_, reinterpret_cast<void*>(src_zps_.data()));
       memory_args_[DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC] = src_zps_m_;
     }
 
     attr_.set_scales_mask(DNNL_ARG_WEIGHTS, /* mask */ weight_scales_.size() > 1 ? 1 : 0);
-    auto src1_scale_md = memory::desc({weight_scales_.size()}, memory::data_type::f32, memory::format_tag::x);
+    auto src1_scale_md =
+        memory::desc({dnnl_dim_t(weight_scales_.size())}, memory::data_type::f32, memory::format_tag::x);
     auto src1_scales_m = memory(src1_scale_md, eng_, reinterpret_cast<void*>(weight_scales_.data()));
     memory_args_[DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS] = src1_scales_m;
 
     if (dst_min_ && (dst_->dtype() == "u8" || dst_->dtype() == "s8")) {
       attr_.set_scales_mask(DNNL_ARG_DST, /* mask */ 0);
-      auto dst_scales_md = memory::desc({dst_scales_.size()}, memory::data_type::f32, memory::format_tag::x);
+      auto dst_scales_md =
+          memory::desc({dnnl_dim_t(dst_scales_.size())}, memory::data_type::f32, memory::format_tag::x);
       auto dst_scales_m = memory(dst_scales_md, eng_, reinterpret_cast<void*>(dst_scales_.data()));
       memory_args_[DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST] = dst_scales_m;
       if (dst_->dtype() == "u8") {
         attr_.set_zero_points_mask(DNNL_ARG_DST, /* mask */ 0);
-        auto dst_zps_md = memory::desc({dst_zps_.size()}, memory::data_type::s32, memory::format_tag::x);
+        auto dst_zps_md = memory::desc({dnnl_dim_t(dst_zps_.size())}, memory::data_type::s32, memory::format_tag::x);
         auto dst_zps_m_ = memory(dst_zps_md, eng_, reinterpret_cast<void*>(dst_zps_.data()));
         memory_args_[DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST] = dst_zps_m_;
       }
@@ -406,13 +408,13 @@ void ConvolutionOperator::Reshape(const vector<Tensor*>& input, const vector<Ten
       attr_.set_scales_mask(DNNL_ARG_SRC, mask);
       // need zero point when src0 is u8
       if (src_->dtype() == "u8") {
-        zp_src0_mem_ = memory({{src_min_->size()}, memory::data_type::s32, {1}}, eng_, DNNL_MEMORY_NONE);
+        zp_src0_mem_ = memory({{dnnl_dim_t(src_min_->size())}, memory::data_type::s32, {1}}, eng_, DNNL_MEMORY_NONE);
         attr_.set_zero_points_mask(DNNL_ARG_SRC, mask);
       }
-      scale_src_mem_ = memory({{src_max_->size()}, memory::data_type::f32, {1}}, eng_, DNNL_MEMORY_NONE);
+      scale_src_mem_ = memory({{dnnl_dim_t(src_max_->size())}, memory::data_type::f32, {1}}, eng_, DNNL_MEMORY_NONE);
       mask = weight_max_->size() > 1 ? 1 : 0;
       attr_.set_scales_mask(DNNL_ARG_WEIGHTS, mask);
-      memory::desc scale_md_ = memory::desc({weight_max_->size()}, memory::data_type::f32, {1});
+      memory::desc scale_md_ = memory::desc({dnnl_dim_t(weight_max_->size())}, memory::data_type::f32, {1});
       scale_weight_mem_ = memory(scale_md_, eng_, DNNL_MEMORY_NONE);
     }
   }

--- a/intel_extension_for_transformers/llm/runtime/deprecated/executor/src/operators/inner_product.cpp
+++ b/intel_extension_for_transformers/llm/runtime/deprecated/executor/src/operators/inner_product.cpp
@@ -1143,7 +1143,8 @@ void InnerProductOperator::PrepareDense(const vector<Tensor*>& input, const vect
         dst_zps_ = GetZeroPoints(dst_min_->data(), dst_scales_, dst_->dtype());
 
         for (int i = 0; i < dst_scales_.size(); i++) dst_scales_[i] = 1.0 / dst_scales_[i];
-        auto dst_scale_md = memory::desc({dst_scales_.size()}, memory::data_type::f32, memory::format_tag::x);
+        auto dst_scale_md =
+            memory::desc({dnnl_dim_t(dst_scales_.size())}, memory::data_type::f32, memory::format_tag::x);
         auto dst_scales_m_ = memory(dst_scale_md, eng_, reinterpret_cast<void*>(dst_scales_.data()));
         memory_args_[DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST] = dst_scales_m_;
       }
@@ -1152,12 +1153,14 @@ void InnerProductOperator::PrepareDense(const vector<Tensor*>& input, const vect
       for (int i = 0; i < src1_scales_.size(); i++) src1_scales_[i] = 1.0 / src1_scales_[i];
 
       attr_.set_scales_mask(DNNL_ARG_SRC, /* mask */ 0);
-      auto src_scale_md = memory::desc({src0_scales_.size()}, memory::data_type::f32, memory::format_tag::x);
+      auto src_scale_md =
+          memory::desc({dnnl_dim_t(src0_scales_.size())}, memory::data_type::f32, memory::format_tag::x);
       auto src_scales_m = memory(src_scale_md, eng_, reinterpret_cast<void*>(src0_scales_.data()));
       memory_args_[DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC] = src_scales_m;
 
       attr_.set_scales_mask(DNNL_ARG_WEIGHTS, /* mask */ src1_scales_.size() > 1 ? 1 : 0);
-      auto src1_scale_md = memory::desc({src1_scales_.size()}, memory::data_type::f32, memory::format_tag::x);
+      auto src1_scale_md =
+          memory::desc({dnnl_dim_t(src1_scales_.size())}, memory::data_type::f32, memory::format_tag::x);
       auto src1_scales_m = memory(src1_scale_md, eng_, reinterpret_cast<void*>(src1_scales_.data()));
       memory_args_[DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS] = src1_scales_m;
     } else {

--- a/intel_extension_for_transformers/llm/runtime/deprecated/executor/src/operators/matmul.cpp
+++ b/intel_extension_for_transformers/llm/runtime/deprecated/executor/src/operators/matmul.cpp
@@ -260,12 +260,13 @@ void MatmulOperator::Prepare(const vector<Tensor*>& input, const vector<Tensor*>
         attr_.set_scales_mask(DNNL_ARG_DST, /* mask */ 0);
         dst_zps_ = GetZeroPoints(dst_min_->data(), dst_scales_, dst_->dtype());
         for (int i = 0; i < dst_scales_.size(); i++) dst_scales_[i] = 1.0 / dst_scales_[i];
-        auto dst_scale_md = memory::desc({dst_scales_.size()}, memory::data_type::f32, memory::format_tag::x);
+        auto dst_scale_md =
+            memory::desc({dnnl_dim_t(dst_scales_.size())}, memory::data_type::f32, memory::format_tag::x);
         auto dst_scales_m_ = memory(dst_scale_md, eng_, reinterpret_cast<void*>(dst_scales_.data()));
         memory_args_[DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST] = dst_scales_m_;
         if (dst_->dtype() == "u8") {
           attr_.set_zero_points_mask(DNNL_ARG_DST, /* mask */ 0);
-          auto dst_zps_md = memory::desc({dst_zps_.size()}, memory::data_type::s32, memory::format_tag::x);
+          auto dst_zps_md = memory::desc({dnnl_dim_t(dst_zps_.size())}, memory::data_type::s32, memory::format_tag::x);
           auto dst_zps_m = memory(dst_zps_md, eng_, reinterpret_cast<void*>(dst_zps_.data()));
           memory_args_[DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST] = dst_zps_m;
         }
@@ -275,19 +276,21 @@ void MatmulOperator::Prepare(const vector<Tensor*>& input, const vector<Tensor*>
       for (int i = 0; i < src1_scales_.size(); i++) src1_scales_[i] = 1.0 / src1_scales_[i];
 
       attr_.set_scales_mask(DNNL_ARG_SRC, /* mask */ 0);
-      auto src_scale_md = memory::desc({src0_scales_.size()}, memory::data_type::f32, memory::format_tag::x);
+      auto src_scale_md =
+          memory::desc({dnnl_dim_t(src0_scales_.size())}, memory::data_type::f32, memory::format_tag::x);
       auto src_scales_m = memory(src_scale_md, eng_, reinterpret_cast<void*>(src0_scales_.data()));
       memory_args_[DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC] = src_scales_m;
 
       if (src0_->dtype() == "u8") {
         attr_.set_zero_points_mask(DNNL_ARG_SRC, /* mask */ 0);
-        auto src_zps_md = memory::desc({src0_zps_.size()}, memory::data_type::s32, memory::format_tag::x);
+        auto src_zps_md = memory::desc({dnnl_dim_t(src0_zps_.size())}, memory::data_type::s32, memory::format_tag::x);
         auto src_zps_m = memory(src_zps_md, eng_, reinterpret_cast<void*>(src0_zps_.data()));
         memory_args_[DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC] = src_zps_m;
       }
 
       attr_.set_scales_mask(DNNL_ARG_WEIGHTS, /* mask */ src1_scales_.size() > 1 ? 2 : 0);
-      auto src1_scale_md = memory::desc({src1_scales_.size()}, memory::data_type::f32, memory::format_tag::x);
+      auto src1_scale_md =
+          memory::desc({dnnl_dim_t(src1_scales_.size())}, memory::data_type::f32, memory::format_tag::x);
       auto src1_scales_m = memory(src1_scale_md, eng_, reinterpret_cast<void*>(src1_scales_.data()));
       memory_args_[DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS] = src1_scales_m;
 

--- a/intel_extension_for_transformers/llm/runtime/deprecated/executor/src/operators/reorder.cpp
+++ b/intel_extension_for_transformers/llm/runtime/deprecated/executor/src/operators/reorder.cpp
@@ -144,7 +144,8 @@ void ReorderOperator::Reshape(const vector<Tensor*>& input, const vector<Tensor*
 
   // Primitive arguments.
   if (src_scales_.size()) {
-    auto dst_scales_mem = memory({{src_scales_.size()}, memory::data_type::f32, memory::format_tag::x}, eng_);
+    auto dst_scales_mem =
+        memory({{dnnl_dim_t(src_scales_.size())}, memory::data_type::f32, memory::format_tag::x}, eng_);
     dst_scales_mem.set_data_handle(reinterpret_cast<void*>(src_scales_.data()));
     reorder_args[DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST] = dst_scales_mem;
   }


### PR DESCRIPTION
## Type of Change: bug fix
API not changed

## Description
- As title, as well as fixing narrowing conversion problems in qbit
- Compilation portability of qbit: use c++20 as MSVC does not have a feature switch for concept (`-fconcept` of GCC).
- Circumvent [a potential MSVC bug](https://developercommunity.visualstudio.com/t/Compilation-bug-C2760-when-using-omp-b/10470905?) that prevent using `}` just after `#progma omp barrier` inside a template.

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?
No