### PR TITLE
add missing packages for neural_chat example

### DIFF
--- a/intel_extension_for_transformers/neural_chat/examples/instruction_tuning/requirements.txt
+++ b/intel_extension_for_transformers/neural_chat/examples/instruction_tuning/requirements.txt
@@ -7,3 +7,9 @@ evaluate
 nltk
 rouge_score
 einops
+uvicorn
+yacs
+fastapi
+shortuuid
+pydub
+python-multipart


### PR DESCRIPTION
## Type of Change

bug fix : add missing python packages for neural_chat/examples/instruction_tuning

## Description

detail description 
JIRA ticket: xxx

## Expected Behavior & Potential Risk

it runs after we following the README and requirement.txt

## How has this PR been tested?

AWS m7i.24xlarge

## Dependency Change?

any library dependency introduced or removed