### PR TITLE
GitHub Action Workflows speedup

### DIFF
--- a/.github/workflows/cpp-graph-test.yml
+++ b/.github/workflows/cpp-graph-test.yml
@@ -124,6 +124,7 @@ jobs:
           echo "------ Generating final report.html ------"
           cd ${{ env.OUT_SCRIPT_PATH }}
           /usr/bin/bash generate_report.sh --workflow=deploy
+          sed -n '/<body>/,/<\/body>/p' generated/report.html | sed -r '/^$/d' | sed -r 's/^ +//g' >> $GITHUB_STEP_SUMMARY
         env:
           RUN_DISPLAY_URL: https://github.com/VincyZhang/intel-extension-for-transformers/actions/runs/${{ github.run_id }}
           BUILD_NUMBER: ${{ github.run_id }}

--- a/.github/workflows/cpp-graph-test.yml
+++ b/.github/workflows/cpp-graph-test.yml
@@ -9,6 +9,22 @@ on:
        - 'intel_extension_for_transformers/llm/runtime/graph/**'
        - '!intel_extension_for_transformers/llm/runtime/graph/README.md'
   workflow_dispatch:
+    inputs:
+      compiler_version:
+        description: 'compiler_version'
+        required: false
+        type: string
+        default: '13.1.0'
+      models:
+        description: 'models (in json)'
+        required: false
+        type: string
+        default: '["llama-7b-hf", "gptj-6b"]'
+      runner:
+        description: 'runner'
+        required: false
+        type: string
+        default: 'spr'
 
 # If there is a new commit, the previous jobs will be canceled
 concurrency:
@@ -20,22 +36,14 @@ env:
   SCRIPT_PATH: ${{ github.workspace }}/.github/workflows/script
   WORKING_DIR: ${{ github.workspace }}
   CONTAINER_NAME: "codeScan"
-
+  INPUT_COMPILER_VERSION: ${{ inputs.compiler_version || '13.1.0' }}
 
 jobs:
   CPP-Graph-Workflow:
-    runs-on: spr
+    runs-on: ${{inputs.runner || 'spr'}}
     strategy:
       matrix:
-        include:
-          - modelName: "llama-7b-hf"
-            framework: "engine"
-            mode: "latency"
-            precision: "bf16,int8"
-          - modelName: "gptj-6b"
-            framework: "engine"
-            mode: "latency"
-            precision: "bf16,int8"
+        modelName: ${{fromJson(inputs.models || '["llama-7b-hf", "gptj-6b"]')}}
     steps:
       - name: Checkout out Repo
         uses: actions/checkout@v3
@@ -48,9 +56,11 @@ jobs:
           bash ${{ github.workspace }}/.github/workflows/script/prepare_env_with_conda.sh "cpp-graph-test" "3.8"
 
       - name: Binary build
+        # cpp model does not requires itrex package
+        if: 0 == 1
         run: |
           cd ${{ github.workspace }}
-          conda activate cpp-graph-test || source activate cpp-graph-test 
+          conda activate cpp-graph-test || source activate cpp-graph-test
           pip install build --upgrade
           pip install -r requirements.txt
           python setup.py sdist bdist_wheel
@@ -60,8 +70,8 @@ jobs:
       - name: BF16 Benchmark
         run: |
           cd ${{ github.workspace }}/.github/workflows/script/models
-          bash cpp_graph_inference.sh cpp-graph-test ${{ matrix.modelName }} 13.1.0
-  
+          bash cpp_graph_inference.sh cpp-graph-test ${{ matrix.modelName }} ${{ env.INPUT_COMPILER_VERSION }}
+
       - name: Publish pipeline artifact
         uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
@@ -134,4 +144,3 @@ jobs:
             echo "[Performance Regression] Some model performance regression occurred, please check artifacts and reports."
             exit 1
           fi
-  

--- a/.github/workflows/cpp-graph-test.yml
+++ b/.github/workflows/cpp-graph-test.yml
@@ -71,13 +71,18 @@ jobs:
         run: |
           cd ${{ github.workspace }}/.github/workflows/script/models
           bash cpp_graph_inference.sh cpp-graph-test ${{ matrix.modelName }} ${{ env.INPUT_COMPILER_VERSION }}
+      
+      - name: Rename summary
+        run: |
+          cd ${{ github.workspace }}
+          cp cpp_graph_summary.log cpp_graph_summary_${{matrix.modelName}}.log
 
       - name: Publish pipeline artifact
         uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
         with:
           name: cpp_graph
-          path: ${{ github.workspace }}/cpp_graph_summary.log
+          path: ${{ github.workspace }}/cpp_graph_summary_${{matrix.modelName}}.log
           if-no-files-found: ignore # 'warn' or 'ignore' are also available, defaults to `warn`
           retention-days: 60 # 1 <= retention-days <= 90
 
@@ -100,6 +105,11 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: ${{ env.OUT_SCRIPT_PATH }}/generated/log
+      
+      - name: Merge CPP Graph Summary Log
+        run: |
+          cd ${{ env.OUT_SCRIPT_PATH }}/generated/log/cpp_graph
+          for summary in $(find . -name "cpp_graph_summary_*.log"); do cat $summary >> cpp_graph_summary.log; done
 
       - name: Download Reference Artifact
         id: download-artifact

--- a/.github/workflows/script/models/cpp_graph_inference.sh
+++ b/.github/workflows/script/models/cpp_graph_inference.sh
@@ -44,7 +44,7 @@ function main() {
         infer_cmd="./build/bin/run_gptj"
         model_name="EleutherAI/gpt-j-6b"
         input_model="/tf_dataset2/models/pytorch/gpt-j-6B"
-        precision_list=("q4_j_b128", "q4_j_b128_asym")
+        precision_list=("q4_j_b128" "q4_j_b128_asym")
     elif [[ "${model}" == "starcoder-3b" ]]; then
         convert_script="${working_dir}/scripts/convert_starcoder.py"
         quant_script="./build/bin/quant_starcoder"

--- a/.github/workflows/script/models/cpp_graph_inference.sh
+++ b/.github/workflows/script/models/cpp_graph_inference.sh
@@ -109,27 +109,27 @@ function main() {
                     ## prepare model.bin
                     quantized_model="${model}-${precision}.bin"
                     if [[ ! -e ${quantized_model} ]]; then
-                      if [[ ${precision} == "q4_j_vnni_b128" ]]; then
-                          ${quant_script} --model_file ${working_dir}/${model}-fp32.bin --out_file ${working_dir}/${model}-${precision}.bin --weight_dtype int4 --group_size 128 --scale_dtype fp32 --compute_dtype int8 --alg sym
-                      elif [[ ${precision} == "q4_j_vnni_bf16_b32" ]]; then
-                          ${quant_script} --model_file ${working_dir}/${model}-fp32.bin --out_file ${working_dir}/${model}-${precision}.bin --weight_dtype int4 --group_size 32 --scale_dtype bf16 --compute_dtype int8 --alg sym
-                      elif [[ ${precision} == "q4_j_vnni_b32" ]]; then
-                          ${quant_script} --model_file ${working_dir}/${model}-fp32.bin --out_file ${working_dir}/${model}-${precision}.bin --weight_dtype int4 --group_size 32 --scale_dtype fp32 --compute_dtype int8 --alg sym
-                      elif [[ ${precision} == "q4_j_b32" ]]; then
-                          ${quant_script} --model_file ${working_dir}/${model}-fp32.bin --out_file ${working_dir}/${model}-${precision}.bin --weight_dtype int4 --group_size 32 --scale_dtype fp32 --compute_dtype fp32 --alg sym
-                      elif [[ ${precision} == "q4_j_b128" ]]; then
-                          ${quant_script} --model_file ${working_dir}/${model}-fp32.bin --out_file ${working_dir}/${model}-${precision}.bin --weight_dtype int4 --group_size 128 --scale_dtype fp32 --compute_dtype fp32 --alg sym
-                      elif [[ ${precision} == "q4_j_b128_asym" ]]; then
-                          ${quant_script} --model_file ${working_dir}/${model}-fp32.bin --out_file ${working_dir}/${model}-${precision}.bin --weight_dtype int4 --group_size 128 --scale_dtype fp32 --compute_dtype fp32 --alg asym
-                      elif [[ ${precision} == "q4_0" ]]; then
-                          ${quant_script} --model_file ${working_dir}/${model}-fp32.bin --out_file ${working_dir}/${model}-${precision}.bin --weight_dtype int4 --group_size 32 --compute_dtype int8 --alg sym --use_ggml
-                      elif [[ ${precision} == "q4_1" ]]; then
-                          ${quant_script} --model_file ${working_dir}/${model}-fp32.bin --out_file ${working_dir}/${model}-${precision}.bin --weight_dtype int4 --group_size 32 --compute_dtype int8 --alg asym --use_ggml
-                      elif [[ ${precision} == "q8_0" ]]; then
-                          ${quant_script} --model_file ${working_dir}/${model}-fp32.bin --out_file ${working_dir}/${model}-${precision}.bin --weight_dtype int8 --group_size 32 --compute_dtype int8 --alg sym --use_ggml
-                      else
-                          ${quant_script} --model_file ${working_dir}/${model}-fp32.bin --out_file ${working_dir}/${model}-${precision}.bin --weight_dtype int4
-                      fi
+                        if [[ ${precision} == "q4_j_vnni_b128" ]]; then
+                            ${quant_script} --model_file ${working_dir}/${model}-fp32.bin --out_file ${working_dir}/${model}-${precision}.bin --nthread $cores_per_instance --weight_dtype int4 --group_size 128 --scale_dtype fp32 --compute_dtype int8 --alg sym
+                        elif [[ ${precision} == "q4_j_vnni_bf16_b32" ]]; then
+                            ${quant_script} --model_file ${working_dir}/${model}-fp32.bin --out_file ${working_dir}/${model}-${precision}.bin --nthread $cores_per_instance --weight_dtype int4 --group_size 32 --scale_dtype bf16 --compute_dtype int8 --alg sym
+                        elif [[ ${precision} == "q4_j_vnni_b32" ]]; then
+                            ${quant_script} --model_file ${working_dir}/${model}-fp32.bin --out_file ${working_dir}/${model}-${precision}.bin --nthread $cores_per_instance --weight_dtype int4 --group_size 32 --scale_dtype fp32 --compute_dtype int8 --alg sym
+                        elif [[ ${precision} == "q4_j_b32" ]]; then
+                            ${quant_script} --model_file ${working_dir}/${model}-fp32.bin --out_file ${working_dir}/${model}-${precision}.bin --nthread $cores_per_instance --weight_dtype int4 --group_size 32 --scale_dtype fp32 --compute_dtype fp32 --alg sym
+                        elif [[ ${precision} == "q4_j_b128" ]]; then
+                            ${quant_script} --model_file ${working_dir}/${model}-fp32.bin --out_file ${working_dir}/${model}-${precision}.bin --nthread $cores_per_instance --weight_dtype int4 --group_size 128 --scale_dtype fp32 --compute_dtype fp32 --alg sym
+                        elif [[ ${precision} == "q4_j_b128_asym" ]]; then
+                            ${quant_script} --model_file ${working_dir}/${model}-fp32.bin --out_file ${working_dir}/${model}-${precision}.bin --nthread $cores_per_instance --weight_dtype int4 --group_size 128 --scale_dtype fp32 --compute_dtype fp32 --alg asym
+                        elif [[ ${precision} == "q4_0" ]]; then
+                            ${quant_script} --model_file ${working_dir}/${model}-fp32.bin --out_file ${working_dir}/${model}-${precision}.bin --nthread $cores_per_instance --weight_dtype int4 --group_size 32 --compute_dtype int8 --alg sym --use_ggml
+                        elif [[ ${precision} == "q4_1" ]]; then
+                            ${quant_script} --model_file ${working_dir}/${model}-fp32.bin --out_file ${working_dir}/${model}-${precision}.bin --nthread $cores_per_instance --weight_dtype int4 --group_size 32 --compute_dtype int8 --alg asym --use_ggml
+                        elif [[ ${precision} == "q8_0" ]]; then
+                            ${quant_script} --model_file ${working_dir}/${model}-fp32.bin --out_file ${working_dir}/${model}-${precision}.bin --nthread $cores_per_instance --weight_dtype int8 --group_size 32 --compute_dtype int8 --alg sym --use_ggml
+                        else
+                            ${quant_script} --model_file ${working_dir}/${model}-fp32.bin --out_file ${working_dir}/${model}-${precision}.bin --nthread $cores_per_instance --weight_dtype int4
+                        fi
                     fi
                     ## run inference
                     export LANG=en_US.UTF-8

--- a/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.c
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.c
@@ -74,9 +74,7 @@ typedef DWORD thread_ret_t;
 static int pthread_create(pthread_t* out, void* unused, thread_ret_t (*func)(void*), void* arg) {
   (void)unused;
   HANDLE handle = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)func, arg, 0, NULL);
-  if (handle == NULL) {
-    return EAGAIN;
-  }
+  if (handle == NULL) return EAGAIN;
 
   *out = handle;
   return 0;
@@ -1331,9 +1329,7 @@ struct ne_tensor* ne_dump_tensor(struct ne_context* ctx, struct ne_tensor* a) {
 struct ne_tensor* ne_dup_impl(struct ne_context* ctx, struct ne_tensor* a, bool inplace) {
   bool is_node = false;
 
-  if (!inplace && (a->grad)) {
-    is_node = true;
-  }
+  if (!inplace && (a->grad)) is_node = true;
 
   struct ne_tensor* result = inplace ? ne_view_tensor(ctx, a) : ne_dup_tensor(ctx, a);
 


### PR DESCRIPTION
## Type of Change:  CI
API not changed

## Description
- CPP Graph CI speedup
  - llama: 10min => 4min
  - gptj: 13min => 8min
- The test result can now be previewed without downloading
- The test results of different models won't replace others any more
- Support trigger CI manually with different models. Developers can use it as a light-weight extension test, which makes our project more open! **(But DO NOT ABUSE! It will block all PRs if too many tests are triggered)**
  ![image](https://github.com/intel/intel-extension-for-transformers/assets/28386673/ee3d969e-2a4f-4224-8591-eba1a85128f8)


## Expected Behavior & Potential Risk
N/A

## How has this PR been tested?
N/A

## Dependency Change?
No