### PR TITLE
[CPP Graph] KV-Update Optimization

### DIFF
--- a/intel_extension_for_transformers/llm/library/jblas/jblas/jit_base.hpp
+++ b/intel_extension_for_transformers/llm/library/jblas/jblas/jit_base.hpp
@@ -50,10 +50,10 @@ class JitBase : protected Xbyak::CodeGenerator {
 #endif
   }
 
-  void generate_Nbitsmask(const Xbyak::Opmask& _msk, const Xbyak::Reg64& _pos, const Xbyak::Reg64& _total,
+  void generate_Nbitsmask(const Xbyak::Opmask& _msk, const Xbyak::Reg64& _pos, const Xbyak::Address& _total,
                           const Xbyak::Reg64& _tmp, const Xbyak::Reg64& _tmp1, int N) {
     inLocalLabel();
-    mov(_tmp, _total);
+    lea(_tmp, _total);
     sub(_tmp, _pos);
     cmp(_tmp, N);
     jb(".maskflag");
@@ -77,6 +77,10 @@ class JitBase : protected Xbyak::CodeGenerator {
     kmovq(_msk, _tmp1);
     L(".maskend");
     outLocalLabel();
+  }
+  void generate_Nbitsmask(const Xbyak::Opmask& _msk, const Xbyak::Reg64& _pos, const Xbyak::Reg64& _total,
+                          const Xbyak::Reg64& _tmp, const Xbyak::Reg64& _tmp1, int N) {
+    generate_Nbitsmask(_msk, _pos, ptr[_total], _tmp, _tmp1, N);
   }
 };
 

--- a/intel_extension_for_transformers/llm/library/jblas/jblas/jit_blas_transformer.h
+++ b/intel_extension_for_transformers/llm/library/jblas/jblas/jit_blas_transformer.h
@@ -144,6 +144,7 @@ class QKVGemmInterfacePackWeightParallelAB {
       }
       if constexpr (_LaunchA || _LaunchB) {
 #pragma omp barrier
+        (void)(0);  // make msvc happy with c++20
       }
       launchT(_param, tidx, _paral, cb.mL2Cache);
     }

--- a/intel_extension_for_transformers/llm/library/jblas/jblas/jit_blas_utils.h
+++ b/intel_extension_for_transformers/llm/library/jblas/jblas/jit_blas_utils.h
@@ -18,6 +18,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstring>
+#include <functional>
 #include <vector>
 
 #include "jit_blas.h"
@@ -68,7 +69,6 @@ struct bf16 {
   bf16() : x(0) {}
 
 #if CompileBF16()
-#pragma GCC push_options
 #pragma GCC target("avx512vl", "avx512bf16")
   explicit bf16(float vf32) : x(bit_cast<uint16_t>(_mm_cvtness_sbh(vf32))) {}
 #else
@@ -198,6 +198,22 @@ struct f4x2 : bit4x2 {
   f4x2() : bit4x2() {}
 };
 
+template <typename T>
+inline constexpr JBLAS_DTYPE jblas_dtype = std::is_same_v<T, double>    ? JBLAS_DTYPE::JblasF64
+                                           : std::is_same_v<T, float>   ? JBLAS_DTYPE::JblasF32
+                                           : std::is_same_v<T, bf16>    ? JBLAS_DTYPE::JblasBF16
+                                           : std::is_same_v<T, int8_t>  ? JBLAS_DTYPE::JblasS8
+                                           : std::is_same_v<T, uint8_t> ? JBLAS_DTYPE::JblasU8
+                                                                        : (assert(0), JBLAS_DTYPE::JblasF32);
+
+inline constexpr size_t jblas_dtype_size(const JBLAS_DTYPE t) {
+  return t == JblasF64    ? sizeof(double)
+         : t == JblasF32  ? sizeof(float)
+         : t == JblasBF16 ? sizeof(bf16)
+         : t == JblasS8   ? sizeof(int8_t)
+         : t == JblasU8   ? sizeof(uint8_t)
+                          : (assert(false), 0);
+}
 #ifndef _WIN32
 #include <err.h>
 #include <errno.h>
@@ -464,6 +480,7 @@ class CpuDevice {
   inline bool AVX512_VNNI() { return mHasAVX512_VNNI; }
   inline bool AMX_INT8() { return mHasAMX_INT8; }
   inline bool AMX_BF16() { return mHasAMX_BF16; }
+  inline bool AVX512_BF16() { return mHasAVX512_BF16; }
   inline bool AVX512_FP16() { return mHasAVX512_FP16; }
 #define ADD_FLAG(isa) mHas##isa = _cpu.has(_cpu.t##isa)
   CpuDevice() {
@@ -477,6 +494,7 @@ class CpuDevice {
     ADD_FLAG(AVX_VNNI);
     ADD_FLAG(AMX_BF16);
     ADD_FLAG(AMX_INT8);
+    ADD_FLAG(AVX512_BF16);
     ADD_FLAG(AVX512_FP16);
     numcores = _cpu.getNumCores(Xbyak::util::IntelCpuTopologyLevel::CoreLevel);
     ompthreads = omp_get_max_threads();
@@ -493,14 +511,17 @@ class CpuDevice {
   }
 
   void print() {
-    printf("AVX:%d AVX2:%d AVX512F:%d AVX_VNNI:%d AVX512_VNNI:%d AMX_INT8:%d AMX_BF16:%d AVX512_FP16:%d\n", mHasAVX,
-           mHasAVX2, mHasAVX512F, mHasAVX_VNNI, mHasAVX512_VNNI, mHasAMX_INT8, mHasAMX_BF16, mHasAVX512_FP16);
+    printf(
+        "AVX:%d AVX2:%d AVX512F:%d AVX_VNNI:%d AVX512_VNNI:%d AMX_INT8:%d AMX_BF16:%d AVX512_BF16:%d AVX512_FP16:%d\n",
+        mHasAVX, mHasAVX2, mHasAVX512F, mHasAVX_VNNI, mHasAVX512_VNNI, mHasAMX_INT8, mHasAMX_BF16, mHasAVX512_BF16,
+        mHasAVX512_FP16);
   }
 #undef ADD_FLAG
 
  protected:
   uint32_t L2Cache, L1Cache;
-  bool mHasAVX2, mHasAVX_VNNI, mHasAVX, mHasAVX512_VNNI, mHasAMX_INT8, mHasAMX_BF16, mHasAVX512F, mHasAVX512_FP16;
+  bool mHasAVX2, mHasAVX_VNNI, mHasAVX, mHasAVX512_VNNI, mHasAMX_INT8, mHasAMX_BF16, mHasAVX512F, mHasAVX512_BF16,
+      mHasAVX512_FP16;
   int numcores;
   int ompthreads;
   int numthreads;
@@ -1106,4 +1127,13 @@ static float nf4_dequant_fp32_LUT[] = {0.f,
                                        0.7229568362236023f,
                                        1.0f};
 
+// Calcuate instruction(s) size (in bytes). Example:
+// const int s = get_inst_size([](Xbyak::CodeGenerator* c) { c->vmovups(c->ptr[c->rax], c->zmm0); });
+// printf("inst_size: %d\n", s);
+inline size_t get_inst_size(std::function<void(Xbyak::CodeGenerator*)> inst) {
+  Xbyak::CodeGenerator code;
+  code.resetSize();
+  inst(&code);
+  return code.getSize();
+}
 }  // namespace jblas

--- a/intel_extension_for_transformers/llm/library/jblas/jblas/jit_blas_weight_compression.h
+++ b/intel_extension_for_transformers/llm/library/jblas/jblas/jit_blas_weight_compression.h
@@ -1713,7 +1713,7 @@ class GemmInterfaceKblockParallelAB {
       }
       if constexpr (_LaunchA || _LaunchB) {
 #pragma omp barrier
-        (void)(0);  // make msvc happy
+        (void)(0);  // make msvc happy with c++20
       }
       int colidx, rowidx, rowsize, colsize;
       para.getIndex(tidx, &rowidx, &colidx, &rowsize, &colsize);

--- a/intel_extension_for_transformers/llm/library/jblas/jblas/jit_blas_wrapper.h
+++ b/intel_extension_for_transformers/llm/library/jblas/jblas/jit_blas_wrapper.h
@@ -190,7 +190,7 @@ class GemmInterfaceParallelAB {
       }
       if constexpr (_LaunchA || _LaunchB) {
 #pragma omp barrier
-        (void)(0);  // make msvc happy
+        (void)(0);  // make msvc happy with c++20
       }
       int colidx, rowidx, rowsize, colsize;
       para.getIndex(tidx, &rowidx, &colidx, &rowsize, &colsize);

--- a/intel_extension_for_transformers/llm/library/jblas/jblas/kernel_avx2.h
+++ b/intel_extension_for_transformers/llm/library/jblas/jblas/kernel_avx2.h
@@ -447,6 +447,10 @@ static inline JBLAS_CODE fp32_cvt_bf16_2D_write_back(const void* raw_srcptr, voi
   return JblasSuccess;
 }
 
+#ifdef __GNUC__
+#pragma GCC pop_options
+#else
+#endif
 #endif
 }  // namespace avx2
 }  // namespace kernel

--- a/intel_extension_for_transformers/llm/runtime/graph/core/layers/mha_dense.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/layers/mha_dense.cpp
@@ -1895,8 +1895,6 @@ void jblas_reordered_attn_fp32_update_v(const jblas_fusion_attn_fp32_update_kv_a
   GetCPUDevice();
   const bool use_jit = _cd->AVX512_BF16() && (p.seq_off == 0);
 
-  jblas::utils::timer<jblas::utils::microseconds> tm;
-  tm.start();
 #pragma omp parallel for collapse(2)
   for (int ibs = 0; ibs < p.batch_size; ++ibs) {
     for (int ihn = 0; ihn < p.head_num; ++ihn) {
@@ -1920,9 +1918,6 @@ void jblas_reordered_attn_fp32_update_v(const jblas_fusion_attn_fp32_update_kv_a
       }
     }
   }
-  const auto t_kern = tm.stop();
-  const auto data_size = sizeof(*p.src) * p.batch_size * p.head_num * p.seq_size * p.head_size;
-  // printf("t: %f us\tBandwidth: %f GB/s\n", t_kern, data_size / t_kern / 1000.f);
 }
 
 #ifdef __GNUC__

--- a/intel_extension_for_transformers/llm/runtime/graph/core/ne.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/ne.h
@@ -48,6 +48,12 @@
 
 #define NE_SIZE_CALC -1
 
+#if __AVX512F__
+#define NE_ALIGNMENT 64
+#else
+#define NE_ALIGNMENT 32
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_utils.cpp
@@ -81,9 +81,11 @@ static bool kv_cache_init(const struct model_hparams& hparams, struct model_kv_c
   }
 
   // NE_TYPE_JBLAS can not be allocated memory
-  cache.k = ne_new_tensor_1d(cache.ctx, wtype == NE_TYPE_JBLAS ? NE_TYPE_I8 : wtype, n_elements_k, NE_SIZE_CALC);
+  cache.k = ne_new_tensor_1d(cache.ctx, wtype == NE_TYPE_JBLAS ? NE_TYPE_I8 : wtype, n_elements_k + 64, NE_SIZE_CALC);
+  cache.k = ne_view_1d(cache.ctx, cache.k, n_elements_k, 64 - (reinterpret_cast<uintptr_t>(cache.k->data) % 64));
   cache.k->type = wtype;
-  cache.v = ne_new_tensor_1d(cache.ctx, wtype == NE_TYPE_JBLAS ? NE_TYPE_I8 : wtype, n_elements_v, NE_SIZE_CALC);
+  cache.v = ne_new_tensor_1d(cache.ctx, wtype == NE_TYPE_JBLAS ? NE_TYPE_I8 : wtype, n_elements_v + 64, NE_SIZE_CALC);
+  cache.v = ne_view_1d(cache.ctx, cache.v, n_elements_v, 64 - (reinterpret_cast<uintptr_t>(cache.v->data) % 64));
   cache.v->type = wtype;
   ne_set_name(cache.k, "cache_k");
   ne_set_name(cache.v, "cache_v");

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_utils.cpp
@@ -824,10 +824,10 @@ size_t jblas_quantize(const float* f32ptr, void* dstpr, const quant_params_inter
           }
         }
       } else if (params.compute_dtype == quant_comp::fp32) {
-        using Kernel = WeiS4ClipFp32<GcCompFp32, JblasAVX512_FP16>;
+        using Kernel = WeiS4ClipFp32<GcCompFp32, JblasAVX512F>;
         using KernelRef = WeiS4ClipFp32<GcCompFp32, JblasNoSIMD>;
         static Kernel kernel;
-        static Kernel kernelref;
+        static KernelRef kernelref;
         packedw = kernel.createStorage(n, k, params.group_size, params.alg == quant_alg::sym);
         if (cd->AVX512_FP16()) {
           kernel.packTransposeWeight(n, k, f32ptr, k, packedw);
@@ -835,10 +835,10 @@ size_t jblas_quantize(const float* f32ptr, void* dstpr, const quant_params_inter
           kernelref.packTransposeWeight(n, k, f32ptr, k, packedw);
         }
       } else if (params.compute_dtype == quant_comp::bf16) {
-        using Kernel = WeiS4ClipFp32<GcCompBf16, JblasAMX_BF16>;
+        using Kernel = WeiS4ClipFp32<GcCompBf16, JblasAVX512F>;
         using KernelRef = WeiS4ClipFp32<GcCompBf16, JblasNoSIMD>;
         static Kernel kernel;
-        static Kernel kernelref;
+        static KernelRef kernelref;
         packedw = kernel.createStorage(n, k, params.group_size, params.alg == quant_alg::sym);
         if (cd->AMX_BF16()) {
           kernel.packTransposeWeight(n, k, f32ptr, k, packedw);
@@ -859,7 +859,7 @@ size_t jblas_quantize(const float* f32ptr, void* dstpr, const quant_params_inter
           using Kernel = WeiS8Fp32PerN<GcCompInt8, JblasAVX512F>;
           using KernelRef = WeiS8Fp32PerN<GcCompInt8, JblasNoSIMD>;
           static Kernel kernel;
-          static Kernel kernelref;
+          static KernelRef kernelref;
           packedw = kernel.createStorage(n, k);
           if (cd->AVX512F()) {
             kernel.packTransposeWeight(n, k, f32ptr, k, packedw);
@@ -870,7 +870,7 @@ size_t jblas_quantize(const float* f32ptr, void* dstpr, const quant_params_inter
           using Kernel = WeiS8Fp32<GcCompInt8KBlock, JblasAVX512F>;
           using KernelRef = WeiS8Fp32<GcCompInt8KBlock, JblasNoSIMD>;
           static Kernel kernel;
-          static Kernel kernelref;
+          static KernelRef kernelref;
           packedw = kernel.createStorage(n, k, params.group_size);
           if (cd->AVX512F()) {
             kernel.packTransposeWeight(n, k, f32ptr, k, packedw);
@@ -879,10 +879,10 @@ size_t jblas_quantize(const float* f32ptr, void* dstpr, const quant_params_inter
           }
         }
       } else if (params.compute_dtype == quant_comp::fp32) {
-        using Kernel = WeiS8Fp32<GcCompFp32, JblasAVX512_FP16>;
+        using Kernel = WeiS8Fp32<GcCompFp32, JblasAVX512F>;
         using KernelRef = WeiS8Fp32<GcCompFp32, JblasNoSIMD>;
         static Kernel kernel;
-        static Kernel kernelref;
+        static KernelRef kernelref;
         packedw = kernel.createStorage(n, k, params.group_size, params.alg == quant_alg::sym);
         if (cd->AVX512_FP16()) {
           kernel.packTransposeWeight(n, k, f32ptr, k, packedw);
@@ -890,10 +890,10 @@ size_t jblas_quantize(const float* f32ptr, void* dstpr, const quant_params_inter
           kernelref.packTransposeWeight(n, k, f32ptr, k, packedw);
         }
       } else if (params.compute_dtype == quant_comp::bf16) {
-        using Kernel = WeiS8Fp32<GcCompBf16, JblasAMX_BF16>;
+        using Kernel = WeiS8Fp32<GcCompBf16, JblasAVX512F>;
         using KernelRef = WeiS8Fp32<GcCompBf16, JblasNoSIMD>;
         static Kernel kernel;
-        static Kernel kernelref;
+        static KernelRef kernelref;
         packedw = kernel.createStorage(n, k, params.group_size, params.alg == quant_alg::sym);
         if (cd->AMX_BF16()) {
           kernel.packTransposeWeight(n, k, f32ptr, k, packedw);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_utils.cpp
@@ -81,11 +81,14 @@ static bool kv_cache_init(const struct model_hparams& hparams, struct model_kv_c
   }
 
   // NE_TYPE_JBLAS can not be allocated memory
-  cache.k = ne_new_tensor_1d(cache.ctx, wtype == NE_TYPE_JBLAS ? NE_TYPE_I8 : wtype, n_elements_k + 64, NE_SIZE_CALC);
-  cache.k = ne_view_1d(cache.ctx, cache.k, n_elements_k, 64 - (reinterpret_cast<uintptr_t>(cache.k->data) % 64));
+  const auto wtype_alloc = wtype == NE_TYPE_JBLAS ? NE_TYPE_I8 : wtype;
+  cache.k = ne_new_tensor_1d(cache.ctx, wtype_alloc, n_elements_k + NE_ALIGNMENT, NE_SIZE_CALC);
+  cache.k = ne_view_1d(cache.ctx, cache.k, n_elements_k,
+                       NE_ALIGNMENT - (reinterpret_cast<uintptr_t>(cache.k->data) % NE_ALIGNMENT));
   cache.k->type = wtype;
-  cache.v = ne_new_tensor_1d(cache.ctx, wtype == NE_TYPE_JBLAS ? NE_TYPE_I8 : wtype, n_elements_v + 64, NE_SIZE_CALC);
-  cache.v = ne_view_1d(cache.ctx, cache.v, n_elements_v, 64 - (reinterpret_cast<uintptr_t>(cache.v->data) % 64));
+  cache.v = ne_new_tensor_1d(cache.ctx, wtype_alloc, n_elements_v + NE_ALIGNMENT, NE_SIZE_CALC);
+  cache.v = ne_view_1d(cache.ctx, cache.v, n_elements_v,
+                       NE_ALIGNMENT - (reinterpret_cast<uintptr_t>(cache.v->data) % NE_ALIGNMENT));
   cache.v->type = wtype;
   ne_set_name(cache.k, "cache_k");
   ne_set_name(cache.v, "cache_v");


### PR DESCRIPTION
## Type of Change: feature
API not changed

## Description
- The FLASH_ATTN_KV_UPDATE op now uses JIT implementations for first token inference
- Update jblas to 21757a4

## Expected Behavior & Potential Risk
N/A

## How has this PR been tested?
<details>
<summary>Interference result:</summary>

```bash
set -ex
#main branch
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=ON -DCMAKE_BUILD_TYPE=Release && ninja run_gptj && env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_gptj -m /home_local/dingyi/data/gpt-j-6B-pr347-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 48 -b 2048 -c 2048 -n 1 -p "$LUOYU_PROMPT"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=ON -DCMAKE_BUILD_TYPE=Release && ninja run_gptj && env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_gptj -m /home_local/dingyi/data/gpt-j-6B-pr347-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 1 -p "$LUOYU_PROMPT"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=OFF -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_gptj && env --unset ENGINE_PROFILING numactl -m 1 -C 56-111 bin/run_gptj -m /home_local/dingyi/data/gpt-j-6B-pr347-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 32 -p "$GIRL_PROMPT"
#llama has different tokenizer and can only process a slightly shorter prompt
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=ON -DCMAKE_BUILD_TYPE=Release && ninja run_llama && env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_llama -m /home_local/dingyi/data/llama-7b-hf-pr347-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 1 -p "$(echo "$LUOYU_PROMPT" | cut -d' ' -f 1-1500)"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=OFF -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_llama && env --unset ENGINE_PROFILING numactl -m 1 -C 56-111 bin/run_llama -m /home_local/dingyi/data/llama-7b-hf-pr347-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 32 -p "$GIRL_PROMPT"

#this branch
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=ON -DCMAKE_BUILD_TYPE=Release && ninja run_gptj && env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_gptj -m /home_local/dingyi/data/gpt-j-6B-pr347-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 48 -b 2048 -c 2048 -n 1 -p "$LUOYU_PROMPT"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=ON -DCMAKE_BUILD_TYPE=Release && ninja run_gptj && env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_gptj -m /home_local/dingyi/data/gpt-j-6B-pr347-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 1 -p "$LUOYU_PROMPT"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=OFF -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_gptj && env --unset ENGINE_PROFILING numactl -m 1 -C 56-111 bin/run_gptj -m /home_local/dingyi/data/gpt-j-6B-pr347-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 32 -p "$GIRL_PROMPT"
#llama has different tokenizer and can only process a slightly shorter prompt
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=ON -DCMAKE_BUILD_TYPE=Release && ninja run_llama && env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_llama -m /home_local/dingyi/data/llama-7b-hf-pr347-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 1 -p "$(echo "$LUOYU_PROMPT" | cut -d' ' -f 1-1500)"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=OFF -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_llama && env --unset ENGINE_PROFILING numactl -m 1 -C 56-111 bin/run_llama -m /home_local/dingyi/data/llama-7b-hf-pr347-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 32 -p "$GIRL_PROMPT"
```
</details>

### Main branch 
- <details>
  <summary>
  <code>env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_gptj -m /home_local/dingyi/data/gpt-j-6B-pr347-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 48 -b 2048 -c 2048 -n 1 -p "$LUOYU_PROMPT"</code>
  </summary>

  ```
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =  55.135 ms
  perf_total_per_op_us[                     MUL] =  15.932 ms
  perf_total_per_op_us[                    NORM] =  25.274 ms
  perf_total_per_op_us[                 MUL_MAT] =  81.835 ms
  perf_total_per_op_us[       MUL_MAT_WITH_BIAS] =  59.493 ms
  perf_total_per_op_us[                 RESHAPE] =   0.285 ms
  perf_total_per_op_us[                    VIEW] =   0.750 ms
  perf_total_per_op_us[                 PERMUTE] =   0.115 ms
  perf_total_per_op_us[                GET_ROWS] =   7.722 ms
  perf_total_per_op_us[                    ROPE] =  30.034 ms
  perf_total_per_op_us[                 MUL_QKV] = 221.504 ms
  perf_total_per_op_us[            FFN_ADD_GeLU] = 600.671 ms
  perf_total_per_op_us[              FLASH_ATTN] = 209.671 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =  94.790 ms
  perf_total_per_op_us[           INNER PRODUCT] =   0.000 ms
  ========================================
  ```
  </details>
- <details>
  <summary>
  <code>env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_gptj -m /home_local/dingyi/data/gpt-j-6B-pr347-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 1 -p "$LUOYU_PROMPT"</code>
  </summary>

  ```
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =  43.585 ms
  perf_total_per_op_us[                     MUL] =  11.440 ms
  perf_total_per_op_us[                    NORM] =  22.630 ms
  perf_total_per_op_us[                 MUL_MAT] =  72.616 ms
  perf_total_per_op_us[       MUL_MAT_WITH_BIAS] =  63.080 ms
  perf_total_per_op_us[                 RESHAPE] =   0.320 ms
  perf_total_per_op_us[                    VIEW] =   0.709 ms
  perf_total_per_op_us[                 PERMUTE] =   0.098 ms
  perf_total_per_op_us[                GET_ROWS] =   8.266 ms
  perf_total_per_op_us[                    ROPE] =  33.194 ms
  perf_total_per_op_us[                 MUL_QKV] = 207.260 ms
  perf_total_per_op_us[            FFN_ADD_GeLU] = 584.771 ms
  perf_total_per_op_us[              FLASH_ATTN] = 194.659 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =  90.783 ms
  perf_total_per_op_us[           INNER PRODUCT] =   0.000 ms
  ========================================
  ```
  </details>
- <details>
  <summary>
  <code>env --unset ENGINE_PROFILING numactl -m 1 -C 56-111 bin/run_gptj -m /home_local/dingyi/data/gpt-j-6B-pr347-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 32 -p "$GIRL_PROMPT"</code>
  </summary>

  ```
  Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun. This girl went by the name of LittleRed Riding Hood.
  One day Little Red Riding Hood was walking through the forest when she noticed someone following her. She
  model_print_timings:        load time =  1083.34 ms
  model_print_timings:      sample time =    28.25 ms /    32 runs   (    0.88 ms per token)
  model_print_timings: prompt eval time =    89.23 ms /    32 tokens (    2.79 ms per token)
  model_print_timings:        eval time =   716.09 ms /    31 runs   (   23.10 ms per token)
  model_print_timings:       total time =  1842.00 ms
  ========== eval time log of each prediction ==========
  prediction   0, time: 89.23ms
  prediction   1, time: 28.39ms
  prediction   2, time: 26.08ms
  prediction   3, time: 23.91ms
  prediction   4, time: 23.78ms
  prediction   5, time: 24.07ms
  prediction   6, time: 24.24ms
  prediction   7, time: 23.89ms
  prediction   8, time: 23.18ms
  prediction   9, time: 22.95ms
  prediction  10, time: 22.72ms
  prediction  11, time: 22.56ms
  prediction  12, time: 22.70ms
  prediction  13, time: 22.48ms
  prediction  14, time: 22.42ms
  prediction  15, time: 22.27ms
  prediction  16, time: 22.65ms
  prediction  17, time: 22.93ms
  prediction  18, time: 22.40ms
  prediction  19, time: 22.64ms
  prediction  20, time: 22.42ms
  prediction  21, time: 22.71ms
  prediction  22, time: 22.46ms
  prediction  23, time: 22.66ms
  prediction  24, time: 22.50ms
  prediction  25, time: 22.40ms
  prediction  26, time: 22.33ms
  prediction  27, time: 22.53ms
  prediction  28, time: 22.52ms
  prediction  29, time: 22.74ms
  prediction  30, time: 22.16ms
  prediction  31, time: 22.38ms
  ```
  </details>
- <details>
  <summary>
  <code>env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_llama -m /home_local/dingyi/data/llama-7b-hf-pr347-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 1 -p "$(echo "$LUOYU_PROMPT" | cut -d' ' -f 1-1500)"</code>
  </summary>

  ```
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =  61.765 ms
  perf_total_per_op_us[                     MUL] =  40.942 ms
  perf_total_per_op_us[                RMS_NORM] =  60.443 ms
  perf_total_per_op_us[                 MUL_MAT] = 149.868 ms
  perf_total_per_op_us[                 RESHAPE] =   0.450 ms
  perf_total_per_op_us[                    VIEW] =   0.980 ms
  perf_total_per_op_us[                 PERMUTE] =   0.115 ms
  perf_total_per_op_us[               TRANSPOSE] =   0.103 ms
  perf_total_per_op_us[                GET_ROWS] =   7.885 ms
  perf_total_per_op_us[                    ROPE] =  50.016 ms
  perf_total_per_op_us[                 MUL_QKV] = 285.974 ms
  perf_total_per_op_us[                FFN_SILU] = 769.070 ms
  perf_total_per_op_us[              FLASH_ATTN] = 223.920 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] = 100.957 ms
  perf_total_per_op_us[           INNER PRODUCT] =   0.000 ms
  ========================================
  ```
  </details>
- <details>
  <summary>
  <code>env --unset ENGINE_PROFILING numactl -m 1 -C 56-111 bin/run_llama -m /home_local/dingyi/data/llama-7b-hf-pr347-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 32 -p "$GIRL_PROMPT"</code>
  </summary>

  ```
  Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun.
  Then one day, that little girl grew up. And she became a woman. A woman with a job, who travelled overseas for work,
  model_print_timings:        load time =  1267.53 ms
  model_print_timings:      sample time =    18.97 ms /    32 runs   (    0.59 ms per token)
  model_print_timings: prompt eval time =   105.54 ms /    34 tokens (    3.10 ms per token)
  model_print_timings:        eval time =   783.36 ms /    31 runs   (   25.27 ms per token)
  model_print_timings:       total time =  2079.16 ms
  ========== eval time log of each prediction ==========
  prediction   0, time: 105.54ms
  prediction   1, time: 26.41ms
  prediction   2, time: 25.19ms
  prediction   3, time: 25.41ms
  prediction   4, time: 25.37ms
  prediction   5, time: 25.21ms
  prediction   6, time: 25.17ms
  prediction   7, time: 25.18ms
  prediction   8, time: 25.28ms
  prediction   9, time: 25.41ms
  prediction  10, time: 25.21ms
  prediction  11, time: 25.12ms
  prediction  12, time: 25.15ms
  prediction  13, time: 25.11ms
  prediction  14, time: 25.07ms
  prediction  15, time: 25.54ms
  prediction  16, time: 25.32ms
  prediction  17, time: 24.97ms
  prediction  18, time: 25.49ms
  prediction  19, time: 25.07ms
  prediction  20, time: 25.04ms
  prediction  21, time: 25.07ms
  prediction  22, time: 25.33ms
  prediction  23, time: 25.16ms
  prediction  24, time: 25.20ms
  prediction  25, time: 25.42ms
  prediction  26, time: 25.51ms
  prediction  27, time: 25.27ms
  prediction  28, time: 25.41ms
  prediction  29, time: 25.02ms
  prediction  30, time: 25.28ms
  prediction  31, time: 25.00ms
  ```
  </details>

### This branch
- <details>
  <summary>
  <code>env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_gptj -m /home_local/dingyi/data/gpt-j-6B-pr347-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 48 -b 2048 -c 2048 -n 1 -p "$LUOYU_PROMPT"</code>
  </summary>

  ```
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =  49.759 ms
  perf_total_per_op_us[                     MUL] =  14.224 ms
  perf_total_per_op_us[                    NORM] =  22.228 ms
  perf_total_per_op_us[                 MUL_MAT] =  81.711 ms
  perf_total_per_op_us[       MUL_MAT_WITH_BIAS] =  59.821 ms
  perf_total_per_op_us[                 RESHAPE] =   0.300 ms
  perf_total_per_op_us[                    VIEW] =   0.700 ms
  perf_total_per_op_us[                 PERMUTE] =   0.093 ms
  perf_total_per_op_us[                GET_ROWS] =   7.708 ms
  perf_total_per_op_us[                    ROPE] =  30.821 ms
  perf_total_per_op_us[                 MUL_QKV] = 226.942 ms
  perf_total_per_op_us[            FFN_ADD_GeLU] = 599.899 ms
  perf_total_per_op_us[              FLASH_ATTN] = 146.544 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =  56.004 ms
  perf_total_per_op_us[           INNER PRODUCT] =   0.000 ms
  ========================================
  ```
  </details>
- <details>
  <summary>
  <code>env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_gptj -m /home_local/dingyi/data/gpt-j-6B-pr347-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 1 -p "$LUOYU_PROMPT"</code>
  </summary>

  ```
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =  44.710 ms
  perf_total_per_op_us[                     MUL] =  11.468 ms
  perf_total_per_op_us[                    NORM] =  21.851 ms
  perf_total_per_op_us[                 MUL_MAT] =  79.625 ms
  perf_total_per_op_us[       MUL_MAT_WITH_BIAS] =  66.223 ms
  perf_total_per_op_us[                 RESHAPE] =   0.334 ms
  perf_total_per_op_us[                    VIEW] =   0.708 ms
  perf_total_per_op_us[                 PERMUTE] =   0.118 ms
  perf_total_per_op_us[                GET_ROWS] =   8.470 ms
  perf_total_per_op_us[                    ROPE] =  42.760 ms
  perf_total_per_op_us[                 MUL_QKV] = 215.438 ms
  perf_total_per_op_us[            FFN_ADD_GeLU] = 592.271 ms
  perf_total_per_op_us[              FLASH_ATTN] = 154.700 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =  58.654 ms
  perf_total_per_op_us[           INNER PRODUCT] =   0.000 ms
  ========================================
  ```
  </details>
- <details>
  <summary>
  <code>env --unset ENGINE_PROFILING numactl -m 1 -C 56-111 bin/run_gptj -m /home_local/dingyi/data/gpt-j-6B-pr347-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 32 -p "$GIRL_PROMPT"</code>
  </summary>

  ```
  Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun. This girl went by the name of LittleRed Riding Hood.
  One day Little Red Riding Hood was walking through the forest when she noticed someone following her. She
  model_print_timings:        load time =  1040.85 ms
  model_print_timings:      sample time =    32.42 ms /    32 runs   (    1.01 ms per token)
  model_print_timings: prompt eval time =    88.35 ms /    32 tokens (    2.76 ms per token)
  model_print_timings:        eval time =   724.59 ms /    31 runs   (   23.37 ms per token)
  model_print_timings:       total time =  1812.39 ms
  ========== eval time log of each prediction ==========
  prediction   0, time: 88.35ms
  prediction   1, time: 26.03ms
  prediction   2, time: 24.79ms
  prediction   3, time: 24.79ms
  prediction   4, time: 25.17ms
  prediction   5, time: 25.08ms
  prediction   6, time: 24.60ms
  prediction   7, time: 23.21ms
  prediction   8, time: 22.98ms
  prediction   9, time: 23.08ms
  prediction  10, time: 23.43ms
  prediction  11, time: 23.05ms
  prediction  12, time: 22.79ms
  prediction  13, time: 23.11ms
  prediction  14, time: 22.85ms
  prediction  15, time: 22.78ms
  prediction  16, time: 23.10ms
  prediction  17, time: 23.08ms
  prediction  18, time: 22.82ms
  prediction  19, time: 23.02ms
  prediction  20, time: 22.91ms
  prediction  21, time: 23.00ms
  prediction  22, time: 22.64ms
  prediction  23, time: 22.92ms
  prediction  24, time: 22.91ms
  prediction  25, time: 22.67ms
  prediction  26, time: 23.11ms
  prediction  27, time: 22.85ms
  prediction  28, time: 23.03ms
  prediction  29, time: 22.81ms
  prediction  30, time: 23.05ms
  prediction  31, time: 22.96ms
  ```
  </details>
- <details>
  <summary>
  <code>env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_llama -m /home_local/dingyi/data/llama-7b-hf-pr347-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 1 -p "$(echo "$LUOYU_PROMPT" | cut -d' ' -f 1-1500)"</code>
  </summary>

  ```
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =  45.444 ms
  perf_total_per_op_us[                     MUL] =  25.363 ms
  perf_total_per_op_us[                RMS_NORM] =  47.991 ms
  perf_total_per_op_us[                 MUL_MAT] = 135.003 ms
  perf_total_per_op_us[                 RESHAPE] =   0.427 ms
  perf_total_per_op_us[                    VIEW] =   0.984 ms
  perf_total_per_op_us[                 PERMUTE] =   0.108 ms
  perf_total_per_op_us[               TRANSPOSE] =   0.102 ms
  perf_total_per_op_us[                GET_ROWS] =   8.830 ms
  perf_total_per_op_us[                    ROPE] =  50.482 ms
  perf_total_per_op_us[                 MUL_QKV] = 277.234 ms
  perf_total_per_op_us[                FFN_SILU] = 707.648 ms
  perf_total_per_op_us[              FLASH_ATTN] = 187.805 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =  72.886 ms
  perf_total_per_op_us[           INNER PRODUCT] =   0.000 ms
  ========================================
  ```
  </details>
- <details>
  <summary>
  <code>env --unset ENGINE_PROFILING numactl -m 1 -C 56-111 bin/run_llama -m /home_local/dingyi/data/llama-7b-hf-pr347-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 32 -p "$GIRL_PROMPT"</code>
  </summary>

  ```
  Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun.
  Then one day, that little girl grew up. And she became a woman. A woman with a job, who travelled overseas for work,
  model_print_timings:        load time =  1308.79 ms
  model_print_timings:      sample time =    18.67 ms /    32 runs   (    0.58 ms per token)
  model_print_timings: prompt eval time =   103.91 ms /    34 tokens (    3.06 ms per token)
  model_print_timings:        eval time =   822.86 ms /    31 runs   (   26.54 ms per token)
  model_print_timings:       total time =  2160.33 ms
  ========== eval time log of each prediction ==========
  prediction   0, time: 103.91ms
  prediction   1, time: 29.13ms
  prediction   2, time: 28.06ms
  prediction   3, time: 27.99ms
  prediction   4, time: 28.03ms
  prediction   5, time: 28.10ms
  prediction   6, time: 27.85ms
  prediction   7, time: 28.10ms
  prediction   8, time: 27.98ms
  prediction   9, time: 27.91ms
  prediction  10, time: 27.99ms
  prediction  11, time: 27.92ms
  prediction  12, time: 27.93ms
  prediction  13, time: 28.07ms
  prediction  14, time: 28.06ms
  prediction  15, time: 26.11ms
  prediction  16, time: 27.22ms
  prediction  17, time: 24.95ms
  prediction  18, time: 25.32ms
  prediction  19, time: 24.98ms
  prediction  20, time: 25.28ms
  prediction  21, time: 25.05ms
  prediction  22, time: 24.94ms
  prediction  23, time: 24.98ms
  prediction  24, time: 25.09ms
  prediction  25, time: 24.97ms
  prediction  26, time: 25.02ms
  prediction  27, time: 25.34ms
  prediction  28, time: 25.38ms
  prediction  29, time: 24.99ms
  prediction  30, time: 24.75ms
  prediction  31, time: 25.36ms
  ```
  </details>
In conclusion, this PR should brings ~40% OP level performance for first-token inference in large scale problems for models that with fused MHA enabled, while not bringing any accuracy compromise. Next token optimization will be investigated later.

## Dependency Change?
N/A
