### PR TITLE
fixes to Neural Chat SparseBM25Retriever pipeline

### DIFF
--- a/intel_extension_for_transformers/neural_chat/pipeline/plugins/retrieval/indexing/indexing.py
+++ b/intel_extension_for_transformers/neural_chat/pipeline/plugins/retrieval/indexing/indexing.py
@@ -133,7 +133,7 @@ class DocumentIndexing:
                     print("Please check your upload file and try again!")
                 if self.document_store == "inmemory":
                     document_store = InMemoryDocumentStore(use_gpu=False, use_bm25=True)
-                elif self.document_stor == "Elasticsearch":
+                elif self.document_store == "Elasticsearch":
                     document_store = ElasticsearchDocumentStore(host="localhost", index=self.index_name,
                                                                 port=9200, search_fields=["content", "title"])
 

--- a/intel_extension_for_transformers/neural_chat/pipeline/plugins/retrieval/retrieval_bm25.py
+++ b/intel_extension_for_transformers/neural_chat/pipeline/plugins/retrieval/retrieval_bm25.py
@@ -20,7 +20,7 @@ from haystack.nodes import BM25Retriever
 class SparseBM25Retriever():
     """Retrieve the document database with BM25 sparse algorithm."""
 
-    def __int__(self, document_store = None, top_k = 1):
+    def __init__(self, document_store = None, top_k = 1):
         assert document_store is not None, "Please give a document database for retrieving."
         self.retriever = BM25Retriever(document_store=document_store, top_k=top_k)
 


### PR DESCRIPTION
## Type of Change

bug fix
no change to API

## Description

Neural Chat SparseBM25Retriever pipeline had some minor typos that caused the code to error.

Specifically:
https://github.com/intel/intel-extension-for-transformers/blob/9491bbb8aa2b36a530abfcdc1155ffa17f3246f8/intel_extension_for_transformers/neural_chat/pipeline/plugins/retrieval/retrieval_bm25.py#L23

Should be `__init__`

and

https://github.com/intel/intel-extension-for-transformers/blob/9491bbb8aa2b36a530abfcdc1155ffa17f3246f8/intel_extension_for_transformers/neural_chat/pipeline/plugins/retrieval/indexing/indexing.py#L136

should be `self.document_store`

JIRA ticket: N/A

## Expected Behavior & Potential Risk

Using Neural chat with SparseBM25Retriever should successfully retrieve outputs from inputted documents without error-ing out

## How has this PR been tested?

Tested on AWS M7i EC2 instance - Intel(R) Xeon(R) Platinum 8488C
Run retrieval pipeline from [example](https://github.com/kta-intel/intel-extension-for-transformers/tree/kta-branch/intel_extension_for_transformers/neural_chat/pipeline/plugins/retrieval#import-the-module-and-set-the-retrieval-config) and set:
```
plugins.retrieval.args["retrieval_type"]="sparse"
plugins.retrieval.args["document_store"]="inmemory"
```

## Dependency Change?

None