### PR TITLE
Fix NeuralChat starcoder mha fusion env issue

### DIFF
--- a/intel_extension_for_transformers/neural_chat/models/model_utils.py
+++ b/intel_extension_for_transformers/neural_chat/models/model_utils.py
@@ -297,7 +297,7 @@ def load_model(
         )
 
         adapt_transformers_to_gaudi()
-    elif device == "cpu":
+    elif device == "cpu" and not ipex_int8:
         set_cpu_running_env()
 
     if isinstance(optimization_config, AMPConfig):


### PR DESCRIPTION
## Type of Change
os.environ["ONEDNN_MAX_CPU_ISA"] = "AVX512_CORE_BF16" will cause int8 starcoder mha fusion failed.

## Description

detail description 
JIRA ticket: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed