### PR TITLE
use INC 2.3.1

### DIFF
--- a/.github/workflows/script/unitTest/env_setup.sh
+++ b/.github/workflows/script/unitTest/env_setup.sh
@@ -7,15 +7,16 @@ if [ ${inc} != 0 ]; then
 fi
 
 echo "Install neural_compressor binary..."
-n=0
-until [ "$n" -ge 5 ]; do
-    git clone https://github.com/intel/neural-compressor.git /neural-compressor
-    cd /neural-compressor
-    pip install -r requirements.txt
-    python setup.py install && break
-    n=$((n + 1))
-    sleep 5
-done
+pip install neural-compressor
+#n=0
+#until [ "$n" -ge 5 ]; do
+#    git clone https://github.com/intel/neural-compressor.git /neural-compressor
+#    cd /neural-compressor
+#    pip install -r requirements.txt
+#    python setup.py install && break
+#    n=$((n + 1))
+#    sleep 5
+#done
 
 # Install test requirements
 cd /intel-extension-for-transformers/tests


### PR DESCRIPTION
## Type of Change

INC API changed in this commit https://github.com/intel/neural-compressor/pull/1323, but ITREX are ready to adapt to new API. So temperately use the latest release version 2.3.1
