### PR TITLE
[CPP Graph] Falcon MHA support

### DIFF
--- a/intel_extension_for_transformers/llm/runtime/graph/README.md
+++ b/intel_extension_for_transformers/llm/runtime/graph/README.md
@@ -1,4 +1,4 @@
-# LLM Runtime 
+# LLM Runtime
 
 LLM Runtime is designed to provide the efficient inference of large language models (LLMs) on Intel platforms through the state-of-the-art (SOTA) model compression techniques. The work is highly inspired from [llama.cpp](https://github.com/ggerganov/llama.cpp), which organizes almost all the core code (e.g., kernels) in a single big file with a large number of pre-defined macros, thus making it not easy for developers to support a new model. Our LLM Runtime has the following features:
 
@@ -6,7 +6,7 @@ LLM Runtime is designed to provide the efficient inference of large language mod
 - [Highly optimized low precision kernels](core/README.md)
 - Utilize AMX, VNNI and AVX512F instruction set
 - Support CPU (x86 platforms only) and initial (Intel) GPU
-- Support 4bits and 8bits quantization 
+- Support 4bits and 8bits quantization
 
 > LLM Runtime is under active development so APIs are subject to change.
 
@@ -16,22 +16,22 @@ LLM Runtime supports the following models:
 ### Text Generation
 | model name | INT8 | INT4|
 |---|:---:|:---:|
-|[LLaMA2-7B](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf), [LLaMA2-13B](https://huggingface.co/meta-llama/Llama-2-13b-chat-hf), [LLaMA2-70B](https://huggingface.co/meta-llama/Llama-2-70b-chat-hf)| ✅ | ✅ | 
-|[LLaMA-7B](https://huggingface.co/decapoda-research/llama-7b-hf), [LLaMA-13B](https://huggingface.co/decapoda-research/llama-13b-hf)| ✅ | ✅ | 
-|[GPT-J-6B](https://huggingface.co/EleutherAI/gpt-j-6b)| ✅ | ✅ | 
-|[GPT-NeoX-20B](https://huggingface.co/EleutherAI/gpt-neox-20b)| ✅ | ✅ | 
-|[Dolly-v2-3B](https://huggingface.co/databricks/dolly-v2-3b)| ✅ | ✅ | 
-|[MPT-7B](https://huggingface.co/mosaicml/mpt-7b), [MPT-30B](https://huggingface.co/mosaicml/mpt-30b)| ✅ | ✅ | 
-|[Falcon-7B](https://huggingface.co/tiiuae/falcon-7b), [Falcon-40B](https://huggingface.co/tiiuae/falcon-40b)| ✅ | ✅ | 
+|[LLaMA2-7B](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf), [LLaMA2-13B](https://huggingface.co/meta-llama/Llama-2-13b-chat-hf), [LLaMA2-70B](https://huggingface.co/meta-llama/Llama-2-70b-chat-hf)| ✅ | ✅ |
+|[LLaMA-7B](https://huggingface.co/decapoda-research/llama-7b-hf), [LLaMA-13B](https://huggingface.co/decapoda-research/llama-13b-hf)| ✅ | ✅ |
+|[GPT-J-6B](https://huggingface.co/EleutherAI/gpt-j-6b)| ✅ | ✅ |
+|[GPT-NeoX-20B](https://huggingface.co/EleutherAI/gpt-neox-20b)| ✅ | ✅ |
+|[Dolly-v2-3B](https://huggingface.co/databricks/dolly-v2-3b)| ✅ | ✅ |
+|[MPT-7B](https://huggingface.co/mosaicml/mpt-7b), [MPT-30B](https://huggingface.co/mosaicml/mpt-30b)| ✅ | ✅ |
+|[Falcon-7B](https://huggingface.co/tiiuae/falcon-7b), [Falcon-40B](https://huggingface.co/tiiuae/falcon-40b)| ✅ | ✅ |
 |[BLOOM-7B](https://huggingface.co/bigscience/bloomz-7b1)| ✅ | ✅ |
-|[OPT-125m](https://huggingface.co/facebook/opt-125m), [OPT-350m](https://huggingface.co/facebook/opt-350m), [OPT-1.3B](https://huggingface.co/facebook/opt-1.3b), [OPT-13B](https://huggingface.co/facebook/opt-13b)| ✅ | ✅ |  
+|[OPT-125m](https://huggingface.co/facebook/opt-125m), [OPT-350m](https://huggingface.co/facebook/opt-350m), [OPT-1.3B](https://huggingface.co/facebook/opt-1.3b), [OPT-13B](https://huggingface.co/facebook/opt-13b)| ✅ | ✅ |
 |[ChatGLM-6B](https://huggingface.co/THUDM/chatglm-6b), [ChatGLM2-6B](https://huggingface.co/THUDM/chatglm2-6b)| ✅ | ✅ |
 
 ### Code Generation
 | model name | INT8 | INT4|
 |---|:---:|:---:|
-|[Code-LLaMA-7B](https://huggingface.co/codellama/CodeLlama-7b-hf), [Code-LLaMA-13B](https://huggingface.co/codellama/CodeLlama-13b-hf)| ✅ | ✅ | 
-|[StarCoder-1B](https://huggingface.co/bigcode/starcoderbase-1b), [StarCoder-3B](https://huggingface.co/bigcode/starcoderbase-3b), [StarCoder-15.5B](https://huggingface.co/bigcode/starcoder)| ✅ | ✅ | 
+|[Code-LLaMA-7B](https://huggingface.co/codellama/CodeLlama-7b-hf), [Code-LLaMA-13B](https://huggingface.co/codellama/CodeLlama-13b-hf)| ✅ | ✅ |
+|[StarCoder-1B](https://huggingface.co/bigcode/starcoderbase-1b), [StarCoder-3B](https://huggingface.co/bigcode/starcoderbase-3b), [StarCoder-15.5B](https://huggingface.co/bigcode/starcoder)| ✅ | ✅ |
 
 
 ## How to Use
@@ -179,6 +179,7 @@ Augument description of inference.py:
 | --color           | colorise output to distinguish prompt and user input from generations   |
 | --keep            | number of tokens to keep from the initial prompt (default: 0, -1 = all) |
 | --glm_tokenizer   | the path of the chatglm tokenizer (default: THUDM/chatglm-6b)           |
+| --memory-f32 <br> --memory-f16 <br> --memory-auto | Data type of kv memory (default to auto);<br>If set to auto, the runtime will try with jblas flash attn managed format (currently requires GCC13 & AMX) and fall back to fp16 if failed |
 
 
 ### 3. Tensor Parallelism cross nodes/sockets

--- a/intel_extension_for_transformers/llm/runtime/graph/core/layers/Ops.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/layers/Ops.h
@@ -85,6 +85,7 @@ enum ne_op {
   NE_OP_ALL_REDUCE,
   NE_OP_TP_CONCAT,
   NE_OP_DUMP_TENSOR,
+  NE_OP_DEBUG,
   NE_OP_COUNT,
 };
 

--- a/intel_extension_for_transformers/llm/runtime/graph/core/layers/mha_dense.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/layers/mha_dense.h
@@ -27,7 +27,9 @@ typedef struct attn_shape_t {
 size_t jblas_fusion_attn_workspace_size(const attn_shape_t* params);
 
 typedef struct kv_shape_t {
-  uint32_t heads_kv, head_size, sl_kv_max;
+  uint32_t heads_kv;   // number of heads in K/V matrix
+  uint32_t head_size;  // channel dimension of each head
+  uint32_t sl_kv_max;  // maximum length of sequence (affect internal step size)
 } kv_shape_t;
 
 typedef enum ATTN_FWD_LAYOUT {

--- a/intel_extension_for_transformers/llm/runtime/graph/core/layers/mha_dense.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/layers/mha_dense.h
@@ -22,12 +22,12 @@ extern "C" {
 #endif
 
 typedef struct attn_shape_t {
-  int batch_size, head_num, head_size, sl_q, sl_kv;
+  int batch_size, head_num, heads_kv, head_size, sl_q, sl_kv;
 } attn_shape_t;
 size_t jblas_fusion_attn_workspace_size(const attn_shape_t* params);
 
 typedef struct kv_shape_t {
-  uint32_t head_num, head_size, sl_kv_max;
+  uint32_t heads_kv, head_size, sl_kv_max;
 } kv_shape_t;
 
 typedef enum ATTN_FWD_LAYOUT {
@@ -54,7 +54,7 @@ typedef struct attn_bf16_fwd_args_t {
   char* tmp;
   float QK_scale;
   ne_attn_flags_t attn_flags;
-  int batch_size, head_num, head_size, sl_q, sl_kv;
+  int batch_size, head_num, heads_kv, head_size, sl_q, sl_kv;
   ATTN_FWD_LAYOUT Q_layout, K_layout, V_layout, dst_layout;
   int step_q_bs, step_q_head_num, step_q_sl;
   int step_k_bs, step_k_head_num, step_k_sl, step_k_head_size;
@@ -72,7 +72,7 @@ typedef struct attn_fp32_fp16_fp16_fp32_fwd_args_t {
   char* tmp;
   float QK_scale;
   ne_attn_flags_t attn_flags;
-  int batch_size, head_num, head_size, sl_q, sl_kv;
+  int batch_size, head_num, heads_kv, head_size, sl_q, sl_kv;
   ATTN_FWD_LAYOUT Q_layout, K_layout, V_layout, dst_layout;
   int step_q_bs, step_q_head_num, step_q_sl;
   int step_k_bs, step_k_head_num, step_k_sl, step_k_head_size;
@@ -91,7 +91,7 @@ typedef struct attn_fp16_fwd_args_t {
   char* tmp;
   float QK_scale;
   ne_attn_flags_t attn_flags;
-  int batch_size, head_num, head_size, sl_q, sl_kv;
+  int batch_size, head_num, heads_kv, head_size, sl_q, sl_kv;
   ATTN_FWD_LAYOUT Q_layout, K_layout, V_layout, dst_layout;
   int step_q_bs, step_q_head_num, step_q_sl;
   int step_k_bs, step_k_head_num, step_k_sl, step_k_head_size;
@@ -107,7 +107,7 @@ typedef struct attn_int8_fwd_args_t {
   char* tmp;
   float QK_scale;
   ne_attn_flags_t attn_flags;
-  int batch_size, head_num, head_size, sl_q, sl_kv;
+  int batch_size, head_num, heads_kv, head_size, sl_q, sl_kv;
   ATTN_FWD_LAYOUT Q_layout, K_layout, V_layout, dst_layout;
   int step_q_bs, step_q_head_num, step_q_sl;
   int step_k_bs, step_k_head_num, step_k_sl, step_k_head_size;
@@ -125,7 +125,7 @@ void jblas_reordered_attn_fp32_batch_kv_info(const kv_shape_t* params, kv_cache_
 typedef struct jblas_fusion_attn_fp32_update_kv_args_t {
   float* src;
   char* cache;
-  int batch_size, head_num, head_size, seq_off, seq_size, seq_max;
+  int batch_size, heads_kv, head_size, seq_off, seq_size, seq_max;
   int step_bs, step_head_num, step_seq, step_head_size;
 } jblas_fusion_attn_fp32_update_kv_args_t;
 // update k-cache and output the memory layout of it
@@ -142,7 +142,7 @@ typedef struct jblas_reordered_attn_fp32_fp32_fwd_args_t {
   char* tmp;
   float QK_scale;
   ne_attn_flags_t attn_flags;
-  int batch_size, head_num, head_size, sl_q, sl_kv;
+  int batch_size, head_num, heads_kv, head_size, sl_q, sl_kv;
   ATTN_FWD_LAYOUT Q_layout, K_layout, V_layout, dst_layout;
   int step_q_bs, step_q_head_num, step_q_sl;
   int stride_k_bs, stride_k_head_num, stride_k_sl, stride_k_head_size;

--- a/intel_extension_for_transformers/llm/runtime/graph/core/layers/mha_dense.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/layers/mha_dense.h
@@ -53,7 +53,7 @@ typedef struct attn_bf16_fwd_args_t {
   float Q_sc, K_sc, V_sc, dst_sc;
   char* tmp;
   float QK_scale;
-  bool is_causal;
+  ne_attn_flags_t attn_flags;
   int batch_size, head_num, head_size, sl_q, sl_kv;
   ATTN_FWD_LAYOUT Q_layout, K_layout, V_layout, dst_layout;
   int step_q_bs, step_q_head_num, step_q_sl;
@@ -71,7 +71,7 @@ typedef struct attn_fp32_fp16_fp16_fp32_fwd_args_t {
   float Q_sc, K_sc, V_sc, dst_sc;
   char* tmp;
   float QK_scale;
-  bool is_causal;
+  ne_attn_flags_t attn_flags;
   int batch_size, head_num, head_size, sl_q, sl_kv;
   ATTN_FWD_LAYOUT Q_layout, K_layout, V_layout, dst_layout;
   int step_q_bs, step_q_head_num, step_q_sl;
@@ -90,7 +90,7 @@ typedef struct attn_fp16_fwd_args_t {
   float Q_sc, K_sc, V_sc, dst_sc;
   char* tmp;
   float QK_scale;
-  bool is_causal;
+  ne_attn_flags_t attn_flags;
   int batch_size, head_num, head_size, sl_q, sl_kv;
   ATTN_FWD_LAYOUT Q_layout, K_layout, V_layout, dst_layout;
   int step_q_bs, step_q_head_num, step_q_sl;
@@ -106,7 +106,7 @@ typedef struct attn_int8_fwd_args_t {
   float Q_sc, K_sc, V_sc, dst_sc;
   char* tmp;
   float QK_scale;
-  bool is_causal;
+  ne_attn_flags_t attn_flags;
   int batch_size, head_num, head_size, sl_q, sl_kv;
   ATTN_FWD_LAYOUT Q_layout, K_layout, V_layout, dst_layout;
   int step_q_bs, step_q_head_num, step_q_sl;
@@ -141,7 +141,7 @@ typedef struct jblas_reordered_attn_fp32_fp32_fwd_args_t {
   float Q_sc, K_sc, V_sc, dst_sc;
   char* tmp;
   float QK_scale;
-  bool is_causal;
+  ne_attn_flags_t attn_flags;
   int batch_size, head_num, head_size, sl_q, sl_kv;
   ATTN_FWD_LAYOUT Q_layout, K_layout, V_layout, dst_layout;
   int step_q_bs, step_q_head_num, step_q_sl;

--- a/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.h
@@ -79,6 +79,14 @@
 extern "C" {
 #endif
 
+// Attention flags
+typedef enum NE_ATTN_FLAG {
+  NE_ATTN_FLAG_IS_CAUSAL = 1 << 1,
+  NE_ATTN_FLAG_IS_ALIBI = 1 << 2,
+} NE_ATTN_FLAG;
+typedef uint32_t ne_attn_flags_t;
+
+
 // convert FP16 <-> FP32
 NE_API float ne_fp16_to_fp32(ne_fp16_t x);
 NE_API ne_fp16_t ne_fp32_to_fp16(float x);
@@ -407,7 +415,7 @@ NE_API struct ne_tensor* ne_conv_1d_1s(struct ne_context* ctx, struct ne_tensor*
 NE_API struct ne_tensor* ne_conv_1d_2s(struct ne_context* ctx, struct ne_tensor* a, struct ne_tensor* b);
 
 NE_API struct ne_tensor* ne_flash_attn(struct ne_context* ctx, struct ne_tensor* q, struct ne_tensor* k,
-                                       struct ne_tensor* v, float scale, bool masked);
+                                       struct ne_tensor* v, float scale, ne_attn_flags_t flags);
 NE_API struct ne_tensor* ne_flash_attn_update_k(struct ne_context* ctx, struct ne_tensor* cache, struct ne_tensor* cur,
                                                 int n_past);
 NE_API struct ne_tensor* ne_flash_attn_update_v(struct ne_context* ctx, struct ne_tensor* cache, struct ne_tensor* cur,

--- a/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.h
@@ -86,7 +86,6 @@ typedef enum NE_ATTN_FLAG {
 } NE_ATTN_FLAG;
 typedef uint32_t ne_attn_flags_t;
 
-
 // convert FP16 <-> FP32
 NE_API float ne_fp16_to_fp32(ne_fp16_t x);
 NE_API ne_fp16_t ne_fp32_to_fp16(float x);
@@ -175,6 +174,13 @@ NE_API void ne_set_name(struct ne_tensor* tensor, const char* name);
 //
 // operations on tensors with backpropagation
 //
+
+typedef void (*ne_debug_callback_t)(const struct ne_tensor* t);
+
+// Run a callback function during graph forwarding.
+// Usage (in C++): `cur = ne_debug_op(ctx0, cur, [](const ne_tensor* cur) { std::cout << cur->data[0]; });`
+// Note that the lambda expression must not have any captures.
+NE_API struct ne_tensor* ne_debug_op(struct ne_context* ctx, struct ne_tensor* a, ne_debug_callback_t cb);
 
 NE_API struct ne_tensor* ne_dup(struct ne_context* ctx, struct ne_tensor* a);
 

--- a/intel_extension_for_transformers/llm/runtime/graph/models/falcon/falcon.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/falcon/falcon.cpp
@@ -91,8 +91,28 @@ static bool falcon_model_eval_internal(model_context& lctx, const model_token* t
   ne_cgraph gf = {};
   gf.n_threads = N >= 32 && ne_cpu_has_blas() ? 1 : n_threads;
 
-  const bool kv_mem_jblas = kv_self.k->type == NE_TYPE_JBLAS;
-  NE_ASSERT(("jblas managed kv-cache is not yet supported; use `--memory-f16 / --memory-f32` instead", !kv_mem_jblas));
+  const bool run_mha_reordered = kv_self.k->type == NE_TYPE_JBLAS;
+  kv_cache_info_t kv_cache_info = {};
+  if (run_mha_reordered) {
+    NE_ASSERT(("kv cache should be the same dtype", kv_self.v->type == NE_TYPE_JBLAS));
+    attn_shape_t attn_shape = {
+        /* .batch_size = */ 1,
+        /* .head_num = */ n_head,
+        /* .heads_kv = */ n_head_kv,
+        /* .head_size = */ head_dim,
+        /* .sl_q = */ N,  // Note: make sure that jblas reordered attn supports next token inference
+        /* .sl_kv = */ n_past + N,
+    };
+
+    NE_ASSERT(("jblas managed kv-cache not supported; use `--memory-f16 / --memory-f32` instead",
+               jblas_reordered_attn_fp32_support(&attn_shape)));
+    kv_shape_t kv_shape{
+        /* .heads_kv = */ static_cast<uint32_t>(n_head_kv),
+        /* .head_size = */ static_cast<uint32_t>(head_dim),
+        /* .sl_kv_max = */ static_cast<uint32_t>(n_ctx),
+    };
+    jblas_reordered_attn_fp32_batch_kv_info(&kv_shape, &kv_cache_info);
+  }
 
   struct ne_tensor* embd = d_ne_new_tensor_1d(ctx0, NE_TYPE_I32, N);
   ne_set_name(embd, "embd");
@@ -141,61 +161,106 @@ static bool falcon_model_eval_internal(model_context& lctx, const model_token* t
       Qcur = ne_rope_inplace(ctx0, Qcur, n_past, head_dim, 2, 0);
       Kcur = ne_rope_inplace(ctx0, Kcur, n_past, head_dim, 2, 0);
 
-      // store key and value to memory
-      {
-        // head_dim, n_head_kv, N --> head_dim, N, n_head_kv
-        struct ne_tensor* Kcur_permuted = ne_permute(ctx0, Kcur, 0, 2, 1, 3);
-        // head_dim, n_head_kv, N --> N, head_dim, n_head_kv
-        struct ne_tensor* Vcur_permuted = ne_permute(ctx0, Vcur, 1, 2, 0, 3);
+      // self-attention
+      const float attn_scale = 1.0f / sqrtf(static_cast<float>(head_dim));
+      if (!run_mha_reordered) {
+        // store key and value to memory
+        {
+          // head_dim, n_head_kv, N --> head_dim, N, n_head_kv
+          struct ne_tensor* Kcur_permuted = ne_permute(ctx0, Kcur, 0, 2, 1, 3);
+          // head_dim, n_head_kv, N --> N, head_dim, n_head_kv
+          struct ne_tensor* Vcur_permuted = ne_permute(ctx0, Vcur, 1, 2, 0, 3);
 
-        struct ne_tensor* k = ne_view_3d(ctx0, kv_self.k, head_dim, N, n_head_kv, ne_element_size(kv_self.k) * head_dim,
-                                         ne_element_size(kv_self.k) * head_dim * n_ctx,
-                                         il * n_ctx * ne_element_size(kv_self.k) * head_dim * n_head_kv +
-                                             n_past * ne_element_size(kv_self.k) * head_dim);
-        struct ne_tensor* v = ne_view_3d(
-            ctx0, kv_self.v, N, head_dim, n_head_kv, n_ctx * ne_element_size(kv_self.v),
-            n_ctx * ne_element_size(kv_self.v) * head_dim,
-            il * n_ctx * ne_element_size(kv_self.v) * head_dim * n_head_kv + n_past * ne_element_size(kv_self.v));
+          struct ne_tensor* k =
+              ne_view_3d(ctx0, kv_self.k, head_dim, N, n_head_kv, ne_element_size(kv_self.k) * head_dim,
+                         ne_element_size(kv_self.k) * head_dim * n_ctx,
+                         il * n_ctx * ne_element_size(kv_self.k) * head_dim * n_head_kv +
+                             n_past * ne_element_size(kv_self.k) * head_dim);
+          struct ne_tensor* v = ne_view_3d(
+              ctx0, kv_self.v, N, head_dim, n_head_kv, n_ctx * ne_element_size(kv_self.v),
+              n_ctx * ne_element_size(kv_self.v) * head_dim,
+              il * n_ctx * ne_element_size(kv_self.v) * head_dim * n_head_kv + n_past * ne_element_size(kv_self.v));
 
-        ne_build_forward_expand(&gf, ne_cpy(ctx0, Kcur_permuted, k));
-        ne_build_forward_expand(&gf, ne_cpy(ctx0, Vcur_permuted, v));
+          ne_build_forward_expand(&gf, ne_cpy(ctx0, Kcur_permuted, k));
+          ne_build_forward_expand(&gf, ne_cpy(ctx0, Vcur_permuted, v));
+        }
+
+        // head_dim, N, n_head
+        struct ne_tensor* Q = ne_permute(ctx0, Qcur, 0, 2, 1, 3);
+
+        struct ne_tensor* K =
+            ne_view_3d(ctx0, kv_self.k, head_dim, N + n_past, n_head_kv, ne_element_size(kv_self.k) * head_dim,
+                       ne_element_size(kv_self.k) * head_dim * n_ctx,
+                       il * n_ctx * ne_element_size(kv_self.k) * head_dim * n_head_kv);
+
+        // K * Q
+        struct ne_tensor* KQ = ne_mul_mat(ctx0, K, Q);
+
+        // KQ_scaled = KQ / sqrt(n_embd/n_head)
+        struct ne_tensor* KQ_scaled = ne_scale_inplace(ctx0, KQ, ne_new_f32(ctx0, attn_scale));
+
+        // KQ_masked = mask_past(KQ_scaled)
+        struct ne_tensor* KQ_masked = ne_diag_mask_inf_inplace(ctx0, KQ_scaled, n_past);
+
+        // KQ = soft_max(KQ_masked)
+        struct ne_tensor* KQ_soft_max = ne_soft_max_inplace(ctx0, KQ_masked);
+
+        // V_trans = Vmem.view(n_embd/n_head, n_head, n_past + N).permute(1, 2, 0, 3).contiguous()
+        struct ne_tensor* V =
+            ne_view_3d(ctx0, kv_self.v, N + n_past, head_dim, n_head_kv, ne_element_size(kv_self.v) * n_ctx,
+                       ne_element_size(kv_self.v) * n_ctx * head_dim,
+                       il * n_ctx * ne_element_size(kv_self.v) * head_dim * n_head_kv);
+
+        // KQV = transpose(V) * KQ_soft_max
+        struct ne_tensor* KQV = ne_mul_mat(ctx0, V, KQ_soft_max);
+
+        // KQV_merged = KQV.permute(0, 2, 1, 3)
+        struct ne_tensor* KQV_merged = ne_permute(ctx0, KQV, 0, 2, 1, 3);
+
+        // cur = KQV_merged.contiguous().view(n_embd, N)
+        cur = ne_cpy(ctx0, KQV_merged, ne_new_tensor_2d(ctx0, NE_TYPE_F32, n_embd, N, NE_SIZE_CALC));
+      } else {  // Using MHA (GQA/MQA) managed kv-cache
+        const auto seq_kv = n_past + N;
+        const auto k_size = kv_cache_info.k_bytes;
+        const auto v_size = kv_cache_info.v_bytes;
+
+        // store key and value to memory
+        {
+          const auto k_cache = ne_view_3d(ctx0, kv_self.k,             // tensor
+                                          head_dim, n_ctx, n_head_kv,  // ne
+                                          0, 0,                        // nb (jblas managed)
+                                          il * k_size);                // offset
+          ne_build_forward_expand(&gf, ne_flash_attn_update_k(ctx0, k_cache, Kcur, n_past));
+          const auto v_cache = ne_view_3d(ctx0, kv_self.v,             // tensor
+                                          head_dim, n_ctx, n_head_kv,  // ne
+                                          0, 0,                        // nb (jblas managed)
+                                          il * v_size);                // offset
+          ne_build_forward_expand(&gf, ne_flash_attn_update_v(ctx0, v_cache, Vcur, n_past));
+        }
+
+        struct ne_tensor* Q = ne_permute(ctx0, Qcur, 0, 2, 1, 3);
+        ne_set_name(Q, "Q");
+
+        struct ne_tensor* K =
+            ne_view_3d(ctx0, kv_self.k,                                             // tensor
+                       head_dim, seq_kv, n_head_kv,                                 // ne
+                       kv_cache_info.stride_k_sl, kv_cache_info.stride_k_head_num,  // nb (jblas managed)
+                       il * k_size);                                                // offset
+        *reinterpret_cast<ATTN_FWD_LAYOUT*>(&K->nb[0]) = kv_cache_info.k_layout;    // us nb0 for layout
+        ne_set_name(K, "K");
+        struct ne_tensor* V =
+            ne_view_3d(ctx0, kv_self.v,                                                    // tensor
+                       seq_kv, head_dim, n_head_kv,                                        // ne
+                       kv_cache_info.stride_v_head_size, kv_cache_info.stride_v_head_num,  // nb (jblas managed)
+                       il * v_size);                                                       // offset
+        *reinterpret_cast<ATTN_FWD_LAYOUT*>(&V->nb[0]) = kv_cache_info.v_layout;           // us nb0 for layout
+        ne_set_name(V, "V");
+
+        ne_attn_flags_t attn_flags = 0;
+        if (n_past == 0) attn_flags |= NE_ATTN_FLAG_IS_CAUSAL;  // no causal mask on next-token cases
+        struct ne_tensor* KQV_Out = ne_flash_attn(ctx0, Q, K, V, attn_scale, attn_flags);
+        cur = ne_view_2d(ctx0, KQV_Out, n_embd, N, n_embd * ne_element_size(KQV_Out), 0);
       }
-
-      // head_dim, N, n_head
-      struct ne_tensor* Q = ne_permute(ctx0, Qcur, 0, 2, 1, 3);
-
-      struct ne_tensor* K =
-          ne_view_3d(ctx0, kv_self.k, head_dim, N + n_past, n_head_kv, ne_element_size(kv_self.k) * head_dim,
-                     ne_element_size(kv_self.k) * head_dim * n_ctx,
-                     il * n_ctx * ne_element_size(kv_self.k) * head_dim * n_head_kv);
-
-      // K * Q
-      struct ne_tensor* KQ = ne_mul_mat(ctx0, K, Q);
-
-      // KQ_scaled = KQ / sqrt(n_embd/n_head)
-      struct ne_tensor* KQ_scaled = ne_scale_inplace(ctx0, KQ, ne_new_f32(ctx0, 1.0f / sqrt(float(n_embd) / n_head)));
-
-      // KQ_masked = mask_past(KQ_scaled)
-      struct ne_tensor* KQ_masked = ne_diag_mask_inf_inplace(ctx0, KQ_scaled, n_past);
-
-      // KQ = soft_max(KQ_masked)
-      struct ne_tensor* KQ_soft_max = ne_soft_max_inplace(ctx0, KQ_masked);
-
-      // V_trans = Vmem.view(n_embd/n_head, n_head, n_past + N).permute(1, 2, 0, 3).contiguous()
-      struct ne_tensor* V =
-          ne_view_3d(ctx0, kv_self.v, N + n_past, head_dim, n_head_kv, ne_element_size(kv_self.v) * n_ctx,
-                     ne_element_size(kv_self.v) * n_ctx * head_dim,
-                     il * n_ctx * ne_element_size(kv_self.v) * head_dim * n_head_kv);
-
-      // KQV = transpose(V) * KQ_soft_max
-      struct ne_tensor* KQV = ne_mul_mat(ctx0, V, KQ_soft_max);
-
-      // KQV_merged = KQV.permute(0, 2, 1, 3)
-      struct ne_tensor* KQV_merged = ne_permute(ctx0, KQV, 0, 2, 1, 3);
-
-      // cur = KQV_merged.contiguous().view(n_embd, N)
-      cur = ne_cpy(ctx0, KQV_merged, ne_new_tensor_2d(ctx0, NE_TYPE_F32, n_embd, N, NE_SIZE_CALC));
-
       // projection
       { cur = ne_mul_mat(ctx0, model.layers[il].attn[1], cur); }
     }

--- a/intel_extension_for_transformers/llm/runtime/graph/models/falcon/falcon_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/falcon/falcon_utils.cpp
@@ -48,6 +48,7 @@ void model_load_internal(const std::string& fname, model_archs arch, model_conte
   ms->init(fname.c_str(), lctx, n_ctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
 
+  lctx.support_jblas_kv = true;
   lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 

--- a/intel_extension_for_transformers/llm/runtime/graph/models/gptj/gptj.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/gptj/gptj.cpp
@@ -102,6 +102,7 @@ static bool gptj_model_eval_internal(model_context& lctx, const model_token* tok
     attn_shape_t attn_shape = {
         /* .batch_size = */ batch_size,
         /* .head_num = */ n_head,
+        /* .heads_kv = */ n_head,  // GPT-J does not have MQA/GQA
         /* .head_size = */ n_embd / n_head,
         /* .sl_q = */ N,  // Note: make sure that jblas reordered attn supports next token inferencing
         /* .sl_kv = */ n_past + N,
@@ -109,7 +110,7 @@ static bool gptj_model_eval_internal(model_context& lctx, const model_token* tok
     NE_ASSERT(("jblas managed kv-cache not supported; use `--memory-f16 / --memory-f32` instead",
                jblas_reordered_attn_fp32_support(&attn_shape)));
     kv_shape_t kv_shape{
-        /* .head_num = */ static_cast<uint32_t>(n_head),
+        /* .heads_kv = */ static_cast<uint32_t>(n_head),
         /* .head_size = */ static_cast<uint32_t>(n_embd / n_head),
         /* .sl_kv_max = */ static_cast<uint32_t>(n_ctx),
     };

--- a/intel_extension_for_transformers/llm/runtime/graph/models/opt/opt.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/opt/opt.cpp
@@ -190,7 +190,7 @@ static bool opt_model_eval_internal(model_context& lctx, const model_token* toke
       //                1, 2, 0, 3),
       //            ne_new_tensor_3d(ctx0, NE_TYPE_F32, n_past + N, n_embd/n_head, n_head, NE_SIZE_CALC));
 
-      // struct ne_tensor * KQV = ne_flash_attn(ctx0, Q, K, V, true);
+      // struct ne_tensor * KQV = ne_flash_attn(ctx0, Q, K, V, NE_ATTN_FLAG_IS_CAUSAL);
 
       // K * Q
       // QK^T

--- a/intel_extension_for_transformers/llm/runtime/graph/models/starcoder/starcoder.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/starcoder/starcoder.cpp
@@ -188,7 +188,7 @@ static bool starcoder_model_eval_internal(model_context& lctx, const model_token
       //                1, 2, 0, 3),
       //            ne_new_tensor_3d(ctx0, NE_TYPE_F32, n_past + N, n_embd/n_head, n_head, NE_SIZE_CALC));
 
-      // struct ne_tensor * KQV = ne_flash_attn(ctx0, Q, K, V, true);
+      // struct ne_tensor * KQV = ne_flash_attn(ctx0, Q, K, V, NE_ATTN_FLAG_IS_CAUSAL);
 
       // K * Q
       // [n_past + N, N, 12]

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/inference.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/inference.py
@@ -91,8 +91,24 @@ def main(args_in: Optional[List[str]] = None) -> None:
     parser.add_argument(
         "--keep",
         type=int,
-        help="number of tokens to keep from the initial prompt (default: 0, -1 = all)  ",
+        help="number of tokens to keep from the initial prompt (default: 0, -1 = all)",
         default=0,
+    )
+    parser.add_argument(
+        "--memory-f32",
+        action="store_true",
+        help="Use fp32 for the data type of kv memory",
+    )
+    parser.add_argument(
+        "--memory-f16",
+        action="store_true",
+        help="Use fp16 for the data type of kv memory",
+    )
+    parser.add_argument(
+        "--memory-auto",
+        action="store_true",
+        help="Try with jblas flash attn managed format for kv memory (Currently GCC13 & AMX required); "
+        "fall back to fp16 if failed (default option for kv-memory)",
     )
 
     args = parser.parse_args(args_in)
@@ -113,8 +129,15 @@ def main(args_in: Optional[List[str]] = None) -> None:
     cmd.extend(["--seed",           str(args.seed)])
     cmd.extend(["--repeat-penalty", str(args.repeat_penalty)])
     cmd.extend(["--keep",           str(args.keep)])
-    # if args.color:
-    #     cmd.append(" --color")
+    if args.color:
+        cmd.append(" --color")
+    if args.memory_f32:
+        cmd.extend(["--memory-f32"])
+    if args.memory_f16:
+        cmd.extend(["--memory-f16"])
+    if args.memory_auto:
+        cmd.extend(["--memory-auto"])
+
 
     if (args.model_name == "chatglm"):
         tokenizer = AutoTokenizer.from_pretrained(args.glm_tokenizer, trust_remote_code=True)
@@ -123,7 +146,7 @@ def main(args_in: Optional[List[str]] = None) -> None:
         token_ids_str = ', '.join(token_ids_list)
         print(token_ids_str)
         cmd.extend(["--ids", token_ids_str])
-        
+
     print("cmd:", cmd)
     subprocess.run(cmd)
 


### PR DESCRIPTION
## Type of Change: feature
API not changed

## Description
Add MHA fusion support for Falcon, including:
- Support GQA and MQA
- Replace is_causal by attn_flags for future flags (particularly prepared for MPT's alibi)
- Forward the `--memory-f16/f32/auto` tags to the python script
- Add `NE_OP_DEBUG` for debugging experience

## Expected Behavior & Potential Risk
N/A

## How has this PR been tested?
<details>
<summary>Test commands:</summary>

```bash
set -ex
#main branch
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_falcon && numactl -m 1 -C 56-111 bin/run_falcon -m /home_local/dingyi/data/falcon-7b-pr410-q40.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 64 --memory-auto -p "$GIRL_PROMPT"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=ON -DCMAKE_BUILD_TYPE=Release && ninja run_falcon && env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_falcon -m /home_local/dingyi/data/falcon-7b-pr410-q40.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 3 --memory-auto -p "$LUOYU_PROMPT"

#this branch
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_falcon && numactl -m 1 -C 56-111 bin/run_falcon -m /home_local/dingyi/data/falcon-7b-pr410-q40.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 64 --memory-auto -p "$GIRL_PROMPT"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_falcon && numactl -m 1 -C 56-111 bin/run_falcon -m /home_local/dingyi/data/falcon-7b-pr410-q40.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 64 --memory-f16 -p "$GIRL_PROMPT"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=ON -DCMAKE_BUILD_TYPE=Release && ninja run_falcon && env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_falcon -m /home_local/dingyi/data/falcon-7b-pr410-q40.bin --seed 1234 -t 48 -b 2048 -c 2048 -n 3 --memory-auto -p "$LUOYU_PROMPT"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=ON -DCMAKE_BUILD_TYPE=Release && ninja run_falcon && env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_falcon -m /home_local/dingyi/data/falcon-7b-pr410-q40.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 3 --memory-auto -p "$LUOYU_PROMPT"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=ON -DCMAKE_BUILD_TYPE=Release && ninja run_falcon && env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_falcon -m /home_local/dingyi/data/falcon-7b-pr410-q40.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 3 --memory-f16 -p "$LUOYU_PROMPT"
```
</details>

In conclusion, the model can generate reasonable text with MHA fusion enabled, and it preserves the identical behavior when disable the fusion (`--memory-f16`). The fusion brings ~80% (33833.79ms => 19023.91ms) for first token and ~20% (64.66ms => 53.95ms) performance for next token inference.

### Main branch 
- <details>
  <summary>
  <code>numactl -m 1 -C 56-111 bin/run_falcon -m /home_local/dingyi/data/falcon-7b-pr410-q40.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 64 --memory-auto -p "$GIRL_PROMPT"</code>
  </summary>

  ```
  Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun. But most of all, she wanted to learn. And so she did.
  This little girl grew up, and became a writer (and sometimes a photographer) and she's still learning.
  She learned that she must live each moment and enjoy it, no matter how hard the road may be.
  She
  ```
  </details>
- <details>
  <summary>
  <code>env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_falcon -m /home_local/dingyi/data/falcon-7b-pr410-q40.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 3 --memory-auto -p "$LUOYU_PROMPT"</code>
  </summary>

  ```
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =  81.301 ms
  perf_total_per_op_us[                     MUL] =  26.273 ms
  perf_total_per_op_us[                  REPEAT] = 297.837 ms
  perf_total_per_op_us[                    GELU] = 408.667 ms
  perf_total_per_op_us[                    NORM] =  29.996 ms
  perf_total_per_op_us[                 MUL_MAT] = 29184.555 ms
  perf_total_per_op_us[                   SCALE] = 2971.997 ms
  perf_total_per_op_us[                     CPY] =  44.583 ms
  perf_total_per_op_us[                    VIEW] =   0.896 ms
  perf_total_per_op_us[                 PERMUTE] =   0.502 ms
  perf_total_per_op_us[                GET_ROWS] =   9.409 ms
  perf_total_per_op_us[           DIAG_MASK_INF] = 183.420 ms
  perf_total_per_op_us[                SOFT_MAX] = 530.065 ms
  perf_total_per_op_us[                    ROPE] =  59.033 ms
  perf_total_per_op_us[           INNER PRODUCT] =   0.000 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.644 ms
  perf_total_per_op_us[                     MUL] =   0.219 ms
  perf_total_per_op_us[                    GELU] =  12.005 ms
  perf_total_per_op_us[                    NORM] =   1.533 ms
  perf_total_per_op_us[                 MUL_MAT] =   9.529 ms
  perf_total_per_op_us[                   SCALE] =   1.491 ms
  perf_total_per_op_us[                     CPY] =   4.314 ms
  perf_total_per_op_us[                    VIEW] =   0.754 ms
  perf_total_per_op_us[                 PERMUTE] =   0.459 ms
  perf_total_per_op_us[                GET_ROWS] =   0.027 ms
  perf_total_per_op_us[           DIAG_MASK_INF] =   0.122 ms
  perf_total_per_op_us[                SOFT_MAX] =   1.853 ms
  perf_total_per_op_us[                    ROPE] =   1.176 ms
  perf_total_per_op_us[           INNER PRODUCT] =  30.112 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.543 ms
  perf_total_per_op_us[                     MUL] =   0.201 ms
  perf_total_per_op_us[                    GELU] =  11.318 ms
  perf_total_per_op_us[                    NORM] =   1.264 ms
  perf_total_per_op_us[                 MUL_MAT] =   8.251 ms
  perf_total_per_op_us[                   SCALE] =   1.447 ms
  perf_total_per_op_us[                     CPY] =   3.837 ms
  perf_total_per_op_us[                    VIEW] =   0.810 ms
  perf_total_per_op_us[                 PERMUTE] =   0.415 ms
  perf_total_per_op_us[                GET_ROWS] =   0.021 ms
  perf_total_per_op_us[           DIAG_MASK_INF] =   0.119 ms
  perf_total_per_op_us[                SOFT_MAX] =   1.672 ms
  perf_total_per_op_us[                    ROPE] =   1.059 ms
  perf_total_per_op_us[           INNER PRODUCT] =  29.651 ms
  ========================================
  model_print_timings:        load time = 34974.57 ms
  model_print_timings:      sample time =     2.66 ms /     3 runs   (    0.89 ms per token)
  model_print_timings: prompt eval time = 33833.78 ms /  2008 tokens (   16.85 ms per token)
  model_print_timings:        eval time =   132.93 ms /     2 runs   (   66.47 ms per token)
  model_print_timings:       total time = 35165.28 ms
  ========== eval time log of each prediction ==========
  prediction   0, time: 33833.79ms
  prediction   1, time: 68.28ms
  prediction   2, time: 64.66ms
  ```
  </details>

### This branch
- <details>
  <summary>
  <code>numactl -m 1 -C 56-111 bin/run_falcon -m /home_local/dingyi/data/falcon-7b-pr410-q40.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 64 --memory-auto -p "$GIRL_PROMPT"</code>
  </summary>

  ```
  Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun. But this little girl lived with her parents and her brother. Her parents had a lot of rules for her. For example she couldn't go out alone after 7pm at night.
  The little girl was always very good to her parents, always listened to them. So she tried her best to obey all the
  ```
  </details>
- <details>
  <summary>
  <code>numactl -m 1 -C 56-111 bin/run_falcon -m /home_local/dingyi/data/falcon-7b-pr410-q40.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 64 --memory-f16 -p "$GIRL_PROMPT"</code>
  </summary>

  ```
  Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun. But most of all, she wanted to learn. And so she did.
  This little girl grew up, and became a writer (and sometimes a photographer) and she's still learning.
  She learned that she must live each moment and enjoy it, no matter how hard the road may be.
  She
  ```
  </details>
- <details>
  <summary>
  <code>env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_falcon -m /home_local/dingyi/data/falcon-7b-pr410-q40.bin --seed 1234 -t 48 -b 2048 -c 2048 -n 3 --memory-auto -p "$LUOYU_PROMPT"</code>
  </summary>

  ```
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =  78.572 ms
  perf_total_per_op_us[                     MUL] =  28.676 ms
  perf_total_per_op_us[                  REPEAT] = 282.013 ms
  perf_total_per_op_us[                    GELU] = 478.248 ms
  perf_total_per_op_us[                    NORM] =  27.356 ms
  perf_total_per_op_us[                 MUL_MAT] = 19122.167 ms
  perf_total_per_op_us[                     CPY] =   9.288 ms
  perf_total_per_op_us[                    VIEW] =   0.904 ms
  perf_total_per_op_us[                 PERMUTE] =   0.129 ms
  perf_total_per_op_us[                GET_ROWS] =   9.050 ms
  perf_total_per_op_us[                    ROPE] =  51.539 ms
  perf_total_per_op_us[              FLASH_ATTN] = 262.149 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =  14.172 ms
  perf_total_per_op_us[           INNER PRODUCT] =   0.000 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.591 ms
  perf_total_per_op_us[                     MUL] =   0.212 ms
  perf_total_per_op_us[                    GELU] =  11.214 ms
  perf_total_per_op_us[                    NORM] =   1.203 ms
  perf_total_per_op_us[                     CPY] =   0.897 ms
  perf_total_per_op_us[                    VIEW] =   0.881 ms
  perf_total_per_op_us[                 PERMUTE] =   0.115 ms
  perf_total_per_op_us[                GET_ROWS] =   0.021 ms
  perf_total_per_op_us[                    ROPE] =   1.029 ms
  perf_total_per_op_us[              FLASH_ATTN] =   4.219 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =   1.551 ms
  perf_total_per_op_us[           INNER PRODUCT] =  31.187 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.474 ms
  perf_total_per_op_us[                     MUL] =   0.176 ms
  perf_total_per_op_us[                    GELU] =  11.143 ms
  perf_total_per_op_us[                    NORM] =   1.238 ms
  perf_total_per_op_us[                     CPY] =   0.884 ms
  perf_total_per_op_us[                    VIEW] =   0.871 ms
  perf_total_per_op_us[                 PERMUTE] =   0.107 ms
  perf_total_per_op_us[                GET_ROWS] =   0.021 ms
  perf_total_per_op_us[                    ROPE] =   1.030 ms
  perf_total_per_op_us[              FLASH_ATTN] =   3.791 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =   1.371 ms
  perf_total_per_op_us[           INNER PRODUCT] =  30.322 ms
  ========================================
  model_print_timings:        load time = 21563.13 ms
  model_print_timings:      sample time =     3.23 ms /     3 runs   (    1.08 ms per token)
  model_print_timings: prompt eval time = 20368.36 ms /  2008 tokens (   10.14 ms per token)
  model_print_timings:        eval time =   110.76 ms /     2 runs   (   55.38 ms per token)
  model_print_timings:       total time = 21740.37 ms
  ========== eval time log of each prediction ==========
  prediction   0, time: 20368.36ms
  prediction   1, time: 56.26ms
  prediction   2, time: 54.49ms
  ```
  </details>
- <details>
  <summary>
  <code>env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_falcon -m /home_local/dingyi/data/falcon-7b-pr410-q40.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 3 --memory-auto -p "$LUOYU_PROMPT"</code>
  </summary>

  ```
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =  67.054 ms
  perf_total_per_op_us[                     MUL] =  25.284 ms
  perf_total_per_op_us[                  REPEAT] = 292.125 ms
  perf_total_per_op_us[                    GELU] = 443.020 ms
  perf_total_per_op_us[                    NORM] =  26.823 ms
  perf_total_per_op_us[                 MUL_MAT] = 17845.975 ms
  perf_total_per_op_us[                     CPY] =   9.194 ms
  perf_total_per_op_us[                    VIEW] =   0.901 ms
  perf_total_per_op_us[                 PERMUTE] =   0.112 ms
  perf_total_per_op_us[                GET_ROWS] =   9.606 ms
  perf_total_per_op_us[                    ROPE] =  55.728 ms
  perf_total_per_op_us[              FLASH_ATTN] = 231.289 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =  12.471 ms
  perf_total_per_op_us[           INNER PRODUCT] =   0.000 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.646 ms
  perf_total_per_op_us[                     MUL] =   0.246 ms
  perf_total_per_op_us[                    GELU] =  11.491 ms
  perf_total_per_op_us[                    NORM] =   1.230 ms
  perf_total_per_op_us[                     CPY] =   0.928 ms
  perf_total_per_op_us[                    VIEW] =   0.860 ms
  perf_total_per_op_us[                 PERMUTE] =   0.099 ms
  perf_total_per_op_us[                GET_ROWS] =   0.022 ms
  perf_total_per_op_us[                    ROPE] =   1.073 ms
  perf_total_per_op_us[              FLASH_ATTN] =   4.416 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =   1.504 ms
  perf_total_per_op_us[           INNER PRODUCT] =  30.194 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.520 ms
  perf_total_per_op_us[                     MUL] =   0.172 ms
  perf_total_per_op_us[                    GELU] =  11.316 ms
  perf_total_per_op_us[                    NORM] =   1.207 ms
  perf_total_per_op_us[                     CPY] =   0.861 ms
  perf_total_per_op_us[                    VIEW] =   0.916 ms
  perf_total_per_op_us[                 PERMUTE] =   0.104 ms
  perf_total_per_op_us[                GET_ROWS] =   0.022 ms
  perf_total_per_op_us[                    ROPE] =   1.022 ms
  perf_total_per_op_us[              FLASH_ATTN] =   3.690 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =   1.550 ms
  perf_total_per_op_us[           INNER PRODUCT] =  29.443 ms
  ========================================
  model_print_timings:        load time = 20171.18 ms
  model_print_timings:      sample time =     3.32 ms /     3 runs   (    1.11 ms per token)
  model_print_timings: prompt eval time = 19023.91 ms /  2008 tokens (    9.47 ms per token)
  model_print_timings:        eval time =   109.89 ms /     2 runs   (   54.95 ms per token)
  model_print_timings:       total time = 20349.47 ms
  ========== eval time log of each prediction ==========
  prediction   0, time: 19023.91ms
  prediction   1, time: 55.94ms
  prediction   2, time: 53.95ms
  ```
  </details>
- <details>
  <summary>
  <code>env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_falcon -m /home_local/dingyi/data/falcon-7b-pr410-q40.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 3 --memory-f16 -p "$LUOYU_PROMPT"</code>
  </summary>

  ```
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =  80.116 ms
  perf_total_per_op_us[                     MUL] =  24.818 ms
  perf_total_per_op_us[                  REPEAT] = 303.144 ms
  perf_total_per_op_us[                    GELU] = 408.902 ms
  perf_total_per_op_us[                    NORM] =  23.654 ms
  perf_total_per_op_us[                 MUL_MAT] = 30113.444 ms
  perf_total_per_op_us[                   SCALE] = 3015.494 ms
  perf_total_per_op_us[                     CPY] =  53.191 ms
  perf_total_per_op_us[                    VIEW] =   0.860 ms
  perf_total_per_op_us[                 PERMUTE] =   0.471 ms
  perf_total_per_op_us[                GET_ROWS] =   9.801 ms
  perf_total_per_op_us[           DIAG_MASK_INF] = 182.767 ms
  perf_total_per_op_us[                SOFT_MAX] = 511.043 ms
  perf_total_per_op_us[                    ROPE] =  62.090 ms
  perf_total_per_op_us[           INNER PRODUCT] =   0.000 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.816 ms
  perf_total_per_op_us[                     MUL] =   0.273 ms
  perf_total_per_op_us[                    GELU] =  12.178 ms
  perf_total_per_op_us[                    NORM] =   1.747 ms
  perf_total_per_op_us[                 MUL_MAT] =  10.204 ms
  perf_total_per_op_us[                   SCALE] =   1.581 ms
  perf_total_per_op_us[                     CPY] =   5.653 ms
  perf_total_per_op_us[                    VIEW] =   0.813 ms
  perf_total_per_op_us[                 PERMUTE] =   0.442 ms
  perf_total_per_op_us[                GET_ROWS] =   0.028 ms
  perf_total_per_op_us[           DIAG_MASK_INF] =   0.122 ms
  perf_total_per_op_us[                SOFT_MAX] =   2.276 ms
  perf_total_per_op_us[                    ROPE] =   1.440 ms
  perf_total_per_op_us[           INNER PRODUCT] =  31.910 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.492 ms
  perf_total_per_op_us[                     MUL] =   0.180 ms
  perf_total_per_op_us[                    GELU] =  12.290 ms
  perf_total_per_op_us[                    NORM] =   1.795 ms
  perf_total_per_op_us[                 MUL_MAT] =  10.161 ms
  perf_total_per_op_us[                   SCALE] =   1.505 ms
  perf_total_per_op_us[                     CPY] =   5.593 ms
  perf_total_per_op_us[                    VIEW] =   0.767 ms
  perf_total_per_op_us[                 PERMUTE] =   0.422 ms
  perf_total_per_op_us[                GET_ROWS] =   0.029 ms
  perf_total_per_op_us[           DIAG_MASK_INF] =   0.138 ms
  perf_total_per_op_us[                SOFT_MAX] =   2.350 ms
  perf_total_per_op_us[                    ROPE] =   1.435 ms
  perf_total_per_op_us[           INNER PRODUCT] =  31.871 ms
  ========================================
  model_print_timings:        load time = 35948.11 ms
  model_print_timings:      sample time =     2.71 ms /     3 runs   (    0.90 ms per token)
  model_print_timings: prompt eval time = 34795.06 ms /  2008 tokens (   17.33 ms per token)
  model_print_timings:        eval time =   146.85 ms /     2 runs   (   73.43 ms per token)
  model_print_timings:       total time = 36152.77 ms
  ========== eval time log of each prediction ==========
  prediction   0, time: 34795.05ms
  prediction   1, time: 73.77ms
  prediction   2, time: 73.09ms
  ```
  </details>

In addition, it is tested that llama & gptj will preserve its behavior in this PR (q4j-int8-g128). 

## Dependency Change?
N/A
