### PR TITLE
[CPP Graph] ChatGLM2 MHA support

### DIFF
--- a/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm2.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm2.cpp
@@ -11,6 +11,8 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
+#include "chatglm2.h"
+
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -31,6 +33,7 @@
 #include "core/data_types.h"
 #include "core/ne.h"
 #include "core/ne_layers.h"
+#include "core/layers/mha_dense.h"
 #include "models/model_utils/model_config.h"
 #include "models/model_utils/model_utils.h"
 #include "models/model_utils/util.h"
@@ -86,13 +89,35 @@ static bool chatglm_model_eval_internal(model_context& lctx, const model_token* 
   ne_cgraph gf = {};
   gf.n_threads = N >= 32 && ne_cpu_has_blas() ? 1 : n_threads;
 
+  const bool run_mha_reordered = model.layers[0].k_cache->type == NE_TYPE_JBLAS;
+  kv_cache_info_t kv_cache_info = {};
+  if (run_mha_reordered) {
+    NE_ASSERT(("kv cache should be the same dtype", model.layers[0].v_cache->type == NE_TYPE_JBLAS));
+    attn_shape_t attn_shape = {
+        /* .batch_size = */ 1,
+        /* .head_num = */ n_head,
+        /* .heads_kv = */ num_kv_heads,
+        /* .head_size = */ head_size,
+        /* .sl_q = */ N,  // Note: make sure that jblas reordered attn supports next token inference
+        /* .sl_kv = */ n_past + N,
+    };
+
+    NE_ASSERT(("jblas managed kv-cache not supported; use `--memory-f16 / --memory-f32` instead",
+               jblas_reordered_attn_fp32_support(&attn_shape)));
+    kv_shape_t kv_shape{
+        /* .heads_kv = */ static_cast<uint32_t>(num_kv_heads),
+        /* .head_size = */ static_cast<uint32_t>(head_size),
+        /* .sl_kv_max = */ static_cast<uint32_t>(n_ctx),
+    };
+    jblas_reordered_attn_fp32_batch_kv_info(&kv_shape, &kv_cache_info);
+  }
+
   struct ne_tensor* embd = d_ne_new_tensor_1d(ctx0, NE_TYPE_I32, N);
   ne_set_name(embd, "embd");
   memcpy(embd->data, tokens, N * ne_element_size(embd));
-  // int qlen = embd->ne[1];
   struct ne_tensor* inpL = ne_get_rows(ctx0, model.others[0], embd);
 
-  int qlen = inpL->ne[1];
+  NE_ASSERT(N == inpL->ne[1]);
   for (int il = 0; il < n_layer; ++il) {
     struct ne_tensor* cur;
 
@@ -108,75 +133,113 @@ static bool chatglm_model_eval_internal(model_context& lctx, const model_token* 
 
       struct ne_tensor* query_layer =
           ne_view_3d(ctx0, cur, head_size, n_head, N, head_size * ne_element_size(cur), cur->nb[1],
-                     0);  // [qlen, heads, head_size]
+                     0);  // [N, heads, head_size]
       ne_set_name(query_layer, "query_layer");
       query_layer = ne_rope_inplace(ctx0, query_layer, n_past, rope_dim, 0, 0);
-      query_layer = ne_cont(ctx0, ne_permute(ctx0, query_layer, 0, 2, 1, 3));  // [heads, qlen, head_size]
-      query_layer = ne_reshape_3d(ctx0, query_layer, head_size, mqa_scale * qlen,
-                                  num_kv_heads);  // [kv_heads, mqa_scale * qlen, head_size]
 
       struct ne_tensor* key_layer =
-          ne_view_3d(ctx0, cur, head_size, num_kv_heads, qlen, head_size * ne_element_size(cur), cur->nb[1],
-                     hidden_size * ne_element_size(cur));  // [qlen, kv_heads, head_size]
+          ne_view_3d(ctx0, cur, head_size, num_kv_heads, N, head_size * ne_element_size(cur), cur->nb[1],
+                     hidden_size * ne_element_size(cur));  // [N, kv_heads, head_size]
       ne_set_name(key_layer, "key_layer");
       key_layer = ne_rope_inplace(ctx0, key_layer, n_past, rope_dim, 0, 0);
-      key_layer = ne_permute(ctx0, key_layer, 0, 2, 1, 3);  // [kv_heads, qlen, head_size]
 
       struct ne_tensor* value_layer =
-          ne_view_3d(ctx0, cur, head_size, num_kv_heads, qlen, head_size * ne_element_size(cur), cur->nb[1],
-                     (hidden_size + head_size * num_kv_heads) * ne_element_size(cur));  // [qlen, kv_heads, head_size]
+          ne_view_3d(ctx0, cur, head_size, num_kv_heads, N, head_size * ne_element_size(cur), cur->nb[1],
+                     (hidden_size + head_size * num_kv_heads) * ne_element_size(cur));  // [N, kv_heads, head_size]
       ne_set_name(value_layer, "value_layer");
-      value_layer = ne_permute(ctx0, value_layer, 1, 2, 0, 3);  // [kv_heads, head_size, qlen]
 
-      // store key and value to memory
-      {
-        struct ne_tensor* k_cache_view =
-            ne_view_3d(ctx0, model.layers[il].k_cache, head_size, qlen, num_kv_heads, model.layers[il].k_cache->nb[1],
-                       model.layers[il].k_cache->nb[2],
-                       n_past * head_size * ne_element_size(model.layers[il].k_cache));  // [kv_heads, qlen, head_size]
-        ne_set_name(k_cache_view, "k_cache_view");
-        struct ne_tensor* v_cache_view =
-            ne_view_3d(ctx0, model.layers[il].v_cache, qlen, head_size, num_kv_heads, model.layers[il].v_cache->nb[1],
-                       model.layers[il].v_cache->nb[2],
-                       n_past * ne_element_size(model.layers[il].v_cache));  // [kv_heads, head_size, qlen]
-        ne_set_name(v_cache_view, "v_cache_view");
+      const float attn_scale = 1.f / std::sqrt(head_size);
+      if (!run_mha_reordered) {
+        query_layer = ne_cont(ctx0, ne_permute(ctx0, query_layer, 0, 2, 1, 3));  // [heads, N, head_size]
+        query_layer = ne_reshape_3d(ctx0, query_layer, head_size, mqa_scale * N,
+                                    num_kv_heads);                // [kv_heads, mqa_scale * N, head_size]
+        key_layer = ne_permute(ctx0, key_layer, 0, 2, 1, 3);      // [kv_heads, N, head_size]
+        value_layer = ne_permute(ctx0, value_layer, 1, 2, 0, 3);  // [kv_heads, head_size, N]
+        // store key and value to memory
+        {
+          struct ne_tensor* k_cache_view =
+              ne_view_3d(ctx0, model.layers[il].k_cache, head_size, N, num_kv_heads, model.layers[il].k_cache->nb[1],
+                         model.layers[il].k_cache->nb[2],
+                         n_past * head_size * ne_element_size(model.layers[il].k_cache));  // [kv_heads, N, head_size]
+          ne_set_name(k_cache_view, "k_cache_view");
+          struct ne_tensor* v_cache_view =
+              ne_view_3d(ctx0, model.layers[il].v_cache, N, head_size, num_kv_heads, model.layers[il].v_cache->nb[1],
+                         model.layers[il].v_cache->nb[2],
+                         n_past * ne_element_size(model.layers[il].v_cache));  // [kv_heads, head_size, N]
+          ne_set_name(v_cache_view, "v_cache_view");
 
-        ne_build_forward_expand(&gf, ne_cpy(ctx0, key_layer, k_cache_view));
-        ne_build_forward_expand(&gf, ne_cpy(ctx0, value_layer, v_cache_view));
+          ne_build_forward_expand(&gf, ne_cpy(ctx0, key_layer, k_cache_view));
+          ne_build_forward_expand(&gf, ne_cpy(ctx0, value_layer, v_cache_view));
+        }
+
+        // concat key & value with past kv
+        key_layer = ne_view_3d(ctx0, model.layers[il].k_cache, head_size, n_past + N, num_kv_heads,
+                               model.layers[il].k_cache->nb[1], model.layers[il].k_cache->nb[2],
+                               0);  // [kv_heads, klen, head_size]
+        value_layer = ne_view_3d(ctx0, model.layers[il].v_cache, n_past + N, head_size, num_kv_heads,
+                                 model.layers[il].v_cache->nb[1], model.layers[il].v_cache->nb[2],
+                                 0);  // [kv_heads, head_size, klen]
+
+        // attention
+        struct ne_tensor* attn_scores = ne_mul_mat(ctx0, key_layer, query_layer);  // [kv_heads, mqa_scale * N, klen]
+        ne_set_name(attn_scores, "attn_scores");
+        attn_scores = ne_scale_inplace(ctx0, attn_scores, ne_new_f32(ctx0, attn_scale));
+
+        if (n_past == 0) {
+          // build attention mask for context input
+          attn_scores = ne_reshape_3d(ctx0, attn_scores, n_past + N, N,
+                                      num_attention_heads);  // [heads, N, klen]
+          attn_scores = ne_diag_mask_inf_inplace(ctx0, attn_scores, n_past);
+          attn_scores = ne_reshape_3d(ctx0, attn_scores, n_past + N, mqa_scale * N,
+                                      num_kv_heads);  // [kv_heads, mqa_scale * N, klen]
+        }
+
+        struct ne_tensor* attn_probs = ne_soft_max_inplace(ctx0, attn_scores);  // [kv_heads, mqa_scale * N, klen]
+
+        cur = ne_mul_mat(ctx0, value_layer, attn_probs);  // [kv_heads, mqa_scale * N, head_size]
+        cur = ne_reshape_3d(ctx0, cur, head_size, N,
+                            num_attention_heads);                // [heads, N, head_size]
+        cur = ne_cont(ctx0, ne_permute(ctx0, cur, 0, 2, 1, 3));  // [N, heads, head_size]
+        cur = ne_reshape_2d(ctx0, cur, hidden_size, N);          // [N, hidden]
+      } else {                                                   // Using MHA (GQA/MQA) managed kv-cache
+        const auto seq_kv = n_past + N;
+        const auto k_size = kv_cache_info.k_bytes;
+        const auto v_size = kv_cache_info.v_bytes;
+
+        // store key and value to memory
+        {
+          const auto k_cache = ne_view_3d(ctx0, model.layers[il].k_cache,  // tensor
+                                          head_size, n_ctx, num_kv_heads,  // ne
+                                          0, 0,                            // nb (jblas managed)
+                                          0);                              // offset
+          ne_build_forward_expand(&gf, ne_flash_attn_update_k(ctx0, k_cache, key_layer, n_past));
+          const auto v_cache = ne_view_3d(ctx0, model.layers[il].v_cache,  // tensor
+                                          head_size, n_ctx, num_kv_heads,  // ne
+                                          0, 0,                            // nb (jblas managed)
+                                          0);                              // offset
+          ne_build_forward_expand(&gf, ne_flash_attn_update_v(ctx0, v_cache, value_layer, n_past));
+        }
+
+        query_layer = ne_permute(ctx0, query_layer, 0, 2, 1, 3);                            // [heads, N, head_size]
+        key_layer =                                                                         //
+            ne_view_3d(ctx0, model.layers[il].k_cache,                                      // tensor
+                       head_size, seq_kv, num_kv_heads,                                     // ne
+                       kv_cache_info.stride_k_sl, kv_cache_info.stride_k_head_num,          // nb (jblas managed)
+                       0);                                                                  // offset
+        *reinterpret_cast<ATTN_FWD_LAYOUT*>(&key_layer->nb[0]) = kv_cache_info.k_layout;    // us nb0 for layout
+        value_layer =                                                                       //
+            ne_view_3d(ctx0, model.layers[il].v_cache,                                      // tensor
+                       seq_kv, head_size, num_kv_heads,                                     // ne
+                       kv_cache_info.stride_v_head_size, kv_cache_info.stride_v_head_num,   // nb (jblas managed)
+                       0);                                                                  // offset
+        *reinterpret_cast<ATTN_FWD_LAYOUT*>(&value_layer->nb[0]) = kv_cache_info.v_layout;  // us nb0 for layout
+
+        ne_attn_flags_t attn_flags = 0;
+        if (n_past == 0) attn_flags |= NE_ATTN_FLAG_IS_CAUSAL;  // no causal mask on next-token cases
+        struct ne_tensor* KQV_Out = ne_flash_attn(ctx0, query_layer, key_layer, value_layer, attn_scale, attn_flags);
+        cur = ne_view_2d(ctx0, KQV_Out, n_embd, N, n_embd * ne_element_size(KQV_Out), 0);
       }
-
-      // concat key & value with past kv
-      key_layer = ne_view_3d(ctx0, model.layers[il].k_cache, head_size, n_past + qlen, num_kv_heads,
-                             model.layers[il].k_cache->nb[1], model.layers[il].k_cache->nb[2],
-                             0);  // [kv_heads, klen, head_size]
-      value_layer = ne_view_3d(ctx0, model.layers[il].v_cache, n_past + qlen, head_size, num_kv_heads,
-                               model.layers[il].v_cache->nb[1], model.layers[il].v_cache->nb[2],
-                               0);  // [kv_heads, head_size, klen]
-
-      // attention
-      struct ne_tensor* attn_scores = ne_mul_mat(ctx0, key_layer, query_layer);  // [kv_heads, mqa_scale * qlen, klen]
-      ne_set_name(attn_scores, "attn_scores");
-      attn_scores = ne_scale_inplace(ctx0, attn_scores, ne_new_f32(ctx0, 1.f / std::sqrt(head_size)));
-
-      if (n_past == 0) {
-        // build attention mask for context input
-        attn_scores = ne_reshape_3d(ctx0, attn_scores, n_past + qlen, qlen,
-                                    num_attention_heads);  // [heads, qlen, klen]
-        attn_scores = ne_diag_mask_inf_inplace(ctx0, attn_scores, n_past);
-        attn_scores = ne_reshape_3d(ctx0, attn_scores, n_past + qlen, mqa_scale * qlen,
-                                    num_kv_heads);  // [kv_heads, mqa_scale * qlen, klen]
-      }
-
-      struct ne_tensor* attn_probs = ne_soft_max_inplace(ctx0, attn_scores);  // [kv_heads, mqa_scale * qlen, klen]
-
-      struct ne_tensor* context_layer =
-          ne_mul_mat(ctx0, value_layer, attn_probs);  // [kv_heads, mqa_scale * qlen, head_size]
-      context_layer = ne_reshape_3d(ctx0, context_layer, head_size, qlen,
-                                    num_attention_heads);                          // [heads, qlen, head_size]
-      context_layer = ne_cont(ctx0, ne_permute(ctx0, context_layer, 0, 2, 1, 3));  // [qlen, heads, head_size]
-      context_layer = ne_reshape_2d(ctx0, context_layer, hidden_size, qlen);       // [qlen, hidden]
-
-      cur = ne_mul_mat(ctx0, model.layers[il].attn[2], context_layer);
+      cur = ne_mul_mat(ctx0, model.layers[il].attn[2], cur);
     }
 
     lctx.use_buf(ctx0, 1);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_utils.cpp
@@ -55,7 +55,7 @@
 // kv cache
 //
 
-// non-null param of model for chatglm style kv-cache
+// non-null pointer of model for kv-cache as components of model->layers[il] (e.g. chatglm)
 static bool kv_cache_init(const struct model_hparams& hparams, struct model_kv_cache& cache, const ne_type wtype,
                           const int batch_size, const int beam_size, model_struct* model) {
   const auto n_layer = hparams.n_layer;
@@ -83,7 +83,7 @@ static bool kv_cache_init(const struct model_hparams& hparams, struct model_kv_c
   // NE_TYPE_JBLAS can not be allocated memory
   const auto wtype_alloc = wtype == NE_TYPE_JBLAS ? NE_TYPE_I8 : wtype;
 
-  if (model) {  // non-null param of model for chatglm style kv-cache
+  if (model) {  // non-null param of model for kv-cache as components of model->layers[il]
     for (int il = 0; il < hparams.n_layer; ++il) {
       auto& k_cache = model->layers[il].k_cache;
       auto& v_cache = model->layers[il].v_cache;

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_utils.cpp
@@ -55,16 +55,18 @@
 // kv cache
 //
 
+// non-null param of model for chatglm style kv-cache
 static bool kv_cache_init(const struct model_hparams& hparams, struct model_kv_cache& cache, const ne_type wtype,
-                          const int batch_size, const int beam_size) {
+                          const int batch_size, const int beam_size, model_struct* model) {
+  const auto n_layer = hparams.n_layer;
   int32_t k_size, v_size;
   get_batch_kv_elements_from_gpt_params(hparams, wtype, &k_size, &v_size);
 
-  const int64_t n_elements_k = hparams.n_layer * batch_size * beam_size * k_size;
-  const int64_t n_elements_v = hparams.n_layer * batch_size * beam_size * v_size;
+  const int64_t layer_ne_k = batch_size * beam_size * k_size;
+  const int64_t layer_ne_v = batch_size * beam_size * v_size;
   const auto wsize = wtype == NE_TYPE_JBLAS ? 1 : ne_type_size(wtype);
 
-  cache.buf.resize((n_elements_k + n_elements_v) * wsize + 2u * MB);
+  cache.buf.resize(n_layer * (layer_ne_k + layer_ne_v) * wsize + 2u * MB);
 
   struct ne_init_params params;
   params.mem_size = cache.buf.size;
@@ -80,16 +82,42 @@ static bool kv_cache_init(const struct model_hparams& hparams, struct model_kv_c
 
   // NE_TYPE_JBLAS can not be allocated memory
   const auto wtype_alloc = wtype == NE_TYPE_JBLAS ? NE_TYPE_I8 : wtype;
-  cache.k = ne_new_tensor_1d(cache.ctx, wtype_alloc, n_elements_k + NE_ALIGNMENT, NE_SIZE_CALC);
-  cache.k = ne_view_1d(cache.ctx, cache.k, n_elements_k,
-                       NE_ALIGNMENT - (reinterpret_cast<uintptr_t>(cache.k->data) % NE_ALIGNMENT));
-  cache.k->type = wtype;
-  cache.v = ne_new_tensor_1d(cache.ctx, wtype_alloc, n_elements_v + NE_ALIGNMENT, NE_SIZE_CALC);
-  cache.v = ne_view_1d(cache.ctx, cache.v, n_elements_v,
-                       NE_ALIGNMENT - (reinterpret_cast<uintptr_t>(cache.v->data) % NE_ALIGNMENT));
-  cache.v->type = wtype;
-  ne_set_name(cache.k, "cache_k");
-  ne_set_name(cache.v, "cache_v");
+
+  if (model) {  // non-null param of model for chatglm style kv-cache
+    for (int il = 0; il < hparams.n_layer; ++il) {
+      auto& k_cache = model->layers[il].k_cache;
+      auto& v_cache = model->layers[il].v_cache;
+      if (wtype == NE_TYPE_F16) {  // chatglm does not support fp32 kv-cache in original impl of chatglm_util.cpp
+        const auto head_size = hparams.n_embd / hparams.n_head;
+        k_cache = d_ne_new_tensor_3d(model->ctx, NE_TYPE_F16, head_size, hparams.n_ctx, hparams.multi_query_group_num);
+        v_cache = d_ne_new_tensor_3d(model->ctx, NE_TYPE_F16, hparams.n_ctx, head_size, hparams.multi_query_group_num);
+      } else if (wtype == NE_TYPE_JBLAS) {
+        k_cache = ne_new_tensor_1d(model->ctx, wtype_alloc, layer_ne_k + NE_ALIGNMENT, NE_SIZE_CALC);
+        const auto k_align_off = reinterpret_cast<uintptr_t>(k_cache->data) % NE_ALIGNMENT;
+        k_cache = ne_view_1d(model->ctx, k_cache, layer_ne_k, NE_ALIGNMENT - k_align_off);
+        k_cache->type = wtype;
+        v_cache = ne_new_tensor_1d(model->ctx, wtype_alloc, layer_ne_v + NE_ALIGNMENT, NE_SIZE_CALC);
+        const auto v_align_off = reinterpret_cast<uintptr_t>(v_cache->data) % NE_ALIGNMENT;
+        v_cache = ne_view_1d(model->ctx, v_cache, layer_ne_v, NE_ALIGNMENT - v_align_off);
+        v_cache->type = wtype;
+      } else {
+        NE_ASSERT(("Unexpected ne dtype for kv-cache", false));
+      }
+      ne_set_name(k_cache, "cache_k");
+      ne_set_name(v_cache, "cache_v");
+    }
+  } else {
+    cache.k = ne_new_tensor_1d(cache.ctx, wtype_alloc, n_layer * layer_ne_k + NE_ALIGNMENT, NE_SIZE_CALC);
+    const auto k_align_off = reinterpret_cast<uintptr_t>(cache.k->data) % NE_ALIGNMENT;
+    cache.k = ne_view_1d(cache.ctx, cache.k, n_layer * layer_ne_k, NE_ALIGNMENT - k_align_off);
+    cache.k->type = wtype;
+    cache.v = ne_new_tensor_1d(cache.ctx, wtype_alloc, n_layer * layer_ne_v + NE_ALIGNMENT, NE_SIZE_CALC);
+    const auto v_align_off = reinterpret_cast<uintptr_t>(cache.v->data) % NE_ALIGNMENT;
+    cache.v = ne_view_1d(cache.ctx, cache.v, n_layer * layer_ne_v, NE_ALIGNMENT - v_align_off);
+    cache.v->type = wtype;
+    ne_set_name(cache.k, "cache_k");
+    ne_set_name(cache.v, "cache_v");
+  }
 
   return true;
 }
@@ -141,6 +169,7 @@ static bool model_load(const std::string& fname, model_archs arch, model_context
                        bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                        void* progress_callback_user_data) {
   try {
+    lctx.model.arch = arch;
     model_load_internal(fname, arch, lctx, n_ctx, n_gpu_layers, use_mmap, use_mlock, vocab_only, progress_callback,
                         progress_callback_user_data);
     return true;
@@ -1080,7 +1109,7 @@ struct model_context* model_init_from_file(const char* path_model, struct model_
   ctx->rng = std::mt19937(params.seed);
   ctx->logits_all = params.logits_all;
   ctx->batch_size = params.batch_size;
-  model_archs arch = params.arch;
+  const model_archs arch = params.arch;
 
   // the type so that kv-cache allocated according to this type must be large enough
   if (!model_load(path_model, arch, *ctx, params.n_ctx, params.n_gpu_layers, params.use_mmap, params.use_mlock,
@@ -1116,17 +1145,28 @@ struct model_context* model_init_from_file(const char* path_model, struct model_
                                     : NE_TYPE_COUNT;
     NE_ASSERT(memory_type != NE_TYPE_COUNT);
 
-    if (!kv_cache_init(ctx->model.hparams, ctx->model.kv_self, memory_type, ctx->batch_size, ctx->beam_size)) {
+    if (!kv_cache_init(ctx->model.hparams, ctx->model.kv_self, memory_type, ctx->batch_size, ctx->beam_size,
+                       (arch == MODEL_CHATGLM2 ? &ctx->model : nullptr))) {
       fprintf(stderr, "%s: kv_cache_init() failed for self-attention cache\n", __func__);
       model_free(ctx);
       return nullptr;
     }
 
-    {
+    if (ctx->model.kv_self.k != nullptr) {
       const size_t memory_size = params.kv_type == KV_MEM_TYPE_AUTO
                                      ? ne_nelements(ctx->model.kv_self.k) + ne_nelements(ctx->model.kv_self.v)
                                      : ne_nbytes(ctx->model.kv_self.k) + ne_nbytes(ctx->model.kv_self.v);
       fprintf(stderr, "%s: kv self size  = %7.2f MB\n", __func__, memory_size / 1024.0 / 1024.0);
+    } else if (ctx->model.layers[0].k_cache != nullptr) {
+      const auto k_cache = ctx->model.layers[0].k_cache;
+      const auto v_cache = ctx->model.layers[0].v_cache;
+      const size_t layer_memory_size = params.kv_type == KV_MEM_TYPE_AUTO
+                                           ? ne_nelements(k_cache) + ne_nelements(v_cache)
+                                           : ne_nbytes(k_cache) + ne_nbytes(v_cache);
+      fprintf(stderr, "%s: kv self size  = %7.2f MB\n", __func__,
+              layer_memory_size / 1024.0 / 1024.0 * hparams.n_layer);
+    } else {
+      NE_ASSERT(("KV-cache not allocated!", false));
     }
 
     // resized during inference
@@ -1444,15 +1484,19 @@ struct model_context* model_init_from_gpt_params(const gpt_params& params) {
   model_context* lctx = model_init_from_file(params.model.c_str(), lparams);
 
   const auto& model_hparams = lctx->model.hparams;
+  NE_ASSERT(("Can not set n_head_kv and multi_query_group_num at the same time",
+             model_hparams.n_head_kv == 0 || model_hparams.multi_query_group_num == 0));
   attn_shape_t attn_shape = {
       /* .batch_size = */ lparams.batch_size * lparams.beam_size,
       /* .head_num = */ static_cast<int>(model_hparams.n_head),
-      /* .heads_kv = */ static_cast<int>(model_hparams.n_head_kv),
+      /* .heads_kv = */ static_cast<int>(model_hparams.n_head_kv + model_hparams.multi_query_group_num),
       /* .head_size = */ static_cast<int>(model_hparams.n_embd / model_hparams.n_head),
       /* .sl_q = */ 1,  // Note: make sure that jblas reordered attn supports next token inferencing
       /* .sl_kv = */ static_cast<int>(model_hparams.n_ctx),
   };
-  NE_ASSERT(lctx->model.kv_self.k->type != NE_TYPE_JBLAS || jblas_reordered_attn_fp32_support(&attn_shape));
+  const auto k_cache_example = lctx->model.kv_self.k != nullptr ? lctx->model.kv_self.k           // llama.cpp style
+                                                                : lctx->model.layers[0].k_cache;  // chatglm style
+  NE_ASSERT(k_cache_example->type != NE_TYPE_JBLAS || jblas_reordered_attn_fp32_support(&attn_shape));
 
   if (lctx == NULL) {
     fprintf(stderr, "%s: error: failed to load model '%s'\n", __func__, params.model.c_str());


### PR DESCRIPTION
## Type of Change: feature
API not changed

## Description
Add MHA fusion support for ChatGLM2 and avoiding initialize kv-cache twice (even with MHA fusion disabled)

## Expected Behavior & Potential Risk
N/A

## How has this PR been tested?
<details>
<summary>Test commands:</summary>

```bash
set -ex
#main branch
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_chatglm2 && numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-auto -p "$GIRL_PROMPT"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_chatglm2 && numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-auto -p "$ZH_PROMPT1"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_chatglm2 && numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-auto -p <a href="https://pastebin.com/v5pXFdCg">"$ZH_PROMPT2"<a>
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=ON -DCMAKE_BUILD_TYPE=Release && ninja run_chatglm2 && env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 3 --memory-auto -p <a href="https://pastebin.com/v5pXFdCg">"$ZH_PROMPT2"<a>

#this branch
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_chatglm2 && numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-f16 -p "$GIRL_PROMPT"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_chatglm2 && numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-auto -p "$GIRL_PROMPT"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_chatglm2 && numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-f16 -p "$ZH_PROMPT1"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_chatglm2 && numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-auto -p "$ZH_PROMPT1"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_chatglm2 && numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-f16 -p <a href="https://pastebin.com/v5pXFdCg">"$ZH_PROMPT2"<a>
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_chatglm2 && numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-auto -p <a href="https://pastebin.com/v5pXFdCg">"$ZH_PROMPT2"<a>
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=ON -DCMAKE_BUILD_TYPE=Release && ninja run_chatglm2 && env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 48 -b 2048 -c 2048 -n 3 --memory-auto -p <a href="https://pastebin.com/v5pXFdCg">"$ZH_PROMPT2"<a>
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=ON -DCMAKE_BUILD_TYPE=Release && ninja run_chatglm2 && env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 3 --memory-auto -p <a href="https://pastebin.com/v5pXFdCg">"$ZH_PROMPT2"<a>
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=ON -DCMAKE_BUILD_TYPE=Release && ninja run_chatglm2 && env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 3 --memory-f16 -p <a href="https://pastebin.com/v5pXFdCg">"$ZH_PROMPT2"<a>
```
</details>

In conclusion, the model can generate reasonable text with MHA fusion enabled, and it preserves the identical behavior when disable the fusion (--memory-f16). The fusion brings ~310% (4721.67ms => 1151.27ms) for first token and ~13% (47.06ms => 41.62ms) performance for next token inference.

### Main branch
- <details>
  <summary>
  <code>numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-auto -p "$GIRL_PROMPT"</code>
  </summary>

  ```
  This little girl sounds like a very adventurous and curious young [end of text]
  ```
  </details>
- <details>
  <summary>
  <code>numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-auto -p "$ZH_PROMPT1"</code>
  </summary>

  ```
  这句话不可以划分为任何一种分类。 [end of text]
  ```
  </details>
- <details>
  <summary>
  <code>numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-auto -p <a href="https://pastebin.com/v5pXFdCg">"$ZH_PROMPT2"</a></code>
  </summary>

  ```
  问题：河北燕郊多个小区90天卖不出一套房 置业顾问：房价“跌无可跌”

  分析：文章讲述了燕郊楼市的现状和趋势。虽然目前北京的楼市出现转热苗头，但燕郊的楼市仍然以平稳为主，房屋供应充足，可选房源多。国庆期间看房的人没有明显增加，但优质新房项目的成交比上去了。而近期社交媒体上出现了卖房热潮，有多位业主在出售燕郊的房源。

  答案：B [end of text]
  ```
  </details>
- <details>
  <summary>
  <code>ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 3 --memory-auto -p <a href="https://pastebin.com/v5pXFdCg">"$ZH_PROMPT2"</a></code>
  </summary>

  ```
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =  57.482 ms
  perf_total_per_op_us[                     MUL] =  74.482 ms
  perf_total_per_op_us[                  REPEAT] = 243.032 ms
  perf_total_per_op_us[                    SILU] =  49.191 ms
  perf_total_per_op_us[                RMS_NORM] =  31.687 ms
  perf_total_per_op_us[                 MUL_MAT] = 3214.093 ms
  perf_total_per_op_us[                   SCALE] = 528.567 ms
  perf_total_per_op_us[                     CPY] =  67.748 ms
  perf_total_per_op_us[                    CONT] = 280.731 ms
  perf_total_per_op_us[                 RESHAPE] =   0.478 ms
  perf_total_per_op_us[                    VIEW] =   0.911 ms
  perf_total_per_op_us[                 PERMUTE] =   0.372 ms
  perf_total_per_op_us[                GET_ROWS] =   6.644 ms
  perf_total_per_op_us[           DIAG_MASK_INF] =  24.075 ms
  perf_total_per_op_us[                SOFT_MAX] =  88.010 ms
  perf_total_per_op_us[                    ROPE] =  47.142 ms
  perf_total_per_op_us[           INNER PRODUCT] =   1.035 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.768 ms
  perf_total_per_op_us[                     MUL] =   0.937 ms
  perf_total_per_op_us[                    SILU] =   3.164 ms
  perf_total_per_op_us[                RMS_NORM] =   1.155 ms
  perf_total_per_op_us[                 MUL_MAT] =   6.039 ms
  perf_total_per_op_us[                   SCALE] =   0.717 ms
  perf_total_per_op_us[                     CPY] =   2.528 ms
  perf_total_per_op_us[                    CONT] =   0.803 ms
  perf_total_per_op_us[                 RESHAPE] =   0.272 ms
  perf_total_per_op_us[                    VIEW] =   0.862 ms
  perf_total_per_op_us[                 PERMUTE] =   0.379 ms
  perf_total_per_op_us[                GET_ROWS] =   0.029 ms
  perf_total_per_op_us[                SOFT_MAX] =   1.398 ms
  perf_total_per_op_us[                    ROPE] =   1.399 ms
  perf_total_per_op_us[           INNER PRODUCT] =  24.177 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.679 ms
  perf_total_per_op_us[                     MUL] =   0.941 ms
  perf_total_per_op_us[                    SILU] =   3.047 ms
  perf_total_per_op_us[                RMS_NORM] =   1.097 ms
  perf_total_per_op_us[                 MUL_MAT] =   5.804 ms
  perf_total_per_op_us[                   SCALE] =   0.682 ms
  perf_total_per_op_us[                     CPY] =   2.397 ms
  perf_total_per_op_us[                    CONT] =   0.494 ms
  perf_total_per_op_us[                 RESHAPE] =   0.268 ms
  perf_total_per_op_us[                    VIEW] =   0.831 ms
  perf_total_per_op_us[                 PERMUTE] =   0.373 ms
  perf_total_per_op_us[                GET_ROWS] =   0.029 ms
  perf_total_per_op_us[                SOFT_MAX] =   1.319 ms
  perf_total_per_op_us[                    ROPE] =   1.382 ms
  perf_total_per_op_us[           INNER PRODUCT] =  23.378 ms
  ========================================
  model_print_timings:        load time =  5957.46 ms
  model_print_timings:      sample time =     3.49 ms /     3 runs   (    1.16 ms per token)
  model_print_timings: prompt eval time =  4721.67 ms /  1323 tokens (    3.57 ms per token)
  model_print_timings:        eval time =    96.11 ms /     2 runs   (   48.05 ms per token)
  model_print_timings:       total time =  6108.33 ms
  ========== eval time log of each prediction ==========
  prediction   0, time: 4721.67ms
  prediction   1, time: 49.04ms
  prediction   2, time: 47.06ms
  ```
  </details>

### This branch
- <details>
  <summary>
  <code>numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-f16 -p "$GIRL_PROMPT"</code>
  </summary>

  ```
  This little girl sounds like a very adventurous and curious young [end of text]
  ```
  </details>
- <details>
  <summary>
  <code>numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-auto -p "$GIRL_PROMPT"</code>
  </summary>

  ```
  This little girl sounds like a very adventurous and curious young [end of text]
  ```
  </details>
- <details>
  <summary>
  <code>numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-f16 -p "$ZH_PROMPT1"</code>
  </summary>

  ```
  这句话不可以划分为任何一种分类。 [end of text]
  ```
  </details>
- <details>
  <summary>
  <code>numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-auto -p "$ZH_PROMPT1"</code>
  </summary>

  ```
  这句话不可以划分为任何一种分类。 [end of text]
  ```
  </details>
- <details>
  <summary>
  <code>numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-f16 -p <a href="https://pastebin.com/v5pXFdCg">"$ZH_PROMPT2"</a></code>
  </summary>

  ```
  问题：河北燕郊多个小区90天卖不出一套房 置业顾问：房价“跌无可跌”

  分析：文章讲述了燕郊楼市的现状和趋势。虽然目前北京的楼市出现转热苗头，但燕郊的楼市仍然以平稳为主，房屋供应充足，可选房源多。国庆期间看房的人没有明显增加，但优质新房项目的成交比上去了。而近期社交媒体上出现了卖房热潮，有多位业主在出售燕郊的房源。

  答案：B [end of text]
  ```
  </details>
- <details>
  <summary>
  <code>numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-auto -p <a href="https://pastebin.com/v5pXFdCg">"$ZH_PROMPT2"</a></code>
  </summary>

  ```
  近几个月来,河北燕郊多个小区房价下跌严重,许多房屋已经卖了超过90天,但仍然没有找到买家。置业顾问表示,房价已经“跌无可跌”,现在购房者的需求主要是自住需求。不过,房地产市场前景依然不乐观,去库存迫在眉睫,房价下跌趋势仍将继续。 [end of text]
  ```
  </details>
- <details>
  <summary>
  <code>ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 48 -b 2048 -c 2048 -n 3 --memory-auto -p <a href="https://pastebin.com/v5pXFdCg">"$ZH_PROMPT2"</a></code>
  </summary>

  ```
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =  44.110 ms
  perf_total_per_op_us[                     MUL] =  71.412 ms
  perf_total_per_op_us[                  REPEAT] = 236.015 ms
  perf_total_per_op_us[                    SILU] =  55.165 ms
  perf_total_per_op_us[                RMS_NORM] =  29.132 ms
  perf_total_per_op_us[                 MUL_MAT] = 632.301 ms
  perf_total_per_op_us[                    VIEW] =   1.173 ms
  perf_total_per_op_us[                 PERMUTE] =   0.095 ms
  perf_total_per_op_us[                GET_ROWS] =   6.754 ms
  perf_total_per_op_us[                    ROPE] =  46.325 ms
  perf_total_per_op_us[              FLASH_ATTN] =  82.043 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =  13.944 ms
  perf_total_per_op_us[           INNER PRODUCT] =   1.045 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.717 ms
  perf_total_per_op_us[                     MUL] =   0.956 ms
  perf_total_per_op_us[                    SILU] =   3.043 ms
  perf_total_per_op_us[                RMS_NORM] =   1.211 ms
  perf_total_per_op_us[                    VIEW] =   1.324 ms
  perf_total_per_op_us[                 PERMUTE] =   0.089 ms
  perf_total_per_op_us[                GET_ROWS] =   0.030 ms
  perf_total_per_op_us[                    ROPE] =   1.298 ms
  perf_total_per_op_us[              FLASH_ATTN] =   3.667 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =   2.044 ms
  perf_total_per_op_us[           INNER PRODUCT] =  23.879 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.636 ms
  perf_total_per_op_us[                     MUL] =   0.881 ms
  perf_total_per_op_us[                    SILU] =   2.886 ms
  perf_total_per_op_us[                RMS_NORM] =   1.139 ms
  perf_total_per_op_us[                    VIEW] =   1.523 ms
  perf_total_per_op_us[                 PERMUTE] =   0.088 ms
  perf_total_per_op_us[                GET_ROWS] =   0.017 ms
  perf_total_per_op_us[                    ROPE] =   1.324 ms
  perf_total_per_op_us[              FLASH_ATTN] =   3.421 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =   1.969 ms
  perf_total_per_op_us[           INNER PRODUCT] =  23.324 ms
  ========================================
  
  model_print_timings:        load time =  2456.21 ms
  model_print_timings:      sample time =     3.36 ms /     3 runs   (    1.12 ms per token)
  model_print_timings: prompt eval time =  1223.68 ms /  1323 tokens (    0.92 ms per token)
  model_print_timings:        eval time =    81.88 ms /     2 runs   (   40.94 ms per token)
  model_print_timings:       total time =  2593.04 ms
  ========== eval time log of each prediction ==========
  prediction   0, time: 1223.68ms
  prediction   1, time: 41.54ms
  prediction   2, time: 40.34ms
  ```
  </details>
- <details>
  <summary>
  <code>ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 3 --memory-auto -p <a href="https://pastebin.com/v5pXFdCg">"$ZH_PROMPT2"</a></code>
  </summary>

  ```
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =  45.072 ms
  perf_total_per_op_us[                     MUL] =  69.500 ms
  perf_total_per_op_us[                  REPEAT] = 240.945 ms
  perf_total_per_op_us[                    SILU] =  52.971 ms
  perf_total_per_op_us[                RMS_NORM] =  27.820 ms
  perf_total_per_op_us[                 MUL_MAT] = 562.168 ms
  perf_total_per_op_us[                    VIEW] =   1.297 ms
  perf_total_per_op_us[                 PERMUTE] =   0.094 ms
  perf_total_per_op_us[                GET_ROWS] =   5.984 ms
  perf_total_per_op_us[                    ROPE] =  46.332 ms
  perf_total_per_op_us[              FLASH_ATTN] =  78.879 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =  14.803 ms
  perf_total_per_op_us[           INNER PRODUCT] =   1.036 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.771 ms
  perf_total_per_op_us[                     MUL] =   0.976 ms
  perf_total_per_op_us[                    SILU] =   3.174 ms
  perf_total_per_op_us[                RMS_NORM] =   1.212 ms
  perf_total_per_op_us[                    VIEW] =   1.384 ms
  perf_total_per_op_us[                 PERMUTE] =   0.093 ms
  perf_total_per_op_us[                GET_ROWS] =   0.032 ms
  perf_total_per_op_us[                    ROPE] =   1.463 ms
  perf_total_per_op_us[              FLASH_ATTN] =   3.748 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =   2.281 ms
  perf_total_per_op_us[           INNER PRODUCT] =  23.935 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.765 ms
  perf_total_per_op_us[                     MUL] =   0.931 ms
  perf_total_per_op_us[                    SILU] =   3.073 ms
  perf_total_per_op_us[                RMS_NORM] =   1.127 ms
  perf_total_per_op_us[                    VIEW] =   1.617 ms
  perf_total_per_op_us[                 PERMUTE] =   0.094 ms
  perf_total_per_op_us[                GET_ROWS] =   0.030 ms
  perf_total_per_op_us[                    ROPE] =   1.427 ms
  perf_total_per_op_us[              FLASH_ATTN] =   3.689 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =   2.255 ms
  perf_total_per_op_us[           INNER PRODUCT] =  23.472 ms
  ========================================
  
  model_print_timings:        load time =  2333.29 ms
  model_print_timings:      sample time =     3.37 ms /     3 runs   (    1.12 ms per token)
  model_print_timings: prompt eval time =  1151.27 ms /  1323 tokens (    0.87 ms per token)
  model_print_timings:        eval time =    84.09 ms /     2 runs   (   42.05 ms per token)
  model_print_timings:       total time =  2472.01 ms
  ========== eval time log of each prediction ==========
  prediction   0, time: 1151.27ms
  prediction   1, time: 42.47ms
  prediction   2, time: 41.62ms
  ```
  </details>
- <details>
  <summary>
  <code>ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_chatglm2 -m /home_local/dingyi/data/chatglm2-6b-pr410-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 3 --memory-f16 -p <a href="https://pastebin.com/v5pXFdCg">"$ZH_PROMPT2"</a></code>
  </summary>

  ```
  perf_total_per_op_us[                     ADD] =  47.564 ms
  perf_total_per_op_us[                     MUL] =  79.097 ms
  perf_total_per_op_us[                  REPEAT] = 238.934 ms
  perf_total_per_op_us[                    SILU] =  49.355 ms
  perf_total_per_op_us[                RMS_NORM] =  36.452 ms
  perf_total_per_op_us[                 MUL_MAT] = 3119.894 ms
  perf_total_per_op_us[                   SCALE] = 531.817 ms
  perf_total_per_op_us[                     CPY] =   5.305 ms
  perf_total_per_op_us[                    CONT] = 295.474 ms
  perf_total_per_op_us[                 RESHAPE] =   0.463 ms
  perf_total_per_op_us[                    VIEW] =   0.846 ms
  perf_total_per_op_us[                 PERMUTE] =   0.401 ms
  perf_total_per_op_us[                GET_ROWS] =   4.705 ms
  perf_total_per_op_us[           DIAG_MASK_INF] =  24.125 ms
  perf_total_per_op_us[                SOFT_MAX] =  86.553 ms
  perf_total_per_op_us[                    ROPE] =  45.357 ms
  perf_total_per_op_us[           INNER PRODUCT] =   1.013 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.980 ms
  perf_total_per_op_us[                     MUL] =   1.074 ms
  perf_total_per_op_us[                    SILU] =   2.594 ms
  perf_total_per_op_us[                RMS_NORM] =   1.231 ms
  perf_total_per_op_us[                 MUL_MAT] =   5.109 ms
  perf_total_per_op_us[                   SCALE] =   0.737 ms
  perf_total_per_op_us[                     CPY] =   1.700 ms
  perf_total_per_op_us[                    CONT] =   0.549 ms
  perf_total_per_op_us[                 RESHAPE] =   0.281 ms
  perf_total_per_op_us[                    VIEW] =   0.908 ms
  perf_total_per_op_us[                 PERMUTE] =   0.381 ms
  perf_total_per_op_us[                GET_ROWS] =   0.024 ms
  perf_total_per_op_us[                SOFT_MAX] =   1.056 ms
  perf_total_per_op_us[                    ROPE] =   0.948 ms
  perf_total_per_op_us[           INNER PRODUCT] =  22.273 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.773 ms
  perf_total_per_op_us[                     MUL] =   1.001 ms
  perf_total_per_op_us[                    SILU] =   2.501 ms
  perf_total_per_op_us[                RMS_NORM] =   1.271 ms
  perf_total_per_op_us[                 MUL_MAT] =   5.056 ms
  perf_total_per_op_us[                   SCALE] =   0.759 ms
  perf_total_per_op_us[                     CPY] =   1.674 ms
  perf_total_per_op_us[                    CONT] =   0.342 ms
  perf_total_per_op_us[                 RESHAPE] =   0.282 ms
  perf_total_per_op_us[                    VIEW] =   0.859 ms
  perf_total_per_op_us[                 PERMUTE] =   0.405 ms
  perf_total_per_op_us[                GET_ROWS] =   0.022 ms
  perf_total_per_op_us[                SOFT_MAX] =   1.036 ms
  perf_total_per_op_us[                    ROPE] =   0.905 ms
  perf_total_per_op_us[           INNER PRODUCT] =  22.118 ms
  ========================================
  
  model_print_timings:        load time =  5757.87 ms
  model_print_timings:      sample time =     3.31 ms /     3 runs   (    1.10 ms per token)
  model_print_timings: prompt eval time =  4572.98 ms /  1323 tokens (    3.46 ms per token)
  model_print_timings:        eval time =    88.01 ms /     2 runs   (   44.00 ms per token)
  model_print_timings:       total time =  5900.31 ms
  ========== eval time log of each prediction ==========
  prediction   0, time: 4572.98ms
  prediction   1, time: 44.52ms
  prediction   2, time: 43.49ms
  ```
  </details>

In addition, it is tested that llama & gptj will preserve its behavior in this PR (q4j-int8-g128). 

## Dependency Change?
N/A
