### PR TITLE
[CPP Graph] MPT MHA support

### DIFF
--- a/intel_extension_for_transformers/llm/runtime/graph/core/layers/mha_dense.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/layers/mha_dense.cpp
@@ -2239,7 +2239,6 @@ class TestMhaDese {
     assert(("head_num must be a multiple of heads_kv!", head_num % heads_kv == 0));
 
     printf("\ntest_case: %s\t", __PRETTY_FUNCTION__);
-
     printf("bs_%d hn_%d hs_%d hkv_%d sl_q_%d sk_kv_%d %s %s\n", batch_size, head_num, heads_kv, head_size, sl_q, sl_kv,
            flags & NE_ATTN_FLAG_IS_CAUSAL ? "maksed" : "unmask", flags & NE_ATTN_FLAG_IS_ALIBI8 ? "alibi8" : "");
 

--- a/intel_extension_for_transformers/llm/runtime/graph/core/layers/mha_dense.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/layers/mha_dense.cpp
@@ -699,7 +699,7 @@ class MHAInterface {
     const auto cb = CpuBase();
     omp_set_num_threads(cb.mNumThreads);
     const bool is_causal = (p.attn_flags & NE_ATTN_FLAG_IS_CAUSAL) != 0;
-    const bool is_alibi = (p.attn_flags & NE_ATTN_FLAG_IS_ALIBI) != 0;
+    const bool is_alibi = (p.attn_flags & NE_ATTN_FLAG_IS_ALIBI8) != 0;
     assert(!is_causal || p.sl_q <= p.sl_kv);
     assert(("alibi not supported!", !is_alibi));
     assert(("GQA not supported!", p.head_num == p.heads_kv));
@@ -961,16 +961,29 @@ class ScaleTrackMax<ISA_T, float, float> {
     int causal_offset;  // offset for causal mask; negative value for disabling causal mask
     float alibi_slope;  // m-factor in the alibi paper for current head: https://arxiv.org/abs/2108.12409
   };
+  static constexpr float seq15[16]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
 
   JBLAS_CODE forward(const SType* src, const int src_step, const int M_offset, const int N_offset, const int M,
                      const int N, const Param& p) const {
+    return p.alibi_slope == 0 ? forward_<false>(src, src_step, M_offset, N_offset, M, N, p)
+                              : forward_<true>(src, src_step, M_offset, N_offset, M, N, p);
+  }
+
+  template <bool HAS_ALIBI>
+  JBLAS_CODE forward_(const SType* src, const int src_step, const int M_offset, const int N_offset, const int M,
+                      const int N, const Param& p) const {
     const auto dst = p.dst + M_offset * p.ld_dst + N_offset;
     const auto dst_max = p.dst_max + M_offset;
 #if CompileAVX512F()
 #if MHA_2ND_EXP
     const auto v_scale = _mm512_set1_ps(p.scale);
+    const auto v_seq15 = _mm512_loadu_ps(seq15);
+    const auto alibi_slope = _mm512_set1_ps(p.alibi_slope);
+    const auto alibi_base = _mm512_mul_ps(alibi_slope, _mm512_add_ps(v_seq15, _mm512_set1_ps(N_offset)));
+    const auto alibi_step = _mm512_set1_ps(p.alibi_slope * 16);
 
     for (int i = 0; i < M; ++i) {
+      auto alibi_curr = alibi_base;
       const auto N_unmasked =
           std::min(N, p.causal_offset < 0 ? INT32_MAX : i + M_offset - N_offset + p.causal_offset + 1);
 
@@ -978,14 +991,16 @@ class ScaleTrackMax<ISA_T, float, float> {
       int j = 0;
       auto v_max = _mm512_set1_ps(-INFINITY);
       for (; j < N_unmasked - 15; j += 16) {
-        const auto xs = _mm512_mul_ps(v_scale, _mm512_loadu_ps(src + i * src_step + j));
+        const auto xs = _mm512_fmadd_ps(v_scale, _mm512_loadu_ps(src + i * src_step + j), alibi_curr);
         v_max = _mm512_max_ps(v_max, xs);
         _mm512_storeu_ps(dst + i * p.ld_dst + j, xs);
+        if constexpr (HAS_ALIBI) alibi_curr = _mm512_add_ps(alibi_curr, alibi_step);
       }
       if (j < N_unmasked) {
-        const auto xs = _mm512_mul_ps(v_scale, _mm512_maskz_loadu_ps(v_mask, src + i * src_step + j));
+        const auto xs = _mm512_fmadd_ps(v_scale, _mm512_maskz_loadu_ps(v_mask, src + i * src_step + j), alibi_curr);
         v_max = _mm512_mask_max_ps(v_max, v_mask, v_max, xs);
         _mm512_storeu_ps(dst + i * p.ld_dst + j, xs);
+        if constexpr (HAS_ALIBI) alibi_curr = _mm512_add_ps(alibi_curr, alibi_step);
         j += 16;
       }
       dst_max[i] = std::max(dst_max[i], _mm512_reduce_max_ps(v_max));
@@ -1363,12 +1378,16 @@ class MHAStableInterface {
     const auto num_heads = p.batch_size * p.head_num;  // Total number of heads
     omp_set_num_threads(cb.mNumThreads);
     const bool is_causal = (p.attn_flags & NE_ATTN_FLAG_IS_CAUSAL) != 0;
-    const bool is_alibi = (p.attn_flags & NE_ATTN_FLAG_IS_ALIBI) != 0;
+    const bool is_alibi = (p.attn_flags & NE_ATTN_FLAG_IS_ALIBI8) != 0;
     assert(!is_causal || p.sl_q <= p.sl_kv);
-    assert(("alibi not supported!", !is_alibi));
     assert(("head_num must be a multiple of heads_kv!", p.head_num % p.heads_kv == 0));
     const auto group_heads = p.head_num / p.heads_kv;
     const auto sl_diff = p.sl_kv - p.sl_q;
+
+    // alibi slope
+    const int n_heads_log2_floor = 1 << static_cast<int>(floor(log2(p.head_num)));
+    const float m0 = powf(2.0f, -(8.f) / n_heads_log2_floor);
+    const float m1 = powf(2.0f, -(8.f / 2.0f) / n_heads_log2_floor);
 
     Parallel2DRowMajor parl;  // main parallel scheme
     const auto m_tiles = updiv(p.sl_q, M_TILE);
@@ -1400,6 +1419,10 @@ class MHAStableInterface {
           const int ihn = ibat % p.head_num;
           const int ihkv = ihn / group_heads;
           const int m_size = std::min(M_TILE, p.sl_q - i_m);
+
+          const auto alibi_ihn_m = !is_alibi                    ? 0.f
+                                   : (ihn < n_heads_log2_floor) ? powf(m0, ihn + 1)
+                                                                : powf(m1, 2 * (ihn - n_heads_log2_floor) + 1);
 
           float s_max[M_TILE]{};  // maximum for each row of the S matrix
           std::fill_n(s_max, M_TILE, -INFINITY);
@@ -1453,7 +1476,7 @@ class MHAStableInterface {
                       /* .ld_dst = */ ld_tmp_s,
                       /* .scale = */ p.QK_scale * p.Q_sc * p.K_sc,
                       /* .causal_offset = */ is_causal ? sl_diff : -1,
-                      /* .alibi_slope = */ 0.f,
+                      /* .alibi_slope = */ alibi_ihn_m,
                   },
                   /* .workspace = */ nullptr,
               });
@@ -1693,9 +1716,8 @@ void jblas_fusion_attn_forward<float, bf16, bf16, float>(const attn_fwd_args_t<f
 template <typename Q_T, typename K_T, typename V_T, typename DST_T>
 void jblas_fusion_attn_forward_ref(const attn_fwd_args_t<Q_T, K_T, V_T, DST_T>& p) {
   const bool is_causal = (p.attn_flags & NE_ATTN_FLAG_IS_CAUSAL) != 0;
-  const bool is_alibi = (p.attn_flags & NE_ATTN_FLAG_IS_ALIBI) != 0;
+  const bool is_alibi = (p.attn_flags & NE_ATTN_FLAG_IS_ALIBI8) != 0;
   assert(!is_causal || p.sl_q <= p.sl_kv);
-  assert(("alibi not supported!", !is_alibi));
   assert(("head_num must be a multiple of heads_kv!", p.head_num % p.heads_kv == 0));
   const auto group_heads = p.head_num / p.heads_kv;
   attn_shape_t attn_shape{
@@ -1727,6 +1749,9 @@ void jblas_fusion_attn_forward_ref(const attn_fwd_args_t<Q_T, K_T, V_T, DST_T>& 
   const auto ROWPACK = p.V_layout == ATTN_FWD_LAYOUT_NTILE48_ROWPACK4   ? 4
                        : p.V_layout == ATTN_FWD_LAYOUT_NTILE48_ROWPACK2 ? 2
                                                                         : 0;
+  const int n_heads_log2_floor = 1 << static_cast<int>(floor(log2(p.head_num)));
+  const float m0 = powf(2.0f, -(8.f) / n_heads_log2_floor);
+  const float m1 = powf(2.0f, -(8.f / 2.0f) / n_heads_log2_floor);
 
 #pragma omp parallel for collapse(3)
   for (int ibs = 0; ibs < p.batch_size; ++ibs)
@@ -1742,6 +1767,10 @@ void jblas_fusion_attn_forward_ref(const attn_fwd_args_t<Q_T, K_T, V_T, DST_T>& 
         const auto sl_diff = p.sl_kv - p.sl_q;
         const auto unmasked = is_causal ? sl_diff + i + 1 : p.sl_kv;
         const auto curr_row = std::unique_ptr<float[]>(new float[unmasked]);
+
+        const auto alibi_ihn_m = !is_alibi                    ? 0.f
+                                 : (ihn < n_heads_log2_floor) ? powf(m0, ihn + 1)
+                                                              : powf(m1, 2 * (ihn - n_heads_log2_floor) + 1);
 
         // Q x K
         float row_max = -INFINITY;
@@ -1764,7 +1793,7 @@ void jblas_fusion_attn_forward_ref(const attn_fwd_args_t<Q_T, K_T, V_T, DST_T>& 
                              static_cast<float>(k_curr[j * p.step_k_sl + k * p.step_k_head_size]);
             }
           }
-          curr_row[j] *= p.QK_scale * p.Q_sc * p.K_sc;
+          curr_row[j] = curr_row[j] * p.QK_scale * p.Q_sc * p.K_sc + j * alibi_ihn_m;
           row_max = std::max(row_max, curr_row[j]);
         }
 
@@ -1990,7 +2019,7 @@ void jblas_reordered_attn_fp32_update_v(const jblas_fusion_attn_fp32_update_kv_a
 
 #ifdef NE_TESTS
 namespace {
-bool return_success = true;
+bool ret_ok = true;
 
 class TestMhaDese {
  public:
@@ -1998,51 +2027,53 @@ class TestMhaDese {
     printf("Test suit: %s\n", __FUNCTION__);
     CheckISA(AMX_BF16);
     jblas::utils::request_perm_xtile_data();
-    return_success &= test_case<float, fp16, fp16, float>({1, 1, 1, 32, 128, 64}, false);
-    return_success &= test_case<float, fp16, fp16, float>({2, 5, 5, 32, 64, 128}, false);
-    return_success &= test_case<float, fp16, fp16, float>({2, 5, 5, 80, 128, 77}, false);
-    return_success &= test_case<float, fp16, fp16, float>({1, 1, 1, 256, 63, 63}, false);
-    return_success &= test_case<float, fp16, fp16, float>({3, 4, 4, 256, 1, 384}, false);
-    return_success &= test_case<float, fp16, fp16, float>({1, 1, 1, 64, 64, 64}, true);
+    ret_ok &= test_case<float, fp16, fp16, float>({1, 1, 1, 32, 128, 64}, NE_ATTN_FLAG_NONE);
+    ret_ok &= test_case<float, fp16, fp16, float>({2, 5, 5, 32, 64, 128}, NE_ATTN_FLAG_NONE);
+    ret_ok &= test_case<float, fp16, fp16, float>({2, 5, 5, 80, 128, 77}, NE_ATTN_FLAG_NONE);
+    ret_ok &= test_case<float, fp16, fp16, float>({1, 1, 1, 256, 63, 63}, NE_ATTN_FLAG_NONE);
+    ret_ok &= test_case<float, fp16, fp16, float>({3, 4, 4, 256, 1, 384}, NE_ATTN_FLAG_NONE);
+    ret_ok &= test_case<float, fp16, fp16, float>({1, 1, 1, 64, 64, 64}, NE_ATTN_FLAG_IS_CAUSAL);
 
-    return_success &= test_case<fp16, fp16, fp16, fp16>({1, 1, 1, 32, 128, 64}, false, true);
-    return_success &= test_case<fp16, fp16, fp16, fp16>({2, 5, 5, 32, 64, 128}, false, true);
-    return_success &= test_case<fp16, fp16, fp16, fp16>({2, 5, 5, 80, 128, 77}, false, true);
-    return_success &= test_case<fp16, fp16, fp16, fp16>({1, 1, 1, 256, 63, 63}, false, true);
-    return_success &= test_case<fp16, fp16, fp16, fp16>({3, 4, 4, 256, 1, 384}, false, true);
-    return_success &= test_case<fp16, fp16, fp16, fp16>({1, 1, 1, 64, 64, 64}, true, true);
+    ret_ok &= test_case<fp16, fp16, fp16, fp16>({1, 1, 1, 32, 128, 64}, NE_ATTN_FLAG_NONE, true);
+    ret_ok &= test_case<fp16, fp16, fp16, fp16>({2, 5, 5, 32, 64, 128}, NE_ATTN_FLAG_NONE, true);
+    ret_ok &= test_case<fp16, fp16, fp16, fp16>({2, 5, 5, 80, 128, 77}, NE_ATTN_FLAG_NONE, true);
+    ret_ok &= test_case<fp16, fp16, fp16, fp16>({1, 1, 1, 256, 63, 63}, NE_ATTN_FLAG_NONE, true);
+    ret_ok &= test_case<fp16, fp16, fp16, fp16>({3, 4, 4, 256, 1, 384}, NE_ATTN_FLAG_NONE, true);
+    ret_ok &= test_case<fp16, fp16, fp16, fp16>({1, 1, 1, 64, 64, 64}, NE_ATTN_FLAG_IS_CAUSAL, true);
 
-    return_success &= test_case<float, fp16, fp16, float>({1, 1, 1, 32, 128, 64}, false, true);
-    return_success &= test_case<float, fp16, fp16, float>({2, 5, 5, 32, 64, 128}, false, true);
-    return_success &= test_case<float, fp16, fp16, float>({2, 5, 5, 80, 128, 77}, false, true);
-    return_success &= test_case<float, fp16, fp16, float>({1, 1, 1, 256, 63, 63}, false, true);
-    return_success &= test_case<float, fp16, fp16, float>({3, 4, 4, 256, 1, 384}, false, true);
-    return_success &= test_case<float, fp16, fp16, float>({1, 1, 1, 64, 64, 64}, true, true);
+    ret_ok &= test_case<float, fp16, fp16, float>({1, 1, 1, 32, 128, 64}, NE_ATTN_FLAG_NONE, true);
+    ret_ok &= test_case<float, fp16, fp16, float>({2, 5, 5, 32, 64, 128}, NE_ATTN_FLAG_NONE, true);
+    ret_ok &= test_case<float, fp16, fp16, float>({2, 5, 5, 80, 128, 77}, NE_ATTN_FLAG_NONE, true);
+    ret_ok &= test_case<float, fp16, fp16, float>({1, 1, 1, 256, 63, 63}, NE_ATTN_FLAG_NONE, true);
+    ret_ok &= test_case<float, fp16, fp16, float>({3, 4, 4, 256, 1, 384}, NE_ATTN_FLAG_NONE, true);
+    ret_ok &= test_case<float, fp16, fp16, float>({1, 1, 1, 64, 64, 64}, NE_ATTN_FLAG_IS_CAUSAL, true);
 
     const auto s8layout = ATTN_FWD_LAYOUT_NTILE48_ROWPACK4;
-    return_success &= test_case<int8_t, int8_t, int8_t, int8_t>({1, 1, 1, 32, 128, 64}, false, false, s8layout);
-    return_success &= test_case<int8_t, int8_t, int8_t, int8_t>({2, 5, 5, 32, 64, 128}, false, false, s8layout);
-    return_success &= test_case<int8_t, int8_t, int8_t, int8_t>({2, 5, 5, 80, 128, 77}, false, false, s8layout);
-    return_success &= test_case<int8_t, int8_t, int8_t, int8_t>({1, 1, 1, 256, 63, 63}, false, false, s8layout);
-    return_success &= test_case<int8_t, int8_t, int8_t, int8_t>({3, 4, 4, 256, 1, 384}, false, false, s8layout);
-    return_success &= test_case<int8_t, int8_t, int8_t, int8_t>({1, 1, 1, 64, 64, 64}, true, false, s8layout);
+    ret_ok &= test_case<int8_t, int8_t, int8_t, int8_t>({1, 1, 1, 32, 128, 64}, NE_ATTN_FLAG_NONE, false, s8layout);
+    ret_ok &= test_case<int8_t, int8_t, int8_t, int8_t>({2, 5, 5, 32, 64, 128}, NE_ATTN_FLAG_NONE, false, s8layout);
+    ret_ok &= test_case<int8_t, int8_t, int8_t, int8_t>({2, 5, 5, 80, 128, 77}, NE_ATTN_FLAG_NONE, false, s8layout);
+    ret_ok &= test_case<int8_t, int8_t, int8_t, int8_t>({1, 1, 1, 256, 63, 63}, NE_ATTN_FLAG_NONE, false, s8layout);
+    ret_ok &= test_case<int8_t, int8_t, int8_t, int8_t>({3, 4, 4, 256, 1, 384}, NE_ATTN_FLAG_NONE, false, s8layout);
+    ret_ok &= test_case<int8_t, int8_t, int8_t, int8_t>({1, 1, 1, 64, 64, 64}, NE_ATTN_FLAG_IS_CAUSAL, false, s8layout);
 
     const auto bf16layout = ATTN_FWD_LAYOUT_NTILE48_ROWPACK2;
-    return_success &= test_case<float, bf16, bf16, float>({1, 1, 1, 32, 128, 64}, false, false, bf16layout);
-    return_success &= test_case<float, bf16, bf16, float>({2, 5, 5, 32, 64, 128}, false, false, bf16layout);
-    return_success &= test_case<float, bf16, bf16, float>({2, 5, 5, 80, 128, 77}, false, false, bf16layout);
-    return_success &= test_case<float, bf16, bf16, float>({1, 1, 1, 256, 63, 63}, false, false, bf16layout);
-    return_success &= test_case<float, bf16, bf16, float>({3, 4, 4, 256, 1, 384}, false, false, bf16layout);
-    return_success &= test_case<float, bf16, bf16, float>({1, 1, 1, 64, 64, 64}, true, false, bf16layout);
+    ret_ok &= test_case<float, bf16, bf16, float>({1, 1, 1, 32, 128, 64}, NE_ATTN_FLAG_NONE, false, bf16layout);
+    ret_ok &= test_case<float, bf16, bf16, float>({2, 5, 5, 32, 64, 128}, NE_ATTN_FLAG_NONE, false, bf16layout);
+    ret_ok &= test_case<float, bf16, bf16, float>({2, 5, 5, 80, 128, 77}, NE_ATTN_FLAG_NONE, false, bf16layout);
+    ret_ok &= test_case<float, bf16, bf16, float>({1, 1, 1, 256, 63, 63}, NE_ATTN_FLAG_NONE, false, bf16layout);
+    ret_ok &= test_case<float, bf16, bf16, float>({3, 4, 4, 256, 1, 384}, NE_ATTN_FLAG_NONE, false, bf16layout);
+    ret_ok &= test_case<float, bf16, bf16, float>({1, 1, 1, 64, 64, 64}, NE_ATTN_FLAG_IS_CAUSAL, false, bf16layout);
 
-    return_success &= test_reorder_pipe<float, float, float, float>({1, 1, 1, 32, 128, 64}, 64, false);
-    return_success &= test_reorder_pipe<float, float, float, float>({2, 5, 5, 32, 64, 128}, 256, false);
-    return_success &= test_reorder_pipe<float, float, float, float>({2, 5, 5, 80, 128, 77}, 256, false);
-    return_success &= test_reorder_pipe<float, float, float, float>({2, 5, 1, 80, 128, 77}, 256, false);
-    return_success &= test_reorder_pipe<float, float, float, float>({1, 1, 1, 256, 63, 63}, 256, false);
-    return_success &= test_reorder_pipe<float, float, float, float>({3, 4, 4, 256, 1, 384}, 384, false);
-    return_success &= test_reorder_pipe<float, float, float, float>({3, 4, 2, 256, 1, 384}, 384, false);
-    return_success &= test_reorder_pipe<float, float, float, float>({1, 1, 1, 64, 64, 64}, 128, true);
+    ret_ok &= test_reorder_pipe<float, float, float, float>({1, 1, 1, 32, 128, 64}, 64, NE_ATTN_FLAG_NONE);
+    ret_ok &= test_reorder_pipe<float, float, float, float>({2, 5, 5, 32, 64, 128}, 256, NE_ATTN_FLAG_NONE);
+    ret_ok &= test_reorder_pipe<float, float, float, float>({2, 5, 5, 80, 128, 77}, 256, NE_ATTN_FLAG_NONE);
+    ret_ok &= test_reorder_pipe<float, float, float, float>({2, 5, 1, 80, 128, 77}, 256, NE_ATTN_FLAG_NONE);
+    ret_ok &= test_reorder_pipe<float, float, float, float>({1, 1, 1, 256, 63, 63}, 256, NE_ATTN_FLAG_NONE);
+    ret_ok &= test_reorder_pipe<float, float, float, float>({3, 4, 4, 256, 1, 384}, 384, NE_ATTN_FLAG_NONE);
+    ret_ok &= test_reorder_pipe<float, float, float, float>({3, 4, 2, 256, 1, 384}, 384, NE_ATTN_FLAG_NONE);
+    ret_ok &= test_reorder_pipe<float, float, float, float>({1, 1, 1, 64, 64, 64}, 128, NE_ATTN_FLAG_IS_CAUSAL);
+    ret_ok &= test_reorder_pipe<float, float, float, float>({1, 8, 8, 64, 64, 64}, 128,
+                                                            NE_ATTN_FLAG_IS_CAUSAL | NE_ATTN_FLAG_IS_ALIBI8);
     printf("Test suit done: %s\n", __FUNCTION__);
   }
 
@@ -2062,7 +2093,7 @@ class TestMhaDese {
 #endif
 
   template <class Q_T, class K_T, class V_T, class DST_T>
-  bool test_case(const attn_shape_t& s, bool is_causal, bool k_trans = false,
+  bool test_case(const attn_shape_t& s, ne_attn_flags_t flags, bool k_trans = false,
                  ATTN_FWD_LAYOUT kv_layout = ATTN_FWD_LAYOUT_PLAIN) {
     assert(kv_layout == ATTN_FWD_LAYOUT_PLAIN || !k_trans);
     using namespace jblas::utils;
@@ -2075,8 +2106,8 @@ class TestMhaDese {
     assert(("GQA not supported!", s.head_num == s.heads_kv));
 
     printf("\ntest_case: %s\t", __PRETTY_FUNCTION__);
-    printf("bs_%d hn_%d hs_%d hkv_%d sl_q_%d sk_kv_%d %s\n", batch_size, head_num, heads_kv, head_size, sl_q, sl_kv,
-           is_causal ? "maksed" : "unmask");
+    printf("bs_%d hn_%d hs_%d hkv_%d sl_q_%d sk_kv_%d %s %s\n", batch_size, head_num, heads_kv, head_size, sl_q, sl_kv,
+           flags & NE_ATTN_FLAG_IS_CAUSAL ? "maksed" : "unmask", flags & NE_ATTN_FLAG_IS_ALIBI8 ? "alibi8" : "");
 
     const auto NTILE = kv_layout == ATTN_FWD_LAYOUT_NTILE48_ROWPACK4   ? 48
                        : kv_layout == ATTN_FWD_LAYOUT_NTILE48_ROWPACK2 ? 48
@@ -2150,7 +2181,7 @@ class TestMhaDese {
         /* .dst_sc = */ init_scale_val<V_T>,
         /* .tmp = */ tmp.data(),
         /* .QK_scale = */ 1.f / sqrtf(static_cast<float>(head_size)),
-        /* .is_causal = */ is_causal,
+        /* .attn_flags = */ flags,
         /* .batch_size = */ batch_size,
         /* .head_num = */ head_num,
         /* .heads_kv = */ heads_kv,
@@ -2197,7 +2228,7 @@ class TestMhaDese {
   }
 
   template <class Q_T, class K_T, class V_T, class DST_T>
-  bool test_reorder_pipe(const attn_shape_t& s, int sl_kv_max, bool is_causal) {
+  bool test_reorder_pipe(const attn_shape_t& s, int sl_kv_max, ne_attn_flags_t flags) {
     using namespace jblas::utils;
     const auto batch_size = s.batch_size;
     const auto head_num = s.head_num;
@@ -2208,8 +2239,9 @@ class TestMhaDese {
     assert(("head_num must be a multiple of heads_kv!", head_num % heads_kv == 0));
 
     printf("\ntest_case: %s\t", __PRETTY_FUNCTION__);
-    printf("bs_%d hn_%d hs_%d hkv_%d sl_q_%d sk_kv_%d %s\n", batch_size, head_num, heads_kv, head_size, sl_q, sl_kv,
-           is_causal ? "maksed" : "unmask");
+
+    printf("bs_%d hn_%d hs_%d hkv_%d sl_q_%d sk_kv_%d %s %s\n", batch_size, head_num, heads_kv, head_size, sl_q, sl_kv,
+           flags & NE_ATTN_FLAG_IS_CAUSAL ? "maksed" : "unmask", flags & NE_ATTN_FLAG_IS_ALIBI8 ? "alibi8" : "");
 
     assert(sl_kv_max >= sl_kv);
 
@@ -2273,7 +2305,7 @@ class TestMhaDese {
         /* .dst_sc = */ init_scale_val<V_T>,
         /* .tmp = */ tmp.data(),
         /* .QK_scale = */ 1.f / sqrtf(static_cast<float>(head_size)),
-        /* .is_causal = */ is_causal,
+        /* .attn_flags = */ flags,
         /* .batch_size = */ batch_size,
         /* .head_num = */ head_num,
         /* .heads_kv = */ heads_kv,
@@ -2361,7 +2393,7 @@ class TestMhaDese {
           /* .dst_sc = */ init_scale_val<V_T>,
           /* .tmp = */ tmp.data(),
           /* .QK_scale = */ 1.f / sqrtf(static_cast<float>(head_size)),
-          /* .is_causal = */ is_causal,
+          /* .attn_flags = */ flags,
           /* .batch_size = */ batch_size,
           /* .head_num = */ head_num,
           /* .heads_kv = */ heads_kv,
@@ -2402,7 +2434,7 @@ static const TestMhaDese inst_;
 
 int main() {
   printf("NE_TESTS: mha_dense ");
-  printf(return_success ? "OK\n" : "FAILED\n");
-  return return_success ? 0 : -1;
+  printf(ret_ok ? "OK\n" : "FAILED\n");
+  return ret_ok ? 0 : -1;
 }
 #endif

--- a/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.c
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.c
@@ -7542,6 +7542,7 @@ static void ne_compute_forward_alibi_f16(const struct ne_compute_params* params,
   const float m0 = powf(2.0f, -(max_bias) / n_heads_log2_floor);
   const float m1 = powf(2.0f, -(max_bias / 2.0f) / n_heads_log2_floor);
 
+  NE_ASSERT(("OP_ALIBI may not be able handle multi-batch cases", src0->ne[3] == 1));
   for (int i = 0; i < ne0; i++) {
     for (int j = 0; j < ne1; j++) {
       for (int k = 0; k < ne2_ne3; k++) {

--- a/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.h
@@ -81,8 +81,9 @@ extern "C" {
 
 // Attention flags
 typedef enum NE_ATTN_FLAG {
+  NE_ATTN_FLAG_NONE = 0,
   NE_ATTN_FLAG_IS_CAUSAL = 1 << 1,
-  NE_ATTN_FLAG_IS_ALIBI = 1 << 2,
+  NE_ATTN_FLAG_IS_ALIBI8 = 1 << 2,
 } NE_ATTN_FLAG;
 typedef uint32_t ne_attn_flags_t;
 

--- a/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm2.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm2.cpp
@@ -234,7 +234,7 @@ static bool chatglm_model_eval_internal(model_context& lctx, const model_token* 
                        0);                                                                  // offset
         *reinterpret_cast<ATTN_FWD_LAYOUT*>(&value_layer->nb[0]) = kv_cache_info.v_layout;  // us nb0 for layout
 
-        ne_attn_flags_t attn_flags = 0;
+        ne_attn_flags_t attn_flags = NE_ATTN_FLAG_NONE;
         if (n_past == 0) attn_flags |= NE_ATTN_FLAG_IS_CAUSAL;  // no causal mask on next-token cases
         struct ne_tensor* KQV_Out = ne_flash_attn(ctx0, query_layer, key_layer, value_layer, attn_scale, attn_flags);
         cur = ne_view_2d(ctx0, KQV_Out, n_embd, N, n_embd * ne_element_size(KQV_Out), 0);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/falcon/falcon.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/falcon/falcon.cpp
@@ -256,7 +256,7 @@ static bool falcon_model_eval_internal(model_context& lctx, const model_token* t
         *reinterpret_cast<ATTN_FWD_LAYOUT*>(&V->nb[0]) = kv_cache_info.v_layout;           // us nb0 for layout
         ne_set_name(V, "V");
 
-        ne_attn_flags_t attn_flags = 0;
+        ne_attn_flags_t attn_flags = NE_ATTN_FLAG_NONE;
         if (n_past == 0) attn_flags |= NE_ATTN_FLAG_IS_CAUSAL;  // no causal mask on next-token cases
         struct ne_tensor* KQV_Out = ne_flash_attn(ctx0, Q, K, V, attn_scale, attn_flags);
         cur = ne_view_2d(ctx0, KQV_Out, n_embd, N, n_embd * ne_element_size(KQV_Out), 0);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/gptj/gptj.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/gptj/gptj.cpp
@@ -343,7 +343,7 @@ static bool gptj_model_eval_internal(model_context& lctx, const model_token* tok
     struct ne_tensor* KQV_merged_contiguous;
 
     const float attn_scale = 1.0f / sqrtf(static_cast<float>(n_embd) / n_head);
-    ne_attn_flags_t attn_flags = 0;
+    ne_attn_flags_t attn_flags = NE_ATTN_FLAG_NONE;
     if (n_past == 0) attn_flags |= NE_ATTN_FLAG_IS_CAUSAL;  // no causal mask on next-token cases
     if (run_mha_reordered) {  // reordered kv-cache bf16 mha must be used if run_mha_reordered
       struct ne_tensor* KQV_Out = ne_flash_attn(ctx0, Q, K, V, attn_scale, attn_flags);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/llama/llama.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/llama/llama.cpp
@@ -275,7 +275,7 @@ static bool llama_model_eval_internal(model_context& lctx, const model_token* to
       *reinterpret_cast<ATTN_FWD_LAYOUT*>(&V->nb[0]) = kv_cache_info.v_layout;           // us nb0 for layout
       ne_set_name(V, "V");
 
-      ne_attn_flags_t attn_flags = 0;
+      ne_attn_flags_t attn_flags = NE_ATTN_FLAG_NONE;
       if (n_past == 0) attn_flags |= NE_ATTN_FLAG_IS_CAUSAL;  // no causal mask on next-token cases
       struct ne_tensor* KQV_Out = ne_flash_attn(ctx0, Q, K, V, attn_scale, attn_flags);
       struct ne_tensor* KQV_merged_contiguous =

--- a/intel_extension_for_transformers/llm/runtime/graph/models/mpt/mpt.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/mpt/mpt.cpp
@@ -70,7 +70,7 @@ static bool mpt_model_eval_internal(model_context& lctx, const model_token* toke
   const int n_ctx = hparams.n_ctx;
   const int n_head = hparams.n_head;
   const int n_vocab = hparams.n_vocab;
-  // const int n_rot = hparams.n_embd / hparams.n_head;
+  const int head_dim = hparams.n_embd / hparams.n_head;
 
   auto& mem_per_token = lctx.mem_per_token;
   auto& buf_compute = lctx.buf_compute;
@@ -88,8 +88,28 @@ static bool mpt_model_eval_internal(model_context& lctx, const model_token* toke
   ne_cgraph gf = {};
   gf.n_threads = N >= 32 && ne_cpu_has_blas() ? 1 : n_threads;
 
-  const bool kv_mem_jblas = kv_self.k->type == NE_TYPE_JBLAS;
-  NE_ASSERT(("jblas managed kv-cache is not yet supported; use `--memory-f16 / --memory-f32` instead", !kv_mem_jblas));
+  const bool run_mha_reordered = kv_self.k->type == NE_TYPE_JBLAS;
+  kv_cache_info_t kv_cache_info = {};
+  if (run_mha_reordered) {
+    NE_ASSERT(("kv cache should be the same dtype", kv_self.v->type == NE_TYPE_JBLAS));
+    attn_shape_t attn_shape = {
+        /* .batch_size = */ 1,
+        /* .head_num = */ n_head,
+        /* .heads_kv = */ n_head,
+        /* .head_size = */ head_dim,
+        /* .sl_q = */ N,  // Note: make sure that jblas reordered attn supports next token inference
+        /* .sl_kv = */ n_past + N,
+    };
+
+    NE_ASSERT(("jblas managed kv-cache not supported; use `--memory-f16 / --memory-f32` instead",
+               jblas_reordered_attn_fp32_support(&attn_shape)));
+    kv_shape_t kv_shape{
+        /* .heads_kv = */ static_cast<uint32_t>(n_head),
+        /* .head_size = */ static_cast<uint32_t>(head_dim),
+        /* .sl_kv_max = */ static_cast<uint32_t>(n_ctx),
+    };
+    jblas_reordered_attn_fp32_batch_kv_info(&kv_shape, &kv_cache_info);
+  }
 
   struct ne_tensor* embd = d_ne_new_tensor_1d(ctx0, NE_TYPE_I32, N);
   ne_set_name(embd, "embd");
@@ -109,20 +129,23 @@ static bool mpt_model_eval_internal(model_context& lctx, const model_token* toke
       cur = ne_mul(ctx0, ne_repeat(ctx0, model.layers[il].norm[0], cur), cur);
     }
 
-    {
-      cur = ne_mul_mat(ctx0, model.layers[il].attn[0], cur);
+    cur = ne_mul_mat(ctx0, model.layers[il].attn[0], cur);
 
-      if (model.hparams.clip_qkv > 0.0f) {
-        cur = ne_clamp(ctx0, cur, -model.hparams.clip_qkv, model.hparams.clip_qkv);
-      }
+    if (model.hparams.clip_qkv > 0.0f) {
+      cur = ne_clamp(ctx0, cur, -model.hparams.clip_qkv, model.hparams.clip_qkv);
+    }
 
-      struct ne_tensor* Qcur = ne_view_2d(ctx0, cur, n_embd, N, cur->nb[1], 0 * sizeof(float) * n_embd);
-      struct ne_tensor* Kcur = ne_view_2d(ctx0, cur, n_embd, N, cur->nb[1], 1 * sizeof(float) * n_embd);
+    struct ne_tensor* Qcur = ne_view_2d(ctx0, cur, n_embd, N, cur->nb[1], 0 * sizeof(float) * n_embd);
+    struct ne_tensor* Kcur = ne_view_2d(ctx0, cur, n_embd, N, cur->nb[1], 1 * sizeof(float) * n_embd);
+    struct ne_tensor* Vcur = ne_view_2d(ctx0, cur, n_embd, N, cur->nb[1], 2 * sizeof(float) * n_embd);
 
+    // self-attention
+    const float attn_scale = 1.0f / sqrtf(static_cast<float>(head_dim));
+
+    if (!run_mha_reordered) {
       // store key and value to memory
       {
-        struct ne_tensor* Vcur =
-            ne_transpose(ctx0, ne_view_2d(ctx0, cur, n_embd, N, cur->nb[1], 2 * sizeof(float) * n_embd));
+        Vcur = ne_transpose(ctx0, Vcur);
         struct ne_tensor* k =
             ne_view_1d(ctx0, kv_self.k, N * n_embd, (ne_element_size(kv_self.k) * n_embd) * (il * n_ctx + n_past));
         struct ne_tensor* v =
@@ -151,7 +174,7 @@ static bool mpt_model_eval_internal(model_context& lctx, const model_token* toke
       struct ne_tensor* KQ = ne_mul_mat(ctx0, K, Q);
 
       // KQ_scaled = KQ / sqrt(n_embd/n_head)
-      struct ne_tensor* KQ_scaled = ne_scale(ctx0, KQ, ne_new_f32(ctx0, 1.0f / sqrt(float(n_embd) / n_head)));
+      struct ne_tensor* KQ_scaled = ne_scale(ctx0, KQ, ne_new_f32(ctx0, attn_scale));
 
       struct ne_tensor* KQ_scaled_alibi = ne_alibi(ctx0, KQ_scaled, n_past, n_head, model.hparams.alibi_bias_max);
 
@@ -175,10 +198,52 @@ static bool mpt_model_eval_internal(model_context& lctx, const model_token* toke
 
       // cur = KQV_merged.contiguous().view(n_embd, N)
       cur = ne_cpy(ctx0, KQV_merged, ne_new_tensor_2d(ctx0, NE_TYPE_F32, n_embd, N, NE_SIZE_CALC));
+    } else {
+      const auto seq_kv = n_past + N;
+      const auto k_size = kv_cache_info.k_bytes;
+      const auto v_size = kv_cache_info.v_bytes;
+      // store key and value to memory
+      {
+        const auto k_cache = ne_view_3d(ctx0, kv_self.k,          // tensor
+                                        head_dim, n_ctx, n_head,  // ne
+                                        0, 0,                     // nb (jblas managed)
+                                        il * k_size);             // offset
+        Kcur = ne_view_3d(ctx0, Kcur, head_dim, n_head, N, Kcur->nb[0] * head_dim, Kcur->nb[1], 0);
+        ne_build_forward_expand(&gf, ne_flash_attn_update_k(ctx0, k_cache, Kcur, n_past));
+        const auto v_cache = ne_view_3d(ctx0, kv_self.v,          // tensor
+                                        head_dim, n_ctx, n_head,  // ne
+                                        0, 0,                     // nb (jblas managed)
+                                        il * v_size);             // offset
+        Vcur = ne_view_3d(ctx0, Vcur, head_dim, n_head, N, Vcur->nb[0] * head_dim, Vcur->nb[1], 0);
+        ne_build_forward_expand(&gf, ne_flash_attn_update_v(ctx0, v_cache, Vcur, n_past));
+      }
 
-      // projection
-      { cur = ne_mul_mat(ctx0, model.layers[il].attn[1], cur); }
+      struct ne_tensor* Q = ne_view_3d(ctx0, Qcur, head_dim, n_head, N, Qcur->nb[0] * head_dim, Qcur->nb[1], 0);
+      Q = ne_permute(ctx0, Q, 0, 2, 1, 3);
+      ne_set_name(Q, "Q");
+      struct ne_tensor* K =
+          ne_view_3d(ctx0, kv_self.k,                                             // tensor
+                     head_dim, seq_kv, n_head,                                    // ne
+                     kv_cache_info.stride_k_sl, kv_cache_info.stride_k_head_num,  // nb (jblas managed)
+                     il * k_size);                                                // offset
+      *reinterpret_cast<ATTN_FWD_LAYOUT*>(&K->nb[0]) = kv_cache_info.k_layout;    // us nb0 for layout
+      ne_set_name(K, "K");
+      struct ne_tensor* V =
+          ne_view_3d(ctx0, kv_self.v,                                                    // tensor
+                     seq_kv, head_dim, n_head,                                           // ne
+                     kv_cache_info.stride_v_head_size, kv_cache_info.stride_v_head_num,  // nb (jblas managed)
+                     il * v_size);                                                       // offset
+      *reinterpret_cast<ATTN_FWD_LAYOUT*>(&V->nb[0]) = kv_cache_info.v_layout;           // us nb0 for layout
+      ne_set_name(V, "V");
+
+      ne_attn_flags_t attn_flags = NE_ATTN_FLAG_IS_ALIBI8;    // mpt uses alibi operation
+      if (n_past == 0) attn_flags |= NE_ATTN_FLAG_IS_CAUSAL;  // no causal mask on next-token cases
+      struct ne_tensor* KQV_Out = ne_flash_attn(ctx0, Q, K, V, attn_scale, attn_flags);
+      cur = ne_view_2d(ctx0, KQV_Out, n_embd, N, n_embd * ne_element_size(KQV_Out), 0);
     }
+
+    // projection
+    { cur = ne_mul_mat(ctx0, model.layers[il].attn[1], cur); }
     inpL = ne_add(ctx0, inpL, cur);
 
     lctx.use_buf(ctx0, 1);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/mpt/mpt_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/mpt/mpt_utils.cpp
@@ -48,6 +48,7 @@ void model_load_internal(const std::string& fname, model_archs arch, model_conte
   ms->init(fname.c_str(), lctx, n_ctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
 
+  lctx.support_jblas_kv = true;
   lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 


### PR DESCRIPTION
## Type of Change: feature
API not changed

## Description
Add MHA fusion support for MPT including [ALiBi](https://arxiv.org/abs/2108.12409) support in fused attention operation.

## Expected Behavior & Potential Risk
N/A

## How has this PR been tested?
This PR is tested with CI vi GHA and local tests for accuracy and performance.

As a result, the model can generate reasonable text with MHA fusion enabled, and it preserves the identical behavior when disable the fusion (with `--memory-f16`). The fusion brings ~850% (12656.38ms => 1330.82ms) performance for first token and ~40% (73.29ms => 52.63ms) performance for next token inference.

In addition, it is tested that llama & gptj will preserve its behavior in this PR (q4j-int8-g128). 

<details>
<summary>Accuracy Tests Details:</summary>

Commands:
```bash
set -ex
#main branch
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_mpt && numactl -m 1 -C 56-111 bin/run_mpt -m /home_local/dingyi/data/mpt-7b-pr447-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-auto -p "$GIRL_PROMPT"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_mpt && numactl -m 1 -C 56-111 bin/run_mpt -m /home_local/dingyi/data/mpt-7b-pr447-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-auto -p "$(echo "$LUOYU_PROMPT" | cut -d' ' -f 1-800)"

#graph-mpt-mha-support
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_mpt && numactl -m 1 -C 56-111 bin/run_mpt -m /home_local/dingyi/data/mpt-7b-pr447-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-f16 -p "$GIRL_PROMPT"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_mpt && numactl -m 1 -C 56-111 bin/run_mpt -m /home_local/dingyi/data/mpt-7b-pr447-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-auto -p "$GIRL_PROMPT"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_mpt && numactl -m 1 -C 56-111 bin/run_mpt -m /home_local/dingyi/data/mpt-7b-pr447-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-f16 -p "$(echo "$LUOYU_PROMPT" | cut -d' ' -f 1-800)"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=OFF -DCMAKE_BUILD_TYPE=Release && ninja run_mpt && numactl -m 1 -C 56-111 bin/run_mpt -m /home_local/dingyi/data/mpt-7b-pr447-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-auto -p "$(echo "$LUOYU_PROMPT" | cut -d' ' -f 1-800)"
```

Results:
- <details>
  <summary>
  main branch <code>numactl -m 1 -C 56-111 bin/run_mpt -m /home_local/dingyi/data/mpt-7b-pr447-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-auto -p "$GIRL_PROMPT"</code>
  </summary>

  > Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun. But the only place she could think of that was interesting enough for her adventure-loving heart isâ¦ The beach! [end of text]
  </details>
- <details>
  <summary>
  main branch <code>numactl -m 1 -C 56-111 bin/run_mpt -m /home_local/dingyi/data/mpt-7b-pr447-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-auto -p "$(echo <a href="https://pastebin.com/Qgs4X0VC">"$LUOYU_PROMPT"</a> | cut -d' ' -f 1-800)"</code>
  </summary>

  > ... If no spaghetti ever reaches all plates on the table (and dies) you win! [end of text]
  </details>
- <details>
  <summary>
  graph-mpt-mha-support <code>numactl -m 1 -C 56-111 bin/run_mpt -m /home_local/dingyi/data/mpt-7b-pr447-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-f16 -p "$GIRL_PROMPT"</code>
  </summary>

  > Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun. But the only place she could think of that was interesting enough for her adventure-loving heart isâ¦ The beach! [end of text]
  </details>
- <details>
  <summary>
  graph-mpt-mha-support <code>numactl -m 1 -C 56-111 bin/run_mpt -m /home_local/dingyi/data/mpt-7b-pr447-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-auto -p "$GIRL_PROMPT"</code>
  </summary>

  > Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun. But the only place she could ever see was her own house in Texas! [end of text]
  </details>
- <details>
  <summary>
  graph-mpt-mha-support <code>numactl -m 1 -C 56-111 bin/run_mpt -m /home_local/dingyi/data/mpt-7b-pr447-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-f16 -p "$(echo <a href="https://pastebin.com/Qgs4X0VC">"$LUOYU_PROMPT"</a> | cut -d' ' -f 1-800)"</code>
  </summary>

  > ... If no spaghetti ever reaches all plates on the table (and dies) you win! [end of text]
  </details>
- <details>
  <summary>
  graph-mpt-mha-support <code>numactl -m 1 -C 56-111 bin/run_mpt -m /home_local/dingyi/data/mpt-7b-pr447-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 256 --memory-auto -p "$(echo <a href="https://pastebin.com/Qgs4X0VC">"$LUOYU_PROMPT"</a> | cut -d' ' -f 1-800)"</code>
  </summary>

  > ... So this makes me wonder: what should I call my game? How about 'Pasta Evolution'? The evolution idea and all-powerful aspect fits in quite well there, but that's not much of an RPG... If anything really stands out is how every player has their own plate to control (and a team/side). So now you can see why this concept wasn't as good. It seems way too basic for my liking; I wanted the game itself was more interesting than just having fun killing pasta on plates and shooting sauce, but of course it's not so simple in real life is that? Anyway! [end of text]
  </details>
</details>


<details>
<summary>Performance Tests Details:</summary>

Commands:
```bash
set -ex
#main branch
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=ON -DCMAKE_BUILD_TYPE=Release && ninja run_mpt && env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_mpt -m /home_local/dingyi/data/mpt-7b-pr447-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 3 --memory-auto -p "$(echo "$LUOYU_PROMPT" | cut -d' ' -f 1-800)"

#graph-mpt-mha-support
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=ON -DCMAKE_BUILD_TYPE=Release && ninja run_mpt && env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_mpt -m /home_local/dingyi/data/mpt-7b-pr447-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 48 -b 2048 -c 2048 -n 3 --memory-auto -p "$(echo "$LUOYU_PROMPT" | cut -d' ' -f 1-800)"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=ON -DCMAKE_BUILD_TYPE=Release && ninja run_mpt && env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_mpt -m /home_local/dingyi/data/mpt-7b-pr447-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 3 --memory-auto -p "$(echo "$LUOYU_PROMPT" | cut -d' ' -f 1-800)"
rm -rf bin && cmake .. -GNinja -DNE_BUILD_TESTS=ON -DNE_PROFILING=ON -DCMAKE_BUILD_TYPE=Release && ninja run_mpt && env ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_mpt -m /home_local/dingyi/data/mpt-7b-pr447-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 3 --memory-f16 -p "$(echo "$LUOYU_PROMPT" | cut -d' ' -f 1-800)"
```

Results:
- <details>
  <summary>
  main branch <code>ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_mpt -m /home_local/dingyi/data/mpt-7b-pr447-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 3 --memory-auto -p "$(echo <a href="https://pastebin.com/Qgs4X0VC">"$LUOYU_PROMPT"</a> | cut -d' ' -f 1-800)"</code>
  </summary>

  ```
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =  23.541 ms
  perf_total_per_op_us[                     MUL] =  25.601 ms
  perf_total_per_op_us[                  REPEAT] = 136.490 ms
  perf_total_per_op_us[                    GELU] = 188.008 ms
  perf_total_per_op_us[                    NORM] =  27.599 ms
  perf_total_per_op_us[                 MUL_MAT] = 2595.437 ms
  perf_total_per_op_us[                   SCALE] = 1141.293 ms
  perf_total_per_op_us[                     CPY] = 138.489 ms
  perf_total_per_op_us[                 RESHAPE] =   0.107 ms
  perf_total_per_op_us[                    VIEW] =   0.812 ms
  perf_total_per_op_us[                 PERMUTE] =   0.330 ms
  perf_total_per_op_us[               TRANSPOSE] =   0.110 ms
  perf_total_per_op_us[                GET_ROWS] =   5.255 ms
  perf_total_per_op_us[           DIAG_MASK_INF] = 368.837 ms
  perf_total_per_op_us[                SOFT_MAX] =  72.537 ms
  perf_total_per_op_us[                   ALIBI] = 7926.504 ms
  perf_total_per_op_us[           INNER PRODUCT] =   0.000 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.357 ms
  perf_total_per_op_us[                     MUL] =   0.384 ms
  perf_total_per_op_us[                    GELU] =  10.747 ms
  perf_total_per_op_us[                    NORM] =   3.074 ms
  perf_total_per_op_us[                 MUL_MAT] =   9.257 ms
  perf_total_per_op_us[                   SCALE] =   1.172 ms
  perf_total_per_op_us[                     CPY] =   5.760 ms
  perf_total_per_op_us[                 RESHAPE] =   0.105 ms
  perf_total_per_op_us[                    VIEW] =   0.739 ms
  perf_total_per_op_us[                 PERMUTE] =   0.318 ms
  perf_total_per_op_us[               TRANSPOSE] =   0.104 ms
  perf_total_per_op_us[                GET_ROWS] =   0.028 ms
  perf_total_per_op_us[           DIAG_MASK_INF] =   0.731 ms
  perf_total_per_op_us[                SOFT_MAX] =   1.544 ms
  perf_total_per_op_us[                   ALIBI] =   7.019 ms
  perf_total_per_op_us[           INNER PRODUCT] =  28.004 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.318 ms
  perf_total_per_op_us[                     MUL] =   0.399 ms
  perf_total_per_op_us[                    GELU] =  10.749 ms
  perf_total_per_op_us[                    NORM] =   3.140 ms
  perf_total_per_op_us[                 MUL_MAT] =   9.072 ms
  perf_total_per_op_us[                   SCALE] =   1.109 ms
  perf_total_per_op_us[                     CPY] =   5.829 ms
  perf_total_per_op_us[                 RESHAPE] =   0.104 ms
  perf_total_per_op_us[                    VIEW] =   0.816 ms
  perf_total_per_op_us[                 PERMUTE] =   0.322 ms
  perf_total_per_op_us[               TRANSPOSE] =   0.105 ms
  perf_total_per_op_us[                GET_ROWS] =   0.029 ms
  perf_total_per_op_us[           DIAG_MASK_INF] =   0.716 ms
  perf_total_per_op_us[                SOFT_MAX] =   1.591 ms
  perf_total_per_op_us[                   ALIBI] =   7.062 ms
  perf_total_per_op_us[           INNER PRODUCT] =  27.667 ms
  ========================================

  model_print_timings:        load time = 13995.45 ms
  model_print_timings:      sample time =     2.73 ms /     3 runs   (    0.91 ms per token)
  model_print_timings: prompt eval time = 12656.38 ms /   988 tokens (   12.81 ms per token)
  model_print_timings:        eval time =   146.90 ms /     2 runs   (   73.45 ms per token)
  model_print_timings:       total time = 14196.92 ms
  ========== eval time log of each prediction ==========
  prediction   0, time: 12656.38ms
  prediction   1, time: 73.60ms
  prediction   2, time: 73.29ms
  ```
  </details>
- <details>
  <summary>
  graph-mpt-mha-support <code>ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_mpt -m /home_local/dingyi/data/mpt-7b-pr447-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 48 -b 2048 -c 2048 -n 3 --memory-auto -p "$(echo <a href="https://pastebin.com/Qgs4X0VC">"$LUOYU_PROMPT"</a> | cut -d' ' -f 1-800)"</code>
  </summary>

  ```
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =  23.430 ms
  perf_total_per_op_us[                     MUL] =  25.247 ms
  perf_total_per_op_us[                  REPEAT] = 130.404 ms
  perf_total_per_op_us[                    GELU] = 208.690 ms
  perf_total_per_op_us[                    NORM] =  27.116 ms
  perf_total_per_op_us[                 MUL_MAT] = 901.936 ms
  perf_total_per_op_us[                    VIEW] =   1.185 ms
  perf_total_per_op_us[                 PERMUTE] =   0.100 ms
  perf_total_per_op_us[                GET_ROWS] =   5.114 ms
  perf_total_per_op_us[              FLASH_ATTN] = 105.717 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =  61.095 ms
  perf_total_per_op_us[           INNER PRODUCT] =   0.000 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.403 ms
  perf_total_per_op_us[                     MUL] =   0.414 ms
  perf_total_per_op_us[                    GELU] =  10.541 ms
  perf_total_per_op_us[                    NORM] =   2.934 ms
  perf_total_per_op_us[                    VIEW] =   1.204 ms
  perf_total_per_op_us[                 PERMUTE] =   0.101 ms
  perf_total_per_op_us[                GET_ROWS] =   0.028 ms
  perf_total_per_op_us[              FLASH_ATTN] =   4.067 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =   2.320 ms
  perf_total_per_op_us[           INNER PRODUCT] =  26.553 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.317 ms
  perf_total_per_op_us[                     MUL] =   0.401 ms
  perf_total_per_op_us[                    GELU] =  10.622 ms
  perf_total_per_op_us[                    NORM] =   2.841 ms
  perf_total_per_op_us[                    VIEW] =   1.298 ms
  perf_total_per_op_us[                 PERMUTE] =   0.148 ms
  perf_total_per_op_us[                GET_ROWS] =   0.014 ms
  perf_total_per_op_us[              FLASH_ATTN] =   4.145 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =   2.270 ms
  perf_total_per_op_us[           INNER PRODUCT] =  26.537 ms
  ========================================

  model_print_timings:        load time =  2834.27 ms
  model_print_timings:      sample time =     2.64 ms /     3 runs   (    0.88 ms per token)
  model_print_timings: prompt eval time =  1494.47 ms /   988 tokens (    1.51 ms per token)
  model_print_timings:        eval time =   103.54 ms /     2 runs   (   51.77 ms per token)
  model_print_timings:       total time =  2992.35 ms
  ========== eval time log of each prediction ==========
  prediction   0, time: 1494.47ms
  prediction   1, time: 51.76ms
  prediction   2, time: 51.79ms
  ```
  </details>
- <details>
  <summary>
  graph-mpt-mha-support <code>ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_mpt -m /home_local/dingyi/data/mpt-7b-pr447-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 3 --memory-auto -p "$(echo <a href="https://pastebin.com/Qgs4X0VC">"$LUOYU_PROMPT"</a> | cut -d' ' -f 1-800)"</code>
  </summary>

  ```
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =  23.198 ms
  perf_total_per_op_us[                     MUL] =  22.576 ms
  perf_total_per_op_us[                  REPEAT] = 137.497 ms
  perf_total_per_op_us[                    GELU] = 188.130 ms
  perf_total_per_op_us[                    NORM] =  27.938 ms
  perf_total_per_op_us[                 MUL_MAT] = 761.702 ms
  perf_total_per_op_us[                    VIEW] =   1.222 ms
  perf_total_per_op_us[                 PERMUTE] =   0.103 ms
  perf_total_per_op_us[                GET_ROWS] =   5.423 ms
  perf_total_per_op_us[              FLASH_ATTN] =  99.823 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =  58.736 ms
  perf_total_per_op_us[           INNER PRODUCT] =   0.000 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.335 ms
  perf_total_per_op_us[                     MUL] =   0.418 ms
  perf_total_per_op_us[                    GELU] =  10.718 ms
  perf_total_per_op_us[                    NORM] =   2.877 ms
  perf_total_per_op_us[                    VIEW] =   1.148 ms
  perf_total_per_op_us[                 PERMUTE] =   0.106 ms
  perf_total_per_op_us[                GET_ROWS] =   0.015 ms
  perf_total_per_op_us[              FLASH_ATTN] =   4.181 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =   2.287 ms
  perf_total_per_op_us[           INNER PRODUCT] =  26.710 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.354 ms
  perf_total_per_op_us[                     MUL] =   0.398 ms
  perf_total_per_op_us[                    GELU] =  10.848 ms
  perf_total_per_op_us[                    NORM] =   3.154 ms
  perf_total_per_op_us[                    VIEW] =   1.232 ms
  perf_total_per_op_us[                 PERMUTE] =   0.106 ms
  perf_total_per_op_us[                GET_ROWS] =   0.027 ms
  perf_total_per_op_us[              FLASH_ATTN] =   4.034 ms
  perf_total_per_op_us[    FLASH_ATTN_KV_UPDATE] =   2.443 ms
  perf_total_per_op_us[           INNER PRODUCT] =  26.731 ms
  ========================================

  model_print_timings:        load time =  2700.29 ms
  model_print_timings:      sample time =     2.79 ms /     3 runs   (    0.93 ms per token)
  model_print_timings: prompt eval time =  1330.82 ms /   988 tokens (    1.35 ms per token)
  model_print_timings:        eval time =   104.65 ms /     2 runs   (   52.33 ms per token)
  model_print_timings:       total time =  2859.34 ms
  ========== eval time log of each prediction ==========
  prediction   0, time: 1330.82ms
  prediction   1, time: 52.03ms
  prediction   2, time: 52.63ms
  ```
  </details>
- <details>
  <summary>
  graph-mpt-mha-support <code>ENGINE_PROFILING=1 numactl -m 1 -C 56-111 bin/run_mpt -m /home_local/dingyi/data/mpt-7b-pr447-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 2048 -c 2048 -n 3 --memory-f16 -p "$(echo <a href="https://pastebin.com/Qgs4X0VC">"$LUOYU_PROMPT"</a> | cut -d' ' -f 1-800)"</code>
  </summary>

  ```
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =  22.522 ms
  perf_total_per_op_us[                     MUL] =  23.008 ms
  perf_total_per_op_us[                  REPEAT] = 128.805 ms
  perf_total_per_op_us[                    GELU] = 188.478 ms
  perf_total_per_op_us[                    NORM] =  25.166 ms
  perf_total_per_op_us[                 MUL_MAT] = 2411.392 ms
  perf_total_per_op_us[                   SCALE] = 1052.907 ms
  perf_total_per_op_us[                     CPY] = 140.443 ms
  perf_total_per_op_us[                 RESHAPE] =   0.107 ms
  perf_total_per_op_us[                    VIEW] =   0.765 ms
  perf_total_per_op_us[                 PERMUTE] =   0.321 ms
  perf_total_per_op_us[               TRANSPOSE] =   0.132 ms
  perf_total_per_op_us[                GET_ROWS] =   4.424 ms
  perf_total_per_op_us[           DIAG_MASK_INF] = 363.926 ms
  perf_total_per_op_us[                SOFT_MAX] =  73.186 ms
  perf_total_per_op_us[                   ALIBI] = 7920.785 ms
  perf_total_per_op_us[           INNER PRODUCT] =   0.000 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.357 ms
  perf_total_per_op_us[                     MUL] =   0.369 ms
  perf_total_per_op_us[                    GELU] =  10.764 ms
  perf_total_per_op_us[                    NORM] =   2.420 ms
  perf_total_per_op_us[                 MUL_MAT] =   8.110 ms
  perf_total_per_op_us[                   SCALE] =   1.234 ms
  perf_total_per_op_us[                     CPY] =   4.041 ms
  perf_total_per_op_us[                 RESHAPE] =   0.114 ms
  perf_total_per_op_us[                    VIEW] =   0.757 ms
  perf_total_per_op_us[                 PERMUTE] =   0.333 ms
  perf_total_per_op_us[               TRANSPOSE] =   0.111 ms
  perf_total_per_op_us[                GET_ROWS] =   0.021 ms
  perf_total_per_op_us[           DIAG_MASK_INF] =   0.686 ms
  perf_total_per_op_us[                SOFT_MAX] =   1.152 ms
  perf_total_per_op_us[                   ALIBI] =   7.307 ms
  perf_total_per_op_us[           INNER PRODUCT] =  25.309 ms
  ========================================
  === GRAPH Profiling ===
  perf_total_per_op_us[                     ADD] =   0.344 ms
  perf_total_per_op_us[                     MUL] =   0.363 ms
  perf_total_per_op_us[                    GELU] =  10.200 ms
  perf_total_per_op_us[                    NORM] =   2.411 ms
  perf_total_per_op_us[                 MUL_MAT] =   8.056 ms
  perf_total_per_op_us[                   SCALE] =   1.046 ms
  perf_total_per_op_us[                     CPY] =   4.097 ms
  perf_total_per_op_us[                 RESHAPE] =   0.103 ms
  perf_total_per_op_us[                    VIEW] =   0.754 ms
  perf_total_per_op_us[                 PERMUTE] =   0.309 ms
  perf_total_per_op_us[               TRANSPOSE] =   0.105 ms
  perf_total_per_op_us[                GET_ROWS] =   0.021 ms
  perf_total_per_op_us[           DIAG_MASK_INF] =   0.705 ms
  perf_total_per_op_us[                SOFT_MAX] =   1.152 ms
  perf_total_per_op_us[                   ALIBI] =   7.020 ms
  perf_total_per_op_us[           INNER PRODUCT] =  25.661 ms
  ========================================

  model_print_timings:        load time = 13633.52 ms
  model_print_timings:      sample time =     2.68 ms /     3 runs   (    0.89 ms per token)
  model_print_timings: prompt eval time = 12361.66 ms /   988 tokens (   12.51 ms per token)
  model_print_timings:        eval time =   133.83 ms /     2 runs   (   66.92 ms per token)
  model_print_timings:       total time = 13821.57 ms
  ========== eval time log of each prediction ==========
  prediction   0, time: 12361.66ms
  prediction   1, time: 67.24ms
  prediction   2, time: 66.59ms
  ```
  </details>
</details>

## Dependency Change?
N/A
