### PR TITLE
fixes to Neural Chat SparseBM25Retriever pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,16 +57,16 @@ Below are the sample code to enable weight-only low precision inference. See mor
 ### INT4 Inference 
 ```python
 from transformers import AutoTokenizer
-from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
+from intel_extension_for_transformers.transformers import AutoModelForCausalLM, WeightOnlyQuantConfig
 
-model_name = "EleutherAI/gpt-j-6B"
+model_name = "Intel/neural-chat-7b-v1-1"     # Hugging Face model_id or local model
 config = WeightOnlyQuantConfig(compute_dtype="int8", weight_dtype="int4")
 prompt = "Once upon a time, a little girl"
 
 tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
 inputs = tokenizer(prompt, return_tensors="pt").input_ids
 
-model = AutoModel.from_pretrained(model_name, quantization_config=config)
+model = AutoModelForCausalLM.from_pretrained(model_name, quantization_config=config)
 gen_tokens = model.generate(inputs, max_new_tokens=300)
 gen_text = tokenizer.batch_decode(gen_tokens)
 ```
@@ -74,16 +74,16 @@ gen_text = tokenizer.batch_decode(gen_tokens)
 ### INT8 Inference
 ```python
 from transformers import AutoTokenizer
-from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
+from intel_extension_for_transformers.transformers import AutoModelForCausalLM, WeightOnlyQuantConfig
 
-model_name = "EleutherAI/gpt-j-6B" 
+model_name = "Intel/neural-chat-7b-v1-1"     # Hugging Face model_id or local model
 config = WeightOnlyQuantConfig(compute_dtype="bf16", weight_dtype="int8")
 prompt = "Once upon a time, a little girl"
 
 tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
 inputs = tokenizer(prompt, return_tensors="pt").input_ids
 
-model = AutoModel.from_pretrained(model_name, quantization_config=config)
+model = AutoModelForCausalLM.from_pretrained(model_name, quantization_config=config)
 gen_tokens = model.generate(inputs, max_new_tokens=300)
 gen_text = tokenizer.batch_decode(gen_tokens)
 ```

--- a/intel_extension_for_transformers/llm/runtime/graph/CMakeLists.txt
+++ b/intel_extension_for_transformers/llm/runtime/graph/CMakeLists.txt
@@ -91,6 +91,7 @@ option(NE_GELU_VEC               "neural_engine: enable vec in gelu"            
 if (NE_GELU_VEC)
     add_compile_definitions(NE_GELU_USE_VEC)
 endif()
+option(PYTHON_API              "neural_engine: use python api"                                  OFF)
 
 if(NE_BUILD_TESTS)
     enable_testing()

--- a/intel_extension_for_transformers/llm/runtime/graph/README.md
+++ b/intel_extension_for_transformers/llm/runtime/graph/README.md
@@ -66,7 +66,7 @@ cmake --build . -j
 You can use Python API to run Hugging Face model simply. Here is the sample code:
 ```python
 from transformers import AutoTokenizer, TextStreamer
-from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
+from intel_extension_for_transformers.transformers import AutoModelForCausalLM, WeightOnlyQuantConfig
 model_name = "Intel/neural-chat-7b-v1-1"     # Hugging Face model_id or local model
 woq_config = WeightOnlyQuantConfig(compute_dtype="int8", weight_dtype="int4")
 prompt = "Once upon a time, a little girl"
@@ -75,7 +75,7 @@ tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
 inputs = tokenizer(prompt, return_tensors="pt").input_ids
 streamer = TextStreamer(tokenizer)
 
-model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, trust_remote_code=True)
+model = AutoModelForCausalLM.from_pretrained(model_name, quantization_config=woq_config, trust_remote_code=True)
 outputs = model.generate(inputs, streamer=streamer, max_new_tokens=300)
 
 ```

--- a/intel_extension_for_transformers/llm/runtime/graph/application/CMakeLists.txt
+++ b/intel_extension_for_transformers/llm/runtime/graph/application/CMakeLists.txt
@@ -66,8 +66,10 @@ compile_quant(quant_chatglm   quant_model.cpp chatglm   chatglm)
 compile_quant(quant_chatglm2  quant_model.cpp chatglm2   chatglm2)
 
 # all models running
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-add_subdirectory(third_party/pybind11)
+if (PYTHON_API)
+  include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+  add_subdirectory(third_party/pybind11)
+endif()
 
 set(mymap_gptj 1)
 set(mymap_falcon 2)
@@ -91,14 +93,12 @@ function(compile_run TARGET SRC MODEL_NAME MODEL_LIB)
     add_dependencies(${TARGET} BUILD_INFO)
   endif()
 
-
-  pybind11_add_module("${MODEL_NAME}_cpp" main_pybind.cpp)
-  target_link_libraries("${MODEL_NAME}_cpp" PRIVATE ne_layers ${MODEL_LIB} common)
-  target_compile_definitions("${MODEL_NAME}_cpp" PUBLIC -DMODEL_NAME="${MODEL_NAME}" -DMODEL_NAME_ID=${mymap_${MODEL_NAME}})
+  if (PYTHON_API)
+    pybind11_add_module("${MODEL_NAME}_cpp" main_pybind.cpp)
+    target_link_libraries("${MODEL_NAME}_cpp" PRIVATE ne_layers ${MODEL_LIB} common)
+    target_compile_definitions("${MODEL_NAME}_cpp" PUBLIC -DMODEL_NAME="${MODEL_NAME}" -DMODEL_NAME_ID=${mymap_${MODEL_NAME}})
+  endif()
 endfunction()
-
-
-
 
 compile_run(run_gptj      main_run.cpp gptj      gptj)
 compile_run(run_falcon    main_run.cpp falcon    falcon)

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_mpt.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_mpt.py
@@ -20,7 +20,6 @@ import argparse
 from typing import (IO, TYPE_CHECKING, Any, Callable, Dict, Iterable, List,
                     Literal, Optional, Sequence, Tuple, TypeVar, Union)
 from transformers import AutoModelForCausalLM, AutoTokenizer
-import sentencepiece.sentencepiece_model_pb2 as model
 
 # ref: https://github.com/openai/gpt-2/blob/master/src/encoder.py
 def bytes_to_unicode():

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/python_api_example.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/python_api_example.py
@@ -16,9 +16,9 @@
 # limitations under the License.
 
 from transformers import AutoTokenizer, TextStreamer
-from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQuantConfig
+from intel_extension_for_transformers.transformers import AutoModelForCausalLM, WeightOnlyQuantConfig
 
-model_name = "THUDM/chatglm2-6b"  # or local path to model
+model_name = "Intel/neural-chat-7b-v1-1"  # or local path to model
 woq_config = WeightOnlyQuantConfig(compute_dtype="int8", weight_dtype="int4")
 prompt = "Once upon a time, a little girl"
 
@@ -26,6 +26,6 @@ tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
 inputs = tokenizer(prompt, return_tensors="pt").input_ids
 streamer = TextStreamer(tokenizer)
 
-model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, trust_remote_code=True)
+model = AutoModelForCausalLM.from_pretrained(model_name, quantization_config=woq_config, trust_remote_code=True)
 outputs = model.generate(inputs, streamer=streamer, max_new_tokens=300)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ setuptools>=42
 setuptools_scm[toml]>=6.2
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch
+accelerate

--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,7 @@ class CMakeBuild(build_ext):
             f"-DDNNL_CPU_RUNTIME=OMP",
             f"-DNE_WITH_AVX2={'ON' if NE_WITH_AVX2 else 'OFF'}",
             f"-DNE_WITH_TESTS=OFF",
+            f"-DPYTHON_API=ON",
         ]
         if sys.platform == "linux":  # relative_rpath
             cmake_args.append('-DCMAKE_BUILD_RPATH=$ORIGIN/')


### PR DESCRIPTION
## Type of Change

bug fix
no change to API

## Description

Neural Chat SparseBM25Retriever pipeline had some minor typos that caused the code to error.

Specifically:
https://github.com/intel/intel-extension-for-transformers/blob/9491bbb8aa2b36a530abfcdc1155ffa17f3246f8/intel_extension_for_transformers/neural_chat/pipeline/plugins/retrieval/retrieval_bm25.py#L23

Should be `__init__`

and

https://github.com/intel/intel-extension-for-transformers/blob/9491bbb8aa2b36a530abfcdc1155ffa17f3246f8/intel_extension_for_transformers/neural_chat/pipeline/plugins/retrieval/indexing/indexing.py#L136

should be `self.document_store`

JIRA ticket: N/A

## Expected Behavior & Potential Risk

Using Neural chat with SparseBM25Retriever should successfully retrieve outputs from inputted documents without error-ing out

## How has this PR been tested?

Tested on AWS M7i EC2 instance - Intel(R) Xeon(R) Platinum 8488C
Run retrieval pipeline from [example](https://github.com/kta-intel/intel-extension-for-transformers/tree/kta-branch/intel_extension_for_transformers/neural_chat/pipeline/plugins/retrieval#import-the-module-and-set-the-retrieval-config) and set:
```
plugins.retrieval.args["retrieval_type"]="sparse"
plugins.retrieval.args["document_store"]="inmemory"
```

## Dependency Change?

None