### PR TITLE
Fixed setuptools version limitation for build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 ninja
 cmake>=3.16
 py-cpuinfo
-setuptools>=61
+setuptools>=65
 setuptools_scm[toml]>=6.2
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.0.1+cpu

--- a/setup.py
+++ b/setup.py
@@ -246,7 +246,7 @@ if __name__ == '__main__':
         check_submodules()
         ext_modules.extend([
             CMakeExtension("intel_extension_for_transformers.neural_engine_py", "intel_extension_for_transformers/llm/runtime/deprecated/"),
-            CMakeExtension("intel_extension_for_transformers.llm.runtime.graph.Model", "intel_extension_for_transformers/llm/runtime/graph/"),
+            CMakeExtension("intel_extension_for_transformers.llm.runtime.graph.mpt_cpp", "intel_extension_for_transformers/llm/runtime/graph/"),
             ])
     cmdclass={'build_ext': CMakeBuild}
 


### PR DESCRIPTION
## Type of Change

bug fix
No API changed

## Description

There is issue for setuptools version<65, so limited setuptools version.

## Expected Behavior & Potential Risk

Build ITREX successfully.

## How has this PR been tested?

Local tested