### PR TITLE
Fixed error for replace -100s in predictions by the pad token

### DIFF
--- a/examples/huggingface/pytorch/summarization/quantization/run_summarization.py
+++ b/examples/huggingface/pytorch/summarization/quantization/run_summarization.py
@@ -651,6 +651,8 @@ def main():
         preds, labels = eval_preds
         if isinstance(preds, tuple):
             preds = preds[0]
+        # Replace -100s used for padding as we can't decode them
+        preds = np.where(preds != -100, preds, tokenizer.pad_token_id)
         decoded_preds = tokenizer.batch_decode(preds, skip_special_tokens=True)
         if data_args.ignore_pad_token_for_loss:
             # Replace -100 in the labels as we can't decode them.

--- a/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
+++ b/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
@@ -68,7 +68,7 @@ class _BaseQBitsAutoModelClass:
         if load_in_8bit or load_in_4bit or quantization_config is not None:
             from intel_extension_for_transformers.llm.quantization.utils import convert_to_quantized_model
             torch_dtype = kwargs.pop("torch_dtype", torch.float32)
-        
+
         if load_in_4bit:
             if quantization_config is None:
                 quantization_config = WeightOnlyQuantConfig(compute_dtype=torch_dtype, weight_dtype="nf4")
@@ -189,6 +189,7 @@ class _BaseQBitsAutoModelClass:
             )
         return model
 
+
 class AutoModelForCausalLM(_BaseQBitsAutoModelClass):
     ORIG_MODEL = transformers.AutoModelForCausalLM
 
@@ -199,4 +200,3 @@ class AutoModel(_BaseQBitsAutoModelClass):
 
 class AutoModelForSeq2SeqLM(_BaseQBitsAutoModelClass):
     ORIG_MODEL = transformers.AutoModelForSeq2SeqLM
-


### PR DESCRIPTION
## Type of Change

bug fix
No API changed

## Description

Fixed error for replace -100s in predictions by the pad token, refer to https://github.com/huggingface/transformers/pull/22693

## Expected Behavior & Potential Risk

Run summarization examples successfully 

## How has this PR been tested?

Local tested
