### PR TITLE
Use transfomers tokenizer and streamer for python api

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Below are the sample code to enable weight-only low precision inference. See mor
 from transformers import AutoTokenizer, TextStreamer
 from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
 
-model_name = "Intel/neural-chat-7b-v1-1"
+model_name = "THUDM/chatglm2-6b"
 config = WeightOnlyQuantConfig(compute_dtype="int8")
 prompt = "Once upon a time, a little girl"
 
@@ -76,7 +76,7 @@ outputs = model.generate(inputs, streamer=streamer, max_new_tokens=300)
 from transformers import AutoTokenizer, TextStreamer
 from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
 
-model_name = "Intel/neural-chat-7b-v1-1" 
+model_name = "THUDM/chatglm2-6b" 
 config = WeightOnlyQuantConfig(compute_dtype="bf16", weight_dtype="int8")
 prompt = "Once upon a time, a little girl"
 

--- a/README.md
+++ b/README.md
@@ -56,20 +56,36 @@ Below are the sample code to enable weight-only low precision inference. See mor
 
 ### INT4 Inference 
 ```python
+from transformers import AutoTokenizer, TextStreamer
 from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
-prompt = "Once upon a time, a little girl"
+
+model_name = "Intel/neural-chat-7b-v1-1"
 config = WeightOnlyQuantConfig(compute_dtype="int8")
-model = AutoModel.from_pretrained("Intel/neural-chat-7b-v1-1", quantization_config=config)
-print(model.generate(prompt, max_new_tokens=30))
+prompt = "Once upon a time, a little girl"
+
+tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+inputs = tokenizer(prompt, return_tensors="pt").input_ids
+streamer = TextStreamer(tokenizer)
+
+model = AutoModel.from_pretrained(model_name, quantization_config=config)
+outputs = model.generate(inputs, streamer=streamer, max_new_tokens=300)
 ```
 
 ### INT8 Inference
 ```python
+from transformers import AutoTokenizer, TextStreamer
 from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
-prompt = "Once upon a time, a little girl"
+
+model_name = "Intel/neural-chat-7b-v1-1" 
 config = WeightOnlyQuantConfig(compute_dtype="bf16", weight_dtype="int8")
-model = AutoModel.from_pretrained("Intel/neural-chat-7b-v1-1", quantization_config=config)
-print(model.generate(prompt, max_new_tokens=30))
+prompt = "Once upon a time, a little girl"
+
+tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+inputs = tokenizer(prompt, return_tensors="pt").input_ids
+streamer = TextStreamer(tokenizer)
+
+model = AutoModel.from_pretrained(model_name, quantization_config=config)
+outputs = model.generate(inputs, streamer=streamer, max_new_tokens=300)
 ```
 
 ## 🎯Validated  Models

--- a/README.md
+++ b/README.md
@@ -56,24 +56,24 @@ Below are the sample code to enable weight-only low precision inference. See mor
 
 ### INT4 Inference 
 ```python
-from transformers import AutoTokenizer, TextStreamer
+from transformers import AutoTokenizer
 from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
 
 model_name = "EleutherAI/gpt-j-6B"
-config = WeightOnlyQuantConfig(compute_dtype="int8")
+config = WeightOnlyQuantConfig(compute_dtype="int8", weight_dtype="int4")
 prompt = "Once upon a time, a little girl"
 
 tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
 inputs = tokenizer(prompt, return_tensors="pt").input_ids
-streamer = TextStreamer(tokenizer)
 
 model = AutoModel.from_pretrained(model_name, quantization_config=config)
-outputs = model.generate(inputs, streamer=streamer, max_new_tokens=300)
+gen_tokens = model.generate(inputs, max_new_tokens=300)
+gen_text = tokenizer.batch_decode(gen_tokens)
 ```
 
 ### INT8 Inference
 ```python
-from transformers import AutoTokenizer, TextStreamer
+from transformers import AutoTokenizer
 from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
 
 model_name = "EleutherAI/gpt-j-6B" 
@@ -82,10 +82,10 @@ prompt = "Once upon a time, a little girl"
 
 tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
 inputs = tokenizer(prompt, return_tensors="pt").input_ids
-streamer = TextStreamer(tokenizer)
 
 model = AutoModel.from_pretrained(model_name, quantization_config=config)
-outputs = model.generate(inputs, streamer=streamer, max_new_tokens=300)
+gen_tokens = model.generate(inputs, max_new_tokens=300)
+gen_text = tokenizer.batch_decode(gen_tokens)
 ```
 
 ## 🎯Validated  Models

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Below are the sample code to enable weight-only low precision inference. See mor
 from transformers import AutoTokenizer, TextStreamer
 from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
 
-model_name = "THUDM/chatglm2-6b"
+model_name = "EleutherAI/gpt-j-6B"
 config = WeightOnlyQuantConfig(compute_dtype="int8")
 prompt = "Once upon a time, a little girl"
 
@@ -76,7 +76,7 @@ outputs = model.generate(inputs, streamer=streamer, max_new_tokens=300)
 from transformers import AutoTokenizer, TextStreamer
 from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
 
-model_name = "THUDM/chatglm2-6b" 
+model_name = "EleutherAI/gpt-j-6B" 
 config = WeightOnlyQuantConfig(compute_dtype="bf16", weight_dtype="int8")
 prompt = "Once upon a time, a little girl"
 

--- a/intel_extension_for_transformers/llm/runtime/graph/README.md
+++ b/intel_extension_for_transformers/llm/runtime/graph/README.md
@@ -57,12 +57,19 @@ cmake --build . -j
 
 You can use the python api to simplely run HF model.
 ```python
+from transformers import AutoTokenizer, TextStreamer
 from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
-model_name = "EleutherAI/gpt-j-6b"     # support model id of HF or local PATH to model
+
+model_name = "THUDM/chatglm2-6b"  # or local path to model
 woq_config = WeightOnlyQuantConfig(compute_dtype="int8", weight_dtype="int4")
-model = AutoModel.from_pretrained(model_name, quantization_config=woq_config)
-prompt = "Once upon a time, a little girl"
-output = model.generate(prompt, max_new_tokens=30)
+prompt = "She opened the door and see"
+
+tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+streamer = TextStreamer(tokenizer)
+
+model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, use_llm_runtime=True, trust_remote_code=True)
+gen_tokens = model.generate(input_ids, streamer=streamer, max_new_tokens=300)
 ```
 
 ### 3. Run LLM with Script

--- a/intel_extension_for_transformers/llm/runtime/graph/README.md
+++ b/intel_extension_for_transformers/llm/runtime/graph/README.md
@@ -62,14 +62,15 @@ from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQ
 
 model_name = "THUDM/chatglm2-6b"  # or local path to model
 woq_config = WeightOnlyQuantConfig(compute_dtype="int8", weight_dtype="int4")
-prompt = "She opened the door and see"
+prompt = "Once upon a time, a little girl"
 
 tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
-input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+inputs = tokenizer(prompt, return_tensors="pt").input_ids
 streamer = TextStreamer(tokenizer)
 
-model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, use_llm_runtime=True, trust_remote_code=True)
-gen_tokens = model.generate(input_ids, streamer=streamer, max_new_tokens=300)
+model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, trust_remote_code=True)
+outputs = model.generate(inputs, streamer=streamer, max_new_tokens=300)
+
 ```
 
 ### 3. Run LLM with Script

--- a/intel_extension_for_transformers/llm/runtime/graph/__init__.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/__init__.py
@@ -65,17 +65,17 @@ class Model:
 
         # 1. convert model
         fp32_bin = "ne_{}_f32.bin".format(model_type)
-        convert_model(model_name, fp32_bin, "f32")
+        # convert_model(model_name, fp32_bin, "f32")
 
         # 2. quant model
         quant_bin = "ne_{}_q.bin".format(model_type)
-        self.module.Model.quant_model(model_path = fp32_bin, out_path = quant_bin, **kwargs)
+        # self.module.Model.quant_model(model_path = fp32_bin, out_path = quant_bin, **kwargs)
         
         self.model_type = model_type
         self.bin_file = quant_bin
         
         # clean
-        os.remove(fp32_bin)
+        # os.remove(fp32_bin)
 
 
     def init_from_bin(self, model_name, model_path, **kwargs):
@@ -93,10 +93,12 @@ class Model:
         if self.model is None:
             self.init_from_bin(self.model_type, self.bin_file, **kwargs)
         # TODO support multi batch
-        out = self.model.generate(input_ids = input_ids.tolist()[0], sentence_mode = sentence_mode)
+        # out = self.model.generate(input_ids = input_ids.tolist()[0], sentence_mode = sentence_mode)
         if streamer:
-            streamer.put(torch.tensor([out]))
-        return out
+            while not self.is_token_end():
+                out = self.model.generate(input_ids = input_ids.tolist()[0], sentence_mode = sentence_mode)
+                streamer.put(torch.tensor([out]))
+        return None
 
     def is_token_end(self):
         return self.model.is_token_end()

--- a/intel_extension_for_transformers/llm/runtime/graph/__init__.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/__init__.py
@@ -65,18 +65,19 @@ class Model:
 
         # 1. convert model
         fp32_bin = "ne_{}_f32.bin".format(model_type)
-        # convert_model(model_name, fp32_bin, "f32")
-        # TODO assert model exists
+        convert_model(model_name, fp32_bin, "f32")
+        assert(os.path.exists(fp32_bin), "Fail to convert pytorch model")
 
         # 2. quant model
         quant_bin = "ne_{}_q.bin".format(model_type)
-        # self.module.Model.quant_model(model_path = fp32_bin, out_path = quant_bin, **kwargs)
+        self.module.Model.quant_model(model_path = fp32_bin, out_path = quant_bin, **kwargs)
+        assert(os.path.exists(quant_bin), "Fail to quantize model")
         
         self.model_type = model_type
         self.bin_file = quant_bin
         
         # clean
-        # os.remove(fp32_bin)
+        os.remove(fp32_bin)
 
 
     def init_from_bin(self, model_name, model_path, **kwargs):

--- a/intel_extension_for_transformers/llm/runtime/graph/__init__.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/__init__.py
@@ -65,17 +65,17 @@ class Model:
 
         # 1. convert model
         fp32_bin = "ne_{}_f32.bin".format(model_type)
-        # convert_model(model_name, fp32_bin, "f32")
+        convert_model(model_name, fp32_bin, "f32")
 
         # 2. quant model
         quant_bin = "ne_{}_q.bin".format(model_type)
-        # self.module.Model.quant_model(model_path = fp32_bin, out_path = quant_bin, **kwargs)
+        self.module.Model.quant_model(model_path = fp32_bin, out_path = quant_bin, **kwargs)
         
         self.model_type = model_type
         self.bin_file = quant_bin
         
         # clean
-        # os.remove(fp32_bin)
+        os.remove(fp32_bin)
 
 
     def init_from_bin(self, model_name, model_path, **kwargs):

--- a/intel_extension_for_transformers/llm/runtime/graph/__init__.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/__init__.py
@@ -17,7 +17,7 @@
 import os
 from transformers import AutoConfig
 from intel_extension_for_transformers.llm.runtime.graph.scripts.convert import convert_model
-
+import torch
 model_maps = {"gpt_neox": "gptneox", "RefinedWebModel": "falcon"}
 
 class Model:
@@ -92,8 +92,10 @@ class Model:
         # TODO support streamer
         if self.model is None:
             self.init_from_bin(self.model_type, self.bin_file, **kwargs)
-        
-        out = self.model.generate(input_ids = input_ids, sentence_mode = sentence_mode)
+        # TODO support multi batch
+        out = self.model.generate(input_ids = input_ids.tolist()[0], sentence_mode = sentence_mode)
+        if streamer:
+            streamer.put(torch.tensor([out]))
         return out
 
     def is_token_end(self):

--- a/intel_extension_for_transformers/llm/runtime/graph/__init__.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/__init__.py
@@ -66,6 +66,7 @@ class Model:
         # 1. convert model
         fp32_bin = "ne_{}_f32.bin".format(model_type)
         # convert_model(model_name, fp32_bin, "f32")
+        # TODO assert model exists
 
         # 2. quant model
         quant_bin = "ne_{}_q.bin".format(model_type)
@@ -88,17 +89,17 @@ class Model:
         self.module.Model.quant_model(model_path = model_path,
                                     out_path = out_path, **kwargs)
 
-    def generate(self, input_ids, streamer = None, sentence_mode = True, **kwargs):
-        # TODO support streamer
+    def generate(self, input_ids, streamer = None, **kwargs):
         if self.model is None:
             self.init_from_bin(self.model_type, self.bin_file, **kwargs)
         # TODO support multi batch
-        # out = self.model.generate(input_ids = input_ids.tolist()[0], sentence_mode = sentence_mode)
         if streamer:
             while not self.is_token_end():
-                out = self.model.generate(input_ids = input_ids.tolist()[0], sentence_mode = sentence_mode)
+                out = self.model.generate(input_ids = input_ids.tolist()[0])
                 streamer.put(torch.tensor([out]))
-        return None
+            return None
+        else:
+            return self.model.generate(input_ids = input_ids.tolist()[0])
 
     def is_token_end(self):
         return self.model.is_token_end()

--- a/intel_extension_for_transformers/llm/runtime/graph/__init__.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/__init__.py
@@ -94,13 +94,18 @@ class Model:
         if self.model is None:
             self.init_from_bin(self.model_type, self.bin_file, **kwargs)
         # TODO support multi batch
+        assert(input_ids.shape[0] == 1, "Unsupport multi-batch input ids.")
         if streamer:
+            ret = input_ids.tolist()
             while not self.is_token_end():
                 out = self.model.generate(input_ids = input_ids.tolist()[0])
                 streamer.put(torch.tensor([out]))
-            return None
+                ret[0].extend(out)
+            return ret
         else:
-            return self.model.generate(input_ids = input_ids.tolist()[0])
+            ret = input_ids.tolist()
+            ret[0].extend(self.model.generate_tokens(input_ids = input_ids.tolist()[0]))
+            return ret
 
     def is_token_end(self):
         return self.model.is_token_end()

--- a/intel_extension_for_transformers/llm/runtime/graph/__init__.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/__init__.py
@@ -65,17 +65,17 @@ class Model:
 
         # 1. convert model
         fp32_bin = "ne_{}_f32.bin".format(model_type)
-        convert_model(model_name, fp32_bin, "f32")
+        # convert_model(model_name, fp32_bin, "f32")
 
         # 2. quant model
         quant_bin = "ne_{}_q.bin".format(model_type)
-        self.module.Model.quant_model(model_path = fp32_bin, out_path = quant_bin, **kwargs)
+        # self.module.Model.quant_model(model_path = fp32_bin, out_path = quant_bin, **kwargs)
         
         self.model_type = model_type
         self.bin_file = quant_bin
         
         # clean
-        os.remove(fp32_bin)
+        # os.remove(fp32_bin)
 
 
     def init_from_bin(self, model_name, model_path, **kwargs):
@@ -88,12 +88,12 @@ class Model:
         self.module.Model.quant_model(model_path = model_path,
                                     out_path = out_path, **kwargs)
 
-    def generate(self, prompt, streamer = None, sentence_mode = True, **kwargs):
+    def generate(self, input_ids, streamer = None, sentence_mode = True, **kwargs):
         # TODO support streamer
         if self.model is None:
             self.init_from_bin(self.model_type, self.bin_file, **kwargs)
         
-        out = self.model.generate(prompt = prompt, sentence_mode = sentence_mode)
+        out = self.model.generate(input_ids = input_ids, sentence_mode = sentence_mode)
         return out
 
     def is_token_end(self):

--- a/intel_extension_for_transformers/llm/runtime/graph/application/main_pybind.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/application/main_pybind.cpp
@@ -182,7 +182,7 @@ std::vector<int> Model::generate(const std::vector<int>& input_ids, bool sentenc
   output_ids.reserve(max_length);
   printf("input ids:\n");
   for (auto item : input_ids) {
-    print("--- %d\n", item);
+    printf("--- %d\n", item);
   }
   while (output_ids.size() < n_remain) {
     for (auto item : curr_input_ids) {

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_chatglm.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_chatglm.py
@@ -333,6 +333,9 @@ def main(args_in: Optional[List[str]] = None) -> None:
     dir_model = args.model.as_posix()
     fname_out = args.outfile.as_posix()
 
+    with open(dir_model + '/config.json', "r", encoding="utf-8") as f:
+        hparams = json.load(f)
+
     # possible data types
     #   ftype == 0 -> float32
     #   ftype == 1 -> float16
@@ -345,7 +348,6 @@ def main(args_in: Optional[List[str]] = None) -> None:
     model = AutoModel.from_pretrained(
         dir_model, low_cpu_mem_usage=True, trust_remote_code=True
     )
-    hparams = model.config.to_dict()
 
     if hasattr(model.config, "multi_query_attention"):
         chatglm2_convert(model, tokenizer, dir_model, fname_out, ftype, hparams)

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_chatglm.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_chatglm.py
@@ -333,9 +333,6 @@ def main(args_in: Optional[List[str]] = None) -> None:
     dir_model = args.model.as_posix()
     fname_out = args.outfile.as_posix()
 
-    with open(dir_model + '/config.json', "r", encoding="utf-8") as f:
-        hparams = json.load(f)
-
     # possible data types
     #   ftype == 0 -> float32
     #   ftype == 1 -> float16
@@ -348,6 +345,7 @@ def main(args_in: Optional[List[str]] = None) -> None:
     model = AutoModel.from_pretrained(
         dir_model, low_cpu_mem_usage=True, trust_remote_code=True
     )
+    hparams = model.config.to_dict()
 
     if hasattr(model.config, "multi_query_attention"):
         chatglm2_convert(model, tokenizer, dir_model, fname_out, ftype, hparams)

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/python_api_example.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/python_api_example.py
@@ -20,7 +20,7 @@ from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQ
 
 model_name = "THUDM/chatglm2-6b"  # or local path to model
 woq_config = WeightOnlyQuantConfig(compute_dtype="int8", weight_dtype="int4")
-prompt = "She opened the door and see"
+prompt = "Once upon a time, a little girl"
 
 tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
 input_ids = tokenizer(prompt, return_tensors="pt").input_ids

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/python_api_example.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/python_api_example.py
@@ -18,11 +18,11 @@
 from transformers import AutoTokenizer, TextStreamer
 from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
 
-model_name = "/mnt/disk1/data2/zhenweil/models/mpt/mpt-7b"
+model_name = "/mnt/disk1/data2/zhenweil/models/chatglm2-6b"
 woq_config = WeightOnlyQuantConfig(compute_dtype="int8")
-prompt = "Once upon a time, a little girl"
+prompt = "你好"
 
-tokenizer = AutoTokenizer.from_pretrained(model_name)
+tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
 input_ids = tokenizer(prompt, return_tensors="pt").input_ids
 <<<<<<< HEAD
 
@@ -31,11 +31,15 @@ gen_tokens = model.generate(input_ids.tolist()[0], max_new_tokens=30)
 =======
 streamer = TextStreamer(tokenizer)
 
+<<<<<<< HEAD
 model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, use_llm_runtime=True)
 <<<<<<< HEAD
 gen_tokens = model.generate(input_ids, streamer=streamer, max_new_tokens=30)
 >>>>>>> add streamer
 =======
+=======
+model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, use_llm_runtime=True, trust_remote_code=True)
+>>>>>>> use chatglm2
 gen_tokens = model.generate(input_ids, streamer=streamer, max_new_tokens=300)
 >>>>>>> update streamer mode
 

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/python_api_example.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/python_api_example.py
@@ -20,10 +20,11 @@ from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQ
 
 model_name = "THUDM/chatglm2-6b"  # or local path to model
 woq_config = WeightOnlyQuantConfig(compute_dtype="int8", weight_dtype="int4")
-prompt = "小明的妈妈有三个孩子，老大叫大毛，老二叫二毛，老三叫什么？"
+prompt = "She opened the door and see"
 
 tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
 input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
 
@@ -32,6 +33,8 @@ gen_tokens = model.generate(input_ids.tolist()[0], max_new_tokens=30)
 =======
 =======
 print(input_ids)
+>>>>>>> update
+=======
 >>>>>>> update
 streamer = TextStreamer(tokenizer)
 

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/python_api_example.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/python_api_example.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, TextStreamer
 from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
 
 model_name = "/mnt/disk1/data2/zhenweil/models/mpt/mpt-7b"
@@ -24,9 +24,36 @@ prompt = "Once upon a time, a little girl"
 
 tokenizer = AutoTokenizer.from_pretrained(model_name)
 input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+<<<<<<< HEAD
 
 model = AutoModel.from_pretrained(model_name, quantization_config=woq_config)
 gen_tokens = model.generate(input_ids.tolist()[0], max_new_tokens=30)
+=======
+streamer = TextStreamer(tokenizer)
 
-gen_text = tokenizer.batch_decode(gen_tokens)[0]
-print(gen_text)
+model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, use_llm_runtime=True)
+gen_tokens = model.generate(input_ids, streamer=streamer, max_new_tokens=30)
+>>>>>>> add streamer
+
+# gen_text = tokenizer.batch_decode(gen_tokens)
+# print(gen_text)
+"""
+
+from transformers import AutoTokenizer, TextStreamer, MptForCausalLM
+# from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
+
+model_name = "/mnt/disk1/data2/zhenweil/models/mpt/mpt-7b"
+# woq_config = WeightOnlyQuantConfig(compute_dtype="int8")
+prompt = "Once upon a time, a little girl"
+
+tokenizer = AutoTokenizer.from_pretrained(model_name)
+input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+streamer = TextStreamer(tokenizer)
+
+model = MptForCausalLM.from_pretrained(model_name)
+import pudb; pudb.set_trace()
+gen_tokens = model.generate(input_ids, streamer=streamer, max_new_tokens=30)
+
+# gen_text = tokenizer.batch_decode(gen_tokens)
+# print(gen_text)
+"""

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/python_api_example.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/python_api_example.py
@@ -15,11 +15,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from transformers import AutoTokenizer
 from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
-model_name = "mosaicml/mpt-7b"
+
+model_name = "/mnt/disk1/data2/zhenweil/models/mpt/mpt-7b"
 woq_config = WeightOnlyQuantConfig(compute_dtype="int8")
+prompt = "Once upon a time, a little girl"
+
+tokenizer = AutoTokenizer.from_pretrained(model_name)
+input_ids = tokenizer(prompt, return_tensors="pt").input_ids
 
 model = AutoModel.from_pretrained(model_name, quantization_config=woq_config)
+gen_tokens = model.generate(input_ids.tolist()[0], max_new_tokens=30)
 
-prompt = "Once upon a time, a little girl"
-print(model.generate(prompt, max_new_tokens=30))
+gen_text = tokenizer.batch_decode(gen_tokens)[0]
+print(gen_text)

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/python_api_example.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/python_api_example.py
@@ -18,17 +18,21 @@
 from transformers import AutoTokenizer, TextStreamer
 from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
 
-model_name = "/mnt/disk1/data2/zhenweil/models/chatglm2-6b"
-woq_config = WeightOnlyQuantConfig(compute_dtype="int8")
-prompt = "你好"
+model_name = "THUDM/chatglm2-6b"  # or local path to model
+woq_config = WeightOnlyQuantConfig(compute_dtype="int8", weight_dtype="int4")
+prompt = "小明的妈妈有三个孩子，老大叫大毛，老二叫二毛，老三叫什么？"
 
 tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
 input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+<<<<<<< HEAD
 <<<<<<< HEAD
 
 model = AutoModel.from_pretrained(model_name, quantization_config=woq_config)
 gen_tokens = model.generate(input_ids.tolist()[0], max_new_tokens=30)
 =======
+=======
+print(input_ids)
+>>>>>>> update
 streamer = TextStreamer(tokenizer)
 
 <<<<<<< HEAD
@@ -43,25 +47,3 @@ model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, us
 gen_tokens = model.generate(input_ids, streamer=streamer, max_new_tokens=300)
 >>>>>>> update streamer mode
 
-# gen_text = tokenizer.batch_decode(gen_tokens)
-# print(gen_text)
-"""
-
-from transformers import AutoTokenizer, TextStreamer, MptForCausalLM
-# from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
-
-model_name = "/mnt/disk1/data2/zhenweil/models/mpt/mpt-7b"
-# woq_config = WeightOnlyQuantConfig(compute_dtype="int8")
-prompt = "Once upon a time, a little girl"
-
-tokenizer = AutoTokenizer.from_pretrained(model_name)
-input_ids = tokenizer(prompt, return_tensors="pt").input_ids
-streamer = TextStreamer(tokenizer)
-
-model = MptForCausalLM.from_pretrained(model_name)
-import pudb; pudb.set_trace()
-gen_tokens = model.generate(input_ids, streamer=streamer, max_new_tokens=30)
-
-# gen_text = tokenizer.batch_decode(gen_tokens)
-# print(gen_text)
-"""

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/python_api_example.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/python_api_example.py
@@ -32,8 +32,12 @@ gen_tokens = model.generate(input_ids.tolist()[0], max_new_tokens=30)
 streamer = TextStreamer(tokenizer)
 
 model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, use_llm_runtime=True)
+<<<<<<< HEAD
 gen_tokens = model.generate(input_ids, streamer=streamer, max_new_tokens=30)
 >>>>>>> add streamer
+=======
+gen_tokens = model.generate(input_ids, streamer=streamer, max_new_tokens=300)
+>>>>>>> update streamer mode
 
 # gen_text = tokenizer.batch_decode(gen_tokens)
 # print(gen_text)

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/python_api_example.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/python_api_example.py
@@ -23,30 +23,9 @@ woq_config = WeightOnlyQuantConfig(compute_dtype="int8", weight_dtype="int4")
 prompt = "Once upon a time, a little girl"
 
 tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
-input_ids = tokenizer(prompt, return_tensors="pt").input_ids
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-
-model = AutoModel.from_pretrained(model_name, quantization_config=woq_config)
-gen_tokens = model.generate(input_ids.tolist()[0], max_new_tokens=30)
-=======
-=======
-print(input_ids)
->>>>>>> update
-=======
->>>>>>> update
+inputs = tokenizer(prompt, return_tensors="pt").input_ids
 streamer = TextStreamer(tokenizer)
 
-<<<<<<< HEAD
-model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, use_llm_runtime=True)
-<<<<<<< HEAD
-gen_tokens = model.generate(input_ids, streamer=streamer, max_new_tokens=30)
->>>>>>> add streamer
-=======
-=======
-model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, use_llm_runtime=True, trust_remote_code=True)
->>>>>>> use chatglm2
-gen_tokens = model.generate(input_ids, streamer=streamer, max_new_tokens=300)
->>>>>>> update streamer mode
+model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, trust_remote_code=True)
+outputs = model.generate(inputs, streamer=streamer, max_new_tokens=300)
 

--- a/intel_extension_for_transformers/neural_chat/examples/talkingbot_pc/build_talkingbot_on_pc.ipynb
+++ b/intel_extension_for_transformers/neural_chat/examples/talkingbot_pc/build_talkingbot_on_pc.ipynb
@@ -99,13 +99,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from transformers import AutoTokenizer, TextStreamer\n",
     "from intel_extension_for_transformers.llm.runtime.graph import Model\n",
+    "\n",
+    "prompt = \"Once upon a time, a little girl\"\n",
+    "tokenizer = AutoTokenizer.from_pretrained(\"mosaicml/mpt-7b\", trust_remote_code=True)\n",
+    "inputs = tokenizer(prompt, return_tensors=\"pt\").input_ids\n",
+    "streamer = TextStreamer(tokenizer)\n",
+    "\n",
     "model = Model()\n",
     "model.bin_file = r\"mpt_q4_0.bin\"\n",
     "model.init_from_bin(\"mpt\", model.bin_file, max_new_tokens=32, seed=12)\n",
-    "prompt = text\n",
-    "output = model.generate(prompt)\n",
-    "print(output)"
+    "outputs = model.generate(inputs, streamer=streamer, max_new_tokens=300)"
    ]
   },
   {
@@ -121,12 +126,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from transformers import AutoTokenizer, TextStreamer\n",
     "from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig\n",
-    "model_name = r\"THUDM/ChatGLM2-6B\"\n",
+    "\n",
+    "model_name = \"THUDM/chatglm2-6b\"  # or local path to model\n",
     "woq_config = WeightOnlyQuantConfig(compute_dtype=\"int8\", weight_dtype=\"int4\")\n",
-    "model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, use_llm_runtime=True, trust_remote_code=True)\n",
-    "prompt = text\n",
-    "output = model.generate(prompt, max_new_tokens=32)"
+    "prompt = \"Once upon a time, a little girl\"\n",
+    "\n",
+    "tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)\n",
+    "inputs = tokenizer(prompt, return_tensors=\"pt\").input_ids\n",
+    "streamer = TextStreamer(tokenizer)\n",
+    "\n",
+    "model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, trust_remote_code=True)\n",
+    "outputs = model.generate(inputs, streamer=streamer, max_new_tokens=300)\n"
    ]
   },
   {

--- a/intel_extension_for_transformers/neural_chat/examples/talkingbot_pc/build_talkingbot_on_pc.ipynb
+++ b/intel_extension_for_transformers/neural_chat/examples/talkingbot_pc/build_talkingbot_on_pc.ipynb
@@ -102,15 +102,15 @@
     "from transformers import AutoTokenizer, TextStreamer\n",
     "from intel_extension_for_transformers.llm.runtime.graph import Model\n",
     "\n",
-    "prompt = \"Once upon a time, a little girl\"\n",
-    "tokenizer = AutoTokenizer.from_pretrained(\"mosaicml/mpt-7b\", trust_remote_code=True)\n",
+    "prompt = text\n",
+    "tokenizer = AutoTokenizer.from_pretrained(\"EleutherAI/gpt-j-6b\", trust_remote_code=True)\n",
     "inputs = tokenizer(prompt, return_tensors=\"pt\").input_ids\n",
     "streamer = TextStreamer(tokenizer)\n",
     "\n",
     "model = Model()\n",
-    "model.bin_file = r\"mpt_q4_0.bin\"\n",
-    "model.init_from_bin(\"mpt\", model.bin_file, max_new_tokens=32, seed=12)\n",
-    "outputs = model.generate(inputs, streamer=streamer, max_new_tokens=300)"
+    "model.init_from_bin(\"gptj\", \"ne_gptj_q.bin\", max_new_tokens=320, seed=12)\n",
+    "\n",
+    "outputs = model.generate(inputs, streamer=streamer)\n"
    ]
   },
   {
@@ -129,9 +129,9 @@
     "from transformers import AutoTokenizer, TextStreamer\n",
     "from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig\n",
     "\n",
-    "model_name = \"THUDM/chatglm2-6b\"  # or local path to model\n",
+    "model_name = \"EleutherAI/gpt-j-6b\"  # or local path to model\n",
     "woq_config = WeightOnlyQuantConfig(compute_dtype=\"int8\", weight_dtype=\"int4\")\n",
-    "prompt = \"Once upon a time, a little girl\"\n",
+    "prompt = text\n",
     "\n",
     "tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)\n",
     "inputs = tokenizer(prompt, return_tensors=\"pt\").input_ids\n",

--- a/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
+++ b/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
@@ -143,7 +143,8 @@ class _BaseQBitsAutoModelClass:
                     alg=quantization_config.scheme,
                     group_size=quantization_config.group_size,
                     scale_dtype=quantization_config.scale_dtype,
-                    compute_dtype=quantization_config.compute_dtype
+                    compute_dtype=quantization_config.compute_dtype,
+                    use_ggml=quantization_config.use_ggml,
                 )
                 return model
             else:

--- a/intel_extension_for_transformers/transformers/utils/quantization_config.py
+++ b/intel_extension_for_transformers/transformers/utils/quantization_config.py
@@ -39,6 +39,7 @@ class WeightOnlyQuantConfig:
         group_size=32,
         scheme="sym",
         algorithm="RTN",
+        use_ggml=False,
         **kwargs,
     ):
         from intel_extension_for_transformers.llm.quantization.utils import convert_dtype_2_str
@@ -57,6 +58,7 @@ class WeightOnlyQuantConfig:
         self.calib_dataset = kwargs.pop("calib_dataset", "NeelNanda/pile-10k")
         self.calib_dataloader = kwargs.pop("calib_dataloader", None)
         self.calib_iters = kwargs.pop("calib_iters", 100)
+        self.use_ggml = use_ggml
 
         if compute_dtype is None:
             self.compute_dtype = "fp32"

--- a/intel_extension_for_transformers/transformers/utils/quantization_config.py
+++ b/intel_extension_for_transformers/transformers/utils/quantization_config.py
@@ -118,8 +118,8 @@ class WeightOnlyQuantConfig:
 
         if self.compute_dtype is None:
             self.compute_dtype = "int8"
-        elif self.compute_dtype not in ['int8', 'fp32']:
-            raise ValueError("compute_dtype must be 'int8', 'fp32'.")
+        elif self.compute_dtype not in ['int8', 'bf16', 'fp32']:
+            raise ValueError("compute_dtype must be 'int8', 'bf16', 'fp32'.")
 
         if self.weight_dtype is None:
             self.weight_dtype = "int4"

--- a/setup.py
+++ b/setup.py
@@ -57,12 +57,11 @@ install_requires_list.extend(opt_install_requires_list)
 class CMakeExtension(Extension):
     """CMakeExtension class."""
 
-    def __init__(self, name, sourcedir="", lib_only=False, compile=True):
+    def __init__(self, name, sourcedir="", lib_only=False):
         """Init a CMakeExtension object."""
         Extension.__init__(self, name, sources=[])
         self.sourcedir = os.path.abspath(sourcedir)
         self.optional = lib_only  # we only deliver shared object but not as a python extension module
-        self.compile = compile
 
 
 class CMakeBuild(build_ext):
@@ -107,8 +106,6 @@ class CMakeBuild(build_ext):
         return files
 
     def build_extension(self, ext: CMakeExtension) -> None:
-        if not ext.compile:
-            return
         # Must be in this form due to bug in .resolve() only fixed in Python 3.10+
         ext_fullpath = Path.cwd() / self.get_ext_fullpath(ext.name)
         extdir = ext_fullpath.parent.resolve()
@@ -248,18 +245,9 @@ if __name__ == '__main__':
         check_submodules()
         ext_modules.extend([
             CMakeExtension("intel_extension_for_transformers.neural_engine_py", "intel_extension_for_transformers/llm/runtime/deprecated/"),
-            CMakeExtension("intel_extension_for_transformers.llm.runtime.graph.gptj_cpp", "intel_extension_for_transformers/llm/runtime/graph/"),
-            CMakeExtension("intel_extension_for_transformers.llm.runtime.graph.falcon_cpp", "intel_extension_for_transformers/llm/runtime/graph/", compile=False),
-            CMakeExtension("intel_extension_for_transformers.llm.runtime.graph.gptneox_cpp", "intel_extension_for_transformers/llm/runtime/graph/", compile=False),
-            CMakeExtension("intel_extension_for_transformers.llm.runtime.graph.dolly_cpp", "intel_extension_for_transformers/llm/runtime/graph/", compile=False),
-            CMakeExtension("intel_extension_for_transformers.llm.runtime.graph.llama_cpp", "intel_extension_for_transformers/llm/runtime/graph/", compile=False),
-            CMakeExtension("intel_extension_for_transformers.llm.runtime.graph.mpt_cpp", "intel_extension_for_transformers/llm/runtime/graph/", compile=False),
-            CMakeExtension("intel_extension_for_transformers.llm.runtime.graph.starcoder_cpp", "intel_extension_for_transformers/llm/runtime/graph/", compile=False),
-            CMakeExtension("intel_extension_for_transformers.llm.runtime.graph.opt_cpp", "intel_extension_for_transformers/llm/runtime/graph/", compile=False),
-            CMakeExtension("intel_extension_for_transformers.llm.runtime.graph.bloom_cpp", "intel_extension_for_transformers/llm/runtime/graph/", compile=False),
-            CMakeExtension("intel_extension_for_transformers.llm.runtime.graph.chatglm2_cpp", "intel_extension_for_transformers/llm/runtime/graph/", compile=False)
+            CMakeExtension("intel_extension_for_transformers.llm.runtime.graph.Model", "intel_extension_for_transformers/llm/runtime/graph/"),
             ])
-        cmdclass={'build_ext': CMakeBuild}
+    cmdclass={'build_ext': CMakeBuild}
 
     setup(
         name="intel-extension-for-transformers",

--- a/tests/test_llm_runtime.py
+++ b/tests/test_llm_runtime.py
@@ -1,16 +1,31 @@
+import numpy
+import shutil
+import torch
+import unittest
+
 from transformers import AutoTokenizer, TextStreamer
 from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
 
 
-model_name = "/tf_dataset2/models/pytorch/chatglm2-6b"  # or local path to model
-woq_config = WeightOnlyQuantConfig(compute_dtype="int8", weight_dtype="int4")
-prompt = "小明的妈妈有三个孩子，老大叫大毛，老二叫二毛，老三叫什么？"
+class TestLLMRUNTIME(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        pass
 
-tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
-input_ids = tokenizer(prompt, return_tensors="pt").input_ids
-streamer = TextStreamer(tokenizer)
- 
+    @classmethod
+    def tearDownClass(cls) -> None:
+        shutil.rmtree("./ne_chatglm_q.bin", ignore_errors=True)
 
-model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, use_llm_runtime=True, trust_remote_code=True)
-gen_tokens = model.generate(input_ids, streamer=streamer, max_new_tokens=300)
+    def test_llm_runtime(self):
+
+        model_name = "/tf_dataset2/models/pytorch/chatglm2-6b"  # or local path to model
+        woq_config = WeightOnlyQuantConfig(compute_dtype="int8", weight_dtype="int4")
+        prompt = "小明的妈妈有三个孩子，老大叫大毛，老二叫二毛，老三叫什么？"
+
+        tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+        input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+        streamer = TextStreamer(tokenizer)
+
+        model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, use_llm_runtime=True, trust_remote_code=True)
+        gen_tokens = model.generate(input_ids, streamer=streamer, max_new_tokens=300)

--- a/tests/test_llm_runtime.py
+++ b/tests/test_llm_runtime.py
@@ -1,0 +1,16 @@
+from transformers import AutoTokenizer, TextStreamer
+from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
+
+
+model_name = "/tf_dataset2/models/pytorch/chatglm2-6b"  # or local path to model
+woq_config = WeightOnlyQuantConfig(compute_dtype="int8", weight_dtype="int4")
+prompt = "小明的妈妈有三个孩子，老大叫大毛，老二叫二毛，老三叫什么？"
+
+
+tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+streamer = TextStreamer(tokenizer)
+ 
+
+model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, use_llm_runtime=True, trust_remote_code=True)
+gen_tokens = model.generate(input_ids, streamer=streamer, max_new_tokens=300)


### PR DESCRIPTION
## Type of Change

feature
API changed

- [x] finish TODO of https://github.com/intel/intel-extension-for-transformers/pull/252
- [x] refine setup.py

## Expected Behavior & Potential Risk

```python
from transformers import AutoTokenizer, TextStreamer
from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig

model_name = "THUDM/chatglm2-6b"  # or local path to model
woq_config = WeightOnlyQuantConfig(compute_dtype="int8", weight_dtype="int4")
prompt = "She opened the door and see"

tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
input_ids = tokenizer(prompt, return_tensors="pt").input_ids
streamer = TextStreamer(tokenizer)

model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, use_llm_runtime=True, trust_remote_code=True)
gen_tokens = model.generate(input_ids, streamer=streamer, max_new_tokens=300)
```
