### PR TITLE
Support lm-eval for merged decoder ONNX models

### DIFF
--- a/intel_extension_for_transformers/llm/evaluation/lm_eval/models/huggingface.py
+++ b/intel_extension_for_transformers/llm/evaluation/lm_eval/models/huggingface.py
@@ -410,7 +410,7 @@ class AutoCausalLM(HuggingFaceAutoLM):
 
         self.model_format = model_format
         if self.model_format == "onnx":
-            if not os.path.exists(os.path.join(pretrained, "decoder_model.onnx")) or \
+            if not os.path.exists(os.path.join(pretrained, "decoder_model.onnx")) and \
                not os.path.exists(os.path.join(pretrained, "decoder_model_merged.onnx")):
                 raise ValueError(
                 "Couldn't find decoder_model.onnx or decoder_model_merged.onnx in {}.".format(pretrained)

--- a/intel_extension_for_transformers/llm/evaluation/lm_eval/models/huggingface.py
+++ b/intel_extension_for_transformers/llm/evaluation/lm_eval/models/huggingface.py
@@ -557,7 +557,7 @@ class AutoSeq2SeqLM(HuggingFaceAutoLM):
                                                   pretrained,
                                                   use_cache=True)
 
-            if os.path.exists(os.path.join(pretrained, "decoder_with_past_model.onnx")):
+            elif os.path.exists(os.path.join(pretrained, "decoder_with_past_model.onnx")):
                 sessions = ORTModelForSeq2SeqLM.load_model(
                                 os.path.join(pretrained, 'encoder_model.onnx'),
                                 os.path.join(pretrained, 'decoder_model.onnx'),

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -102,6 +102,8 @@ class TestLmEvaluationHarness(unittest.TestCase):
         p = subprocess.Popen(cmd, preexec_fn=os.setsid, stdout=subprocess.PIPE,
                                              stderr=subprocess.PIPE, shell=True) # nosec
         p.communicate()
+
+        # test evaluate encoder_model + decoder_model_merged
         results = evaluate(
             model="hf-seq2seq",
             model_args='pretrained="./t5-past",tokenizer="./t5-past",dtype=float32',
@@ -111,7 +113,21 @@ class TestLmEvaluationHarness(unittest.TestCase):
         )
         self.assertEqual(results["results"]["piqa"]["acc"], 0.60)
 
-        cmd = 'optimum-cli export onnx --model hf-internal-testing/tiny-random-t5 --task text2text-generation-with-past t5/'
+        # test evaluate encoder_model + decoder_model + decoder_with_past_model
+        merged_model_path = "./t5-past/decoder_model_merged.onnx"
+        if os.path.exists(merged_model_path):
+            os.remove(merged_model_path)
+            results = evaluate(
+                model="hf-seq2seq",
+                model_args='pretrained="./t5-past",tokenizer="./t5-past",dtype=float32',
+                tasks=["piqa"],
+                limit=20,
+                model_format="onnx"
+            )
+            self.assertEqual(results["results"]["piqa"]["acc"], 0.60)
+
+        # test evaluate encoder_model + decoder_model
+        cmd = 'optimum-cli export onnx --model hf-internal-testing/tiny-random-t5 --task text2text-generation t5/'
         p = subprocess.Popen(cmd, preexec_fn=os.setsid, stdout=subprocess.PIPE,
                                              stderr=subprocess.PIPE, shell=True) # nosec
         p.communicate()
@@ -130,6 +146,8 @@ class TestLmEvaluationHarness(unittest.TestCase):
         p = subprocess.Popen(cmd, preexec_fn=os.setsid, stdout=subprocess.PIPE,
                                              stderr=subprocess.PIPE, shell=True) # nosec
         p.communicate()
+
+        # test evaluate decoder_model_merged
         results = evaluate(
             model="hf-causal",
             model_args='pretrained="./gptj-past",tokenizer="./gptj-past",dtype=float32',
@@ -139,6 +157,20 @@ class TestLmEvaluationHarness(unittest.TestCase):
         )
         self.assertEqual(results["results"]["piqa"]["acc"], 0.45)
 
+        # test evaluate decoder_model + decoder_with_past_model
+        merged_model_path = "./gptj-past/decoder_model_merged.onnx"
+        if os.path.exists(merged_model_path):
+            os.remove(merged_model_path)
+            results = evaluate(
+                model="hf-causal",
+                model_args='pretrained="./gptj-past",tokenizer="./gptj-past",dtype=float32',
+                tasks=["piqa"],
+                limit=20,
+                model_format="onnx"
+            )
+            self.assertEqual(results["results"]["piqa"]["acc"], 0.45)
+
+        # test evaluate decoder_model
         cmd = 'optimum-cli export onnx --model hf-internal-testing/tiny-random-gptj --task text-generation gptj/'
         p = subprocess.Popen(cmd, preexec_fn=os.setsid, stdout=subprocess.PIPE,
                                              stderr=subprocess.PIPE, shell=True) # nosec


### PR DESCRIPTION
## Type of Change

feature
API not change

## Description

`decoder.onnx` and `decoder_with_past.onnx`  can be merged in a single model proto `decoder_model_merged.onnx`. Support lm-eval for `decoder_model_merged.onnx`

## Expected Behavior & Potential Risk

evaluate  `decoder_model_merged.onnx` with lm-eval

## How has this PR been tested?

CI, local test

## Dependency Change?

no