### PR TITLE
Remove OneDNN graph env setting for BF16 inference

### DIFF
--- a/intel_extension_for_transformers/neural_chat/models/model_utils.py
+++ b/intel_extension_for_transformers/neural_chat/models/model_utils.py
@@ -253,11 +253,6 @@ def init_deepspeed_inference(model, model_name_or_path, use_hpu_graphs, is_meta)
     model = deepspeed.init_inference(model, **ds_inference_kwargs)
     return model.module
 
-
-def set_cpu_running_env():
-    os.environ["ONEDNN_MAX_CPU_ISA"] = "AVX512_CORE_BF16"
-
-
 def load_model(
     model_name,
     tokenizer_name,
@@ -297,8 +292,6 @@ def load_model(
         )
 
         adapt_transformers_to_gaudi()
-    elif device == "cpu" and not ipex_int8:
-        set_cpu_running_env()
 
     if isinstance(optimization_config, AMPConfig):
         dtype = optimization_config.dtype

--- a/intel_extension_for_transformers/neural_chat/pipeline/plugins/ner/ner.py
+++ b/intel_extension_for_transformers/neural_chat/pipeline/plugins/ner/ner.py
@@ -28,7 +28,6 @@ from transformers import (
 )
 import intel_extension_for_pytorch as intel_ipex
 from .utils.utils import (
-    set_cpu_running_env, 
     enforce_stop_tokens,
     get_current_time
 )
@@ -43,9 +42,6 @@ class NamedEntityRecognition():
     """
 
     def __init__(self, model_path="./Llama-2-7b-chat-hf/", spacy_model="en_core_web_lg", bf16: bool=False) -> None:
-        # set up cpu running environment
-        if bf16:
-            set_cpu_running_env()
         # initialize tokenizer and models
         self.nlp = spacy.load(spacy_model)
         config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)

--- a/intel_extension_for_transformers/neural_chat/pipeline/plugins/ner/utils/utils.py
+++ b/intel_extension_for_transformers/neural_chat/pipeline/plugins/ner/utils/utils.py
@@ -35,7 +35,3 @@ def get_current_time() -> str:
     utc_now = datetime.datetime.utcnow().replace(tzinfo=timezone.utc)
     cur_time = utc_now.astimezone(SHA_TZ).strftime("%Y/%m/%d")
     return cur_time
-
-
-def set_cpu_running_env():
-    os.environ["ONEDNN_MAX_CPU_ISA"] = "AVX512_CORE_BF16"


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

Remove OneDNN graph env setting for BF16 inference
Latest official pytorch version has fixed the onednn graph https://github.com/pytorch/pytorch/pull/97957. 

## Expected Behavior & Potential Risk

LLM inference for BF16 can be run successfully and without any performance reduce.

## How has this PR been tested?

Pre-CI and local test.

## Dependency Change?

None.