### PR TITLE
[LLM Runtime] Streaming-LLM based on shift RoPE

### DIFF
--- a/intel_extension_for_transformers/llm/runtime/graph/application/main_pybind.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/application/main_pybind.cpp
@@ -57,7 +57,8 @@ class Model {
   }
   void init_model(const std::string& model_path, int n_predict, int batch_size, int ctx_size, int seed, int threads,
                   float repetition_penalty, int num_beams, bool do_sample, int top_k, float top_p, float temperature,
-                  int min_new_tokens, float length_penalty, bool early_stopping, int n_keep, int n_discard);
+                  int min_new_tokens, float length_penalty, bool early_stopping, int n_keep, int n_discard,
+                  bool shift_roped_k);
   void reinit();
   std::vector<model_token> generate(const std::vector<model_token>& input_ids);
   std::vector<model_token> generate_tokens(const std::vector<model_token>& input_ids);
@@ -93,7 +94,7 @@ class Model {
 void Model::init_model(const std::string& model_path, int max_new_tokens, int batch_size, int ctx_size, int seed,
                        int threads, float repetition_penalty, int num_beams, bool do_sample, int top_k, float top_p,
                        float temperature, int min_new_tokens, float length_penalty, bool early_stopping, int n_keep,
-                       int n_discard) {
+                       int n_discard, bool shift_roped_k) {
 #ifdef MODEL_NAME
   params.model_name = MODEL_NAME;
 #endif
@@ -116,6 +117,7 @@ void Model::init_model(const std::string& model_path, int max_new_tokens, int ba
   params.temp = temperature;
   params.n_keep = n_keep;
   params.n_discard = n_discard;
+  params.shift_roped_k = shift_roped_k;
 
   printf("beam_size: %d, do_sample: %d, top_k: %d, top_p: %f\n", params.beam_size, params.do_sample, params.top_k,
          params.top_p);
@@ -163,10 +165,14 @@ std::vector<model_token> Model::generate(const std::vector<model_token>& input_i
     n_past = std::max(1, params.n_keep);
 
     int n_discard = params.n_discard;
-    if (n_discard == -1) n_discard = (n_ctx - curr_input_ids.size() - params.n_keep) / 2;
-    // drop n_discard tokens
-    curr_input_ids.insert(curr_input_ids.begin(), last_n_tokens.begin() + params.n_keep + n_discard,
-                          last_n_tokens.end() - curr_input_ids.size());
+    if (!params.shift_roped_k) {  // shift_roped_k can use ring-buffer and thus does not need re-computing
+      if (n_discard == -1) n_discard = (n_ctx - curr_input_ids.size() - params.n_keep) / 2;
+      // drop n_discard tokens
+      curr_input_ids.insert(curr_input_ids.begin(), last_n_tokens.begin() + params.n_keep + n_discard,
+                            last_n_tokens.end() - curr_input_ids.size());
+    } else {
+      NE_ASSERT(("n_discard cannot be used with shift_roped_k!", n_discard == -1 || n_discard == 1));
+    }
   }
   model_eval(ctx, &curr_input_ids[0], curr_input_ids.size(), n_past, n_total, params.n_threads);
   n_past += curr_input_ids.size();
@@ -210,10 +216,14 @@ std::vector<model_token> Model::generate_tokens(const std::vector<model_token>& 
       n_past = std::max(1, params.n_keep);
 
       int n_discard = params.n_discard;
-      if (n_discard == -1) n_discard = (n_ctx - curr_input_ids.size() - params.n_keep) / 2;
-      // drop n_discard tokens
-      curr_input_ids.insert(curr_input_ids.begin(), last_n_tokens.begin() + params.n_keep + n_discard,
-                            last_n_tokens.end() - curr_input_ids.size());
+      if (!params.shift_roped_k) {  // shift_roped_k can use ring-buffer and thus does not need re-computing
+        if (n_discard == -1) n_discard = (n_ctx - curr_input_ids.size() - params.n_keep) / 2;
+        // drop n_discard tokens
+        curr_input_ids.insert(curr_input_ids.begin(), last_n_tokens.begin() + params.n_keep + n_discard,
+                              last_n_tokens.end() - curr_input_ids.size());
+      } else {
+        NE_ASSERT(("n_discard cannot be used with shift_roped_k!", n_discard == -1 || n_discard == 1));
+      }
     }
     if (ctx->beam_search) {
       output_ids = post_beam_search(ctx, n_remain, curr_input_ids.data(), curr_input_ids.size(), params.n_threads);
@@ -295,15 +305,11 @@ model_token Model::post_sample_top_k_top_p_repeat(float* logits) {
 }
 
 model_token Model::post_process(float* logits) {
-  if (params.beam_size == 1) {
-    if (params.do_sample == false) {
-      return post_greedy_search(logits);
-    } else {
-      return post_sample_top_k_top_p_repeat(logits);
-    }
+  assert(("Beam search does not support streaming.", params.beam_size == 1));
+  if (params.do_sample == false) {
+    return post_greedy_search(logits);
   } else {
-    fprintf(stderr, "error, beam search not supported!\n");
-    exit(0);
+    return post_sample_top_k_top_p_repeat(logits);
   }
 }
 
@@ -408,7 +414,7 @@ PYBIND11_MODULE(mistral_cpp, m)
            py::arg("threads") = 8, py::arg("repetition_penalty") = 1.1f, py::arg("num_beams") = 1,
            py::arg("do_sample") = false, py::arg("top_k") = 40, py::arg("top_p") = 0.95, py::arg("temperature") = 0.8,
            py::arg("min_new_tokens") = 0, py::arg("length_penalty") = 1.0, py::arg("early_stopping") = false,
-           py::arg("n_keep") = 0, py::arg("n_discard") = -1)
+           py::arg("n_keep") = 0, py::arg("n_discard") = -1, py::arg("shift_roped_k") = false)
       .def("generate", &Model::generate, "Generate token with input ids", py::arg("input_ids"))
       .def("generate_tokens", &Model::generate_tokens, "Generate tokens with input ids", py::arg("input_ids"))
       .def_static("quant_model", &Model::quant_model, "Quantize model", py::arg("model_path"), py::arg("out_path"),

--- a/intel_extension_for_transformers/llm/runtime/graph/application/main_run.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/application/main_run.cpp
@@ -149,14 +149,14 @@ int main(int argc, char** argv) {
   if (params.mem_test) {
     {
       const std::vector<model_token> tmp(params.n_batch, ctx->vocab.bos_token_id);
-      model_eval(ctx, tmp.data(), tmp.size(), 0, params.n_threads);
+      model_eval(ctx, tmp.data(), tmp.size(), 0, 0, params.n_threads);
     }
 
     {
       const std::vector<model_token> tmp = {
           0,
       };
-      model_eval(ctx, tmp.data(), tmp.size(), params.n_predict - 1, params.n_threads);
+      model_eval(ctx, tmp.data(), tmp.size(), params.n_predict - 1, params.n_predict - 1, params.n_threads);
     }
 
     model_print_timings(ctx);
@@ -182,13 +182,13 @@ int main(int argc, char** argv) {
       std::fclose(fp);
 
       session_tokens.resize(params.n_ctx);
-      size_t n_token_count_out = 0;
+      size_t n_token_total_out = 0;
       if (!model_load_session_file(ctx, path_session.c_str(), session_tokens.data(), session_tokens.capacity(),
-                                   &n_token_count_out)) {
+                                   &n_token_total_out)) {
         fprintf(stderr, "%s: error: failed to load session file '%s'\n", __func__, path_session.c_str());
         return 1;
       }
-      session_tokens.resize(n_token_count_out);
+      session_tokens.resize(n_token_total_out);
 
       fprintf(stderr, "%s: loaded a session with prompt size of %d tokens\n", __func__, (int)session_tokens.size());
     } else {
@@ -355,7 +355,8 @@ int main(int argc, char** argv) {
   bool input_echo = true;
   bool need_to_save_session = !path_session.empty() && n_matching_session_tokens < embd_inp.size();
 
-  int n_past = 0;
+  int n_past = 0;   // offset to which the kv-cache will be stored
+  int n_total = 0;  // total number of tokens evaluated
   int n_remain = params.n_predict;
   int n_consumed = 0;
   int n_session_consumed = 0;
@@ -409,6 +410,7 @@ int main(int argc, char** argv) {
             break;
           }
 
+          n_total++;
           n_past++;
           n_session_consumed++;
 
@@ -429,11 +431,12 @@ int main(int argc, char** argv) {
         if (n_eval > params.n_batch) {
           n_eval = params.n_batch;
         }
-        if (model_eval(ctx, &embd[i], n_eval, n_past, params.n_threads)) {
+        if (model_eval(ctx, &embd[i], n_eval, n_past, n_total, params.n_threads)) {
           fprintf(stderr, "%s : failed to eval\n", __func__);
           return 1;
         }
         n_past += n_eval;
+        n_total += n_eval;
       }
 
       {
@@ -608,7 +611,7 @@ int main(int argc, char** argv) {
         }
       }
 
-      if (n_past > 0 && is_interacting) {
+      if (n_total > 0 && is_interacting) {
         if (params.instruct) {
           printf("\n> ");
         }
@@ -658,7 +661,7 @@ int main(int argc, char** argv) {
         input_echo = false;  // do not echo this again
       }
 
-      if (n_past > 0) {
+      if (n_total > 0) {
         is_interacting = false;
       }
     }

--- a/intel_extension_for_transformers/llm/runtime/graph/application/pybind_gptj.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/application/pybind_gptj.cpp
@@ -40,7 +40,7 @@ bool gptj_model_eval_ids(model_context* ctx, model_token* tokens, size_t n_eval,
     return 1;
   }
 
-  if (model_eval(ctx, tokens, n_eval, n_past, n_threads)) {
+  if (model_eval(ctx, tokens, n_eval, n_past, n_past, n_threads)) {
     fprintf(stderr, "%s : failed to eval\n", __func__);
     return 1;
   }
@@ -93,7 +93,7 @@ int32_t* eval_gptj_ids(void* ctx, int32_t* embd_inp_ptr, int ind_size, int n_pre
 
   auto hparams = lctx->model.hparams;
 
-  n_predict = std::min(n_predict, (int)hparams.n_ctx - (int)ind_size);
+  n_predict = std::min(n_predict, (int)lctx->n_ctx - (int)ind_size);
   std::vector<model_token> res;
   bool do_beam_search = lctx->beam_search;
 
@@ -151,7 +151,7 @@ char* eval_gptj_char(void* ctx, const char* prom, int n_predict, int top_k, floa
 
   auto hparams = lctx->model.hparams;
   std::vector<model_token> embd_inp = ::model_tokenize(lctx, std::string(prom), false);
-  n_predict = std::min(n_predict, (int)hparams.n_ctx - (int)embd_inp.size());
+  n_predict = std::min(n_predict, (int)lctx->n_ctx - (int)embd_inp.size());
   std::string res;
   std::vector<model_token> embd;
 

--- a/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.c
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.c
@@ -7858,7 +7858,7 @@ static void ne_compute_forward_rope_f16(const struct ne_compute_params* params, 
       cossin = malloc(ne0 * sizeof(ne_fp16_t));
       for (int i0 = 0; i0 < ne0; i0 += 2) {
         cossin[i0 + 0] = NE_FP32_TO_FP16(cosf(theta));
-        cossin[i0 + 1] = NE_FP32_TO_FP16(sinf(-theta));  // sin is negate to ease the use of fp16 instructions
+        cossin[i0 + 1] = NE_FP32_TO_FP16(sinf(theta));
         theta *= theta_scale;
       }
     }
@@ -7880,8 +7880,8 @@ static void ne_compute_forward_rope_f16(const struct ne_compute_params* params, 
             const float cos = NE_FP16_TO_FP32(cossin[i0 + 0]);
             const float sin = NE_FP16_TO_FP32(cossin[i0 + 1]);
 
-            dst_data[0] = NE_FP32_TO_FP16(x0 * cos + x1 * sin);
-            dst_data[1] = NE_FP32_TO_FP16(x1 * cos - x0 * sin);
+            dst_data[0] = NE_FP32_TO_FP16(x0 * cos - x1 * sin);
+            dst_data[1] = NE_FP32_TO_FP16(x1 * cos + x0 * sin);
           }
         }
       }

--- a/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.c
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.c
@@ -7670,8 +7670,8 @@ static void ne_compute_forward_rope_f32(const struct ne_compute_params* params, 
   NE_ASSERT(src1->type == NE_TYPE_I32);
   NE_ASSERT(ne_nelements(src1) == 5);  // 5 params
 
-  const float freq_base = 10000.0f;
-  const float freq_scale = 1.0f;
+  static const float freq_base = 10000.0f;
+  static const float freq_scale = 1.0f;
 
   const int64_t n_past = ((int32_t*)src1->data)[0];
   const int64_t n_dims = ((int32_t*)src1->data)[1];

--- a/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.c
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.c
@@ -2933,8 +2933,8 @@ struct ne_tensor* ne_soft_max_inplace(struct ne_context* ctx, struct ne_tensor* 
 // ne_rope
 
 struct ne_tensor* ne_rope_impl(struct ne_context* ctx, struct ne_tensor* a, int n_past, int n_dims, int mode,
-                               int prompt_size, bool inplace) {
-  NE_ASSERT(n_past >= 0);
+                               int prompt_size, bool inplace, int n_keep, struct ne_tensor* cossin) {
+  NE_ASSERT(n_past >= 0 || n_keep >= 0);
   bool is_node = false;
 
   if (!inplace && a->grad) {
@@ -2945,12 +2945,13 @@ struct ne_tensor* ne_rope_impl(struct ne_context* ctx, struct ne_tensor* a, int 
 
   ne_scratch_save(ctx);
 
-  struct ne_tensor* b = ne_new_tensor_1d(ctx, NE_TYPE_I32, 3, NE_SIZE_CALC);
+  struct ne_tensor* b = ne_new_tensor_1d(ctx, NE_TYPE_I32, 5, NE_SIZE_CALC);
 
   ((int32_t*)b->data)[0] = n_past;
   ((int32_t*)b->data)[1] = n_dims;
   ((int32_t*)b->data)[2] = mode;
   ((int32_t*)b->data)[3] = prompt_size;
+  ((int32_t*)b->data)[4] = n_keep;  // set to non-negative value to enable shift mode
 
   ne_scratch_load(ctx);
 
@@ -2958,18 +2959,24 @@ struct ne_tensor* ne_rope_impl(struct ne_context* ctx, struct ne_tensor* a, int 
   result->grad = is_node ? ne_dup_tensor(ctx, result) : NULL;
   result->src0 = a;
   result->src1 = b;
+  result->opt[0] = cossin;
 
   return result;
 }
 
 struct ne_tensor* ne_rope(struct ne_context* ctx, struct ne_tensor* a, int n_past, int n_dims, int mode,
                           int prompt_size) {
-  return ne_rope_impl(ctx, a, n_past, n_dims, mode, prompt_size, false);
+  return ne_rope_impl(ctx, a, n_past, n_dims, mode, prompt_size, false, -1, NULL);
 }
 
 struct ne_tensor* ne_rope_inplace(struct ne_context* ctx, struct ne_tensor* a, int n_past, int n_dims, int mode,
                                   int prompt_size) {
-  return ne_rope_impl(ctx, a, n_past, n_dims, mode, prompt_size, true);
+  return ne_rope_impl(ctx, a, n_past, n_dims, mode, prompt_size, true, -1, NULL);
+}
+
+struct ne_tensor* ne_rope_shift_inplace(struct ne_context* ctx, struct ne_tensor* a, int n_shift, int n_dims, int mode,
+                                        int prompt_size, int n_keep, struct ne_tensor* cossin) {
+  return ne_rope_impl(ctx, a, n_shift, n_dims, mode, prompt_size, true, n_keep, cossin);
 }
 
 // ne_rope_back
@@ -7660,14 +7667,17 @@ static void ne_compute_forward_rope_f32(const struct ne_compute_params* params, 
   if (params->type == NE_TASK_INIT || params->type == NE_TASK_FINALIZE) {
     return;
   }
+  NE_ASSERT(src1->type == NE_TYPE_I32);
+  NE_ASSERT(ne_nelements(src1) == 5);  // 5 params
 
-  float freq_base = 10000.0f;
-  float freq_scale = 1.0f;
+  const float freq_base = 10000.0f;
+  const float freq_scale = 1.0f;
 
   const int64_t n_past = ((int32_t*)src1->data)[0];
   const int64_t n_dims = ((int32_t*)src1->data)[1];
   const int64_t mode = ((int32_t*)src1->data)[2];
   const int64_t prompt_size = ((int32_t*)src1->data)[3];
+  const int64_t n_keep = ((int32_t*)src1->data)[4];
 
   assert(n_past >= 0);
 
@@ -7695,12 +7705,15 @@ static void ne_compute_forward_rope_f32(const struct ne_compute_params* params, 
 
   const float theta_scale = powf(freq_base, -2.0f / n_dims);
 
+  const bool skip = mode & 1;
   const bool is_neox = mode & 2;
   const bool is_glm = mode & 4;
+  const bool is_shift = n_keep >= 0;
+  NE_ASSERT(("RoPE shift not supported!", !is_shift));
 
   for (int64_t i3 = 0; i3 < ne3; i3++) {
-    for (int64_t i2 = ((mode & 1) == 0 ? 0 : n_past); i2 < ne2; i2++) {
-      const int64_t p = ((mode & 1) == 0 ? n_past + i2 : i2);
+    for (int64_t i2 = (skip ? n_past : 0); i2 < ne2; i2++) {
+      const int64_t p = skip ? i2 : n_past + i2;
       for (int64_t i1 = 0; i1 < ne1; i1++) {
         if (ir++ < ir0) continue;
         if (ir > ir1) break;
@@ -7738,7 +7751,7 @@ static void ne_compute_forward_rope_f32(const struct ne_compute_params* params, 
             const float cos_theta = cosf(theta);
             const float sin_theta = sinf(theta);
 
-            theta *= theta_scale;
+            theta *= theta_scale;  // theta = i2 * theta_scale^(i0/2)
 
             const float* const src = (float*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01 + i0 * nb00);
             float* dst_data = (float*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1 + i0 * nb0);
@@ -7780,18 +7793,19 @@ static void ne_compute_forward_rope_f32(const struct ne_compute_params* params, 
 
 static void ne_compute_forward_rope_f16(const struct ne_compute_params* params, const struct ne_tensor* src0,
                                         const struct ne_tensor* src1, struct ne_tensor* dst) {
-  NE_ASSERT(src1->type == NE_TYPE_I32);
-  NE_ASSERT(ne_nelements(src1) == 3);
-
   if (params->type == NE_TASK_INIT || params->type == NE_TASK_FINALIZE) {
     return;
   }
+  NE_ASSERT(src1->type == NE_TYPE_I32);
+  NE_ASSERT(ne_nelements(src1) == 5);  // 5 params
 
   const int n_past = ((int32_t*)src1->data)[0];
   const int n_dims = ((int32_t*)src1->data)[1];
   const int mode = ((int32_t*)src1->data)[2];
+  const int prompt_size = ((int32_t*)src1->data)[3];
+  const int n_keep = ((int32_t*)src1->data)[4];
 
-  assert(n_past >= 0);
+  assert(n_past >= 0 || n_keep >= 0);
 
   const size_t nb00 = src0->nb[0];
   const size_t nb01 = src0->nb[1];
@@ -7830,11 +7844,55 @@ static void ne_compute_forward_rope_f16(const struct ne_compute_params* params, 
 
   const float theta_scale = powf(10000.0, -2.0f / n_dims);
 
+  const bool skip = mode & 1;
   const bool is_neox = mode & 2;
+  const bool is_glm = mode & 4;
+  NE_ASSERT(("glm mode RoPE is not implemented!", !is_glm));
+  const bool is_shift = n_keep >= 0;
+  NE_ASSERT(("shift RoPE is only implemented for the vanilla mode", !is_shift || !(is_glm || is_neox || skip)));
+
+  if (is_shift) {
+    float theta = n_past;
+    ne_fp16_t* cossin = (dst->opt[0] != NULL) ? dst->opt[0]->data : NULL;
+    if (cossin == NULL) {
+      cossin = malloc(ne0 * sizeof(ne_fp16_t));
+      for (int i0 = 0; i0 < ne0; i0 += 2) {
+        cossin[i0 + 0] = NE_FP32_TO_FP16(cosf(theta));
+        cossin[i0 + 1] = NE_FP32_TO_FP16(sinf(-theta));  // sin is negate to ease the use of fp16 instructions
+        theta *= theta_scale;
+      }
+    }
+
+    for (int64_t i3 = 0; i3 < ne3; i3++) {
+      for (int64_t i2 = 0; i2 < ne2; i2++) {    // along seq
+        for (int64_t i1 = 0; i1 < ne1; i1++) {  // along head num
+          if (ir++ < ir0) continue;
+          if (ir > ir1) break;
+          if (i2 < n_keep) continue;  // The "break" will break `ir`
+
+          for (int64_t i0 = 0; i0 < ne0; i0 += 2) {  // along head size
+            const ne_fp16_t* const src =
+                (ne_fp16_t*)((char*)src0->data + i3 * nb03 + i2 * nb02 + i1 * nb01 + i0 * nb00);
+            ne_fp16_t* dst_data = (ne_fp16_t*)((char*)dst->data + i3 * nb3 + i2 * nb2 + i1 * nb1 + i0 * nb0);
+
+            const float x0 = NE_FP16_TO_FP32(src[0]);
+            const float x1 = NE_FP16_TO_FP32(src[1]);
+            const float cos = NE_FP16_TO_FP32(cossin[i0 + 0]);
+            const float sin = NE_FP16_TO_FP32(cossin[i0 + 1]);
+
+            dst_data[0] = NE_FP32_TO_FP16(x0 * cos + x1 * sin);
+            dst_data[1] = NE_FP32_TO_FP16(x1 * cos - x0 * sin);
+          }
+        }
+      }
+    }
+    if (dst->opt[0] == NULL) free(cossin);
+    return;
+  }
 
   for (int64_t i3 = 0; i3 < ne3; i3++) {
-    for (int64_t i2 = ((mode & 1) == 0 ? 0 : n_past); i2 < ne2; i2++) {
-      const int64_t p = ((mode & 1) == 0 ? n_past + i2 : i2);
+    for (int64_t i2 = (skip ? n_past : 0); i2 < ne2; i2++) {
+      const int64_t p = skip ? i2 : n_past + i2;
       for (int64_t i1 = 0; i1 < ne1; i1++) {
         if (ir++ < ir0) continue;
         if (ir > ir1) break;

--- a/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.h
@@ -402,6 +402,11 @@ NE_API struct ne_tensor* ne_rope(struct ne_context* ctx, struct ne_tensor* a, in
 NE_API struct ne_tensor* ne_rope_inplace(struct ne_context* ctx, struct ne_tensor* a, int n_past, int n_dims, int mode,
                                          int prompt_size);
 
+// shift all tokens by a give p (n_shift)
+// Optionally give a 1d tensor of precomputed interleaved cos/-sin value of n_shift*scale^k for k \in [0, n_dims)
+NE_API struct ne_tensor* ne_rope_shift_inplace(struct ne_context* ctx, struct ne_tensor* a, int n_shift, int n_dims,
+                                               int mode, int prompt_size, int n_keep, struct ne_tensor* cossin);
+
 // rotary position embedding backward, i.e compute dx from dy
 // a - dy
 NE_API struct ne_tensor* ne_rope_back(struct ne_context* ctx, struct ne_tensor* a, int n_past, int n_dims, int mode);

--- a/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.h
@@ -403,7 +403,7 @@ NE_API struct ne_tensor* ne_rope_inplace(struct ne_context* ctx, struct ne_tenso
                                          int prompt_size);
 
 // shift all tokens by a give p (n_shift)
-// Optionally give a 1d tensor of precomputed interleaved cos/-sin value of n_shift*scale^k for k \in [0, n_dims)
+// Optionally give a 1d tensor of precomputed interleaved cos/sin value of n_shift*scale^k for k \in [0, n_dims)
 NE_API struct ne_tensor* ne_rope_shift_inplace(struct ne_context* ctx, struct ne_tensor* a, int n_shift, int n_dims,
                                                int mode, int prompt_size, int n_keep, struct ne_tensor* cossin);
 

--- a/intel_extension_for_transformers/llm/runtime/graph/models/baichuan/baichuan.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/baichuan/baichuan.cpp
@@ -42,12 +42,12 @@
 //
 //   - lctx:      model context
 //   - tokens:    new batch of tokens to process
-//   - n_past:    the context size so far
+//   - n_past:    the offset to which the kv is cached to
+//   - n_total:   the number of tokens evaluated so far (including evicted tokens if there is any)
 //   - n_threads: number of threads to use
 //
-
 static bool baichuan_model_eval_internal(model_context& lctx, const model_token* tokens, const int n_tokens,
-                                         const int n_past, const int n_threads) {
+                                         const int n_past, const int n_total, const int n_threads) {
   const int64_t t_start_us = ne_time_us();
 
   const int N = n_tokens;
@@ -62,7 +62,8 @@ static bool baichuan_model_eval_internal(model_context& lctx, const model_token*
 
   const int n_embd = hparams.n_embd;
   const int n_layer = hparams.n_layer;
-  const int n_ctx = hparams.n_ctx;
+  const int n_ctx = lctx.n_ctx;  // max number fo tokens to keep in the kv-cache
+  const int n_keep = lctx.n_keep;
 
   const int n_head = hparams.n_head;
   const int n_vocab = hparams.n_vocab;
@@ -325,8 +326,9 @@ static bool baichuan_model_eval_internal(model_context& lctx, const model_token*
   return true;
 }
 
-int model_eval(struct model_context* ctx, const model_token* tokens, int n_tokens, int n_past, int n_threads) {
-  if (!baichuan_model_eval_internal(*ctx, tokens, n_tokens, n_past, n_threads)) {
+int model_eval(struct model_context* ctx, const model_token* tokens, int n_tokens, int n_past, int n_total,
+               int n_threads) {
+  if (!baichuan_model_eval_internal(*ctx, tokens, n_tokens, n_past, n_total, n_threads)) {
     fprintf(stderr, "%s: failed to eval\n", __func__);
     return 1;
   }

--- a/intel_extension_for_transformers/llm/runtime/graph/models/baichuan/baichuan.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/baichuan/baichuan.h
@@ -37,12 +37,12 @@ class BAICHUAN : public IModel {
   model_archs name = MODEL_BAICHUAN;
   std::unique_ptr<model_model_loader> ml;
   uint32_t n_layer, n_embd, n_ff, n_vocab;
-  int n_ctx, n_gpu_layer;
+  int n_gpu_layer;
   bool use_mmap, use_mlock, vocab_only;
   model_scratch scratch;
 
  public:
-  void init(const char* path_model, model_context& lctx, int n_ctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
+  void init(const char* path_model, model_context& lctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
             bool vocab_only_) override;
   void load(model_context& lctx, model_progress_callback progress_callback, void* progress_callback_user_data) override;
 };

--- a/intel_extension_for_transformers/llm/runtime/graph/models/baichuan/baichuan_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/baichuan/baichuan_utils.cpp
@@ -42,14 +42,11 @@
 void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data) {
-  lctx.t_start_us = ne_time_us();
-
-  std::unique_ptr<IModel> ms(new BAICHUAN());
+  std::unique_ptr<BAICHUAN> ms(new BAICHUAN());
   ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
 
   lctx.support_jblas_kv = true;
-  lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 
 void BAICHUAN::init(const char* path_model, model_context& lctx, int n_gpu_layer_, bool use_mmap_, bool use_mlock_,

--- a/intel_extension_for_transformers/llm/runtime/graph/models/baichuan/baichuan_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/baichuan/baichuan_utils.cpp
@@ -39,22 +39,21 @@
 #include "models/model_utils/util.h"
 #include "models/models.h"
 
-void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_ctx, int n_gpu_layers,
+void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data) {
   lctx.t_start_us = ne_time_us();
 
   std::unique_ptr<IModel> ms(new BAICHUAN());
-  ms->init(fname.c_str(), lctx, n_ctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
+  ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
 
   lctx.support_jblas_kv = true;
   lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 
-void BAICHUAN::init(const char* path_model, model_context& lctx, int n_ctx_, int n_gpu_layer_, bool use_mmap_,
-                    bool use_mlock_, bool vocab_only_) {
-  n_ctx = n_ctx_;
+void BAICHUAN::init(const char* path_model, model_context& lctx, int n_gpu_layer_, bool use_mmap_, bool use_mlock_,
+                    bool vocab_only_) {
   n_gpu_layer = n_gpu_layer_;
   use_mmap = use_mmap_;
   use_mlock = use_mlock_;
@@ -66,9 +65,7 @@ void BAICHUAN::init(const char* path_model, model_context& lctx, int n_ctx_, int
   model_file_version file_version = ml->file_loaders.at(0)->file_version;
   auto& hparams = model.hparams;
   n_ff = 4 * hparams.n_embd;
-  hparams.n_ctx = n_ctx;
   fprintf(stderr, "%s: n_vocab    = %u\n", __func__, hparams.n_vocab);
-  fprintf(stderr, "%s: n_ctx      = %u\n", __func__, hparams.n_ctx);
   fprintf(stderr, "%s: n_embd     = %u\n", __func__, hparams.n_embd);
   fprintf(stderr, "%s: n_mult     = %u\n", __func__, hparams.n_mult);
   fprintf(stderr, "%s: n_head     = %u\n", __func__, hparams.n_head);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/bloom/bloom.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/bloom/bloom.cpp
@@ -41,12 +41,13 @@
 //
 //   - lctx:      model context
 //   - tokens:    new batch of tokens to process
-//   - n_past:    the context size so far
+//   - n_past:    the offset to which the kv is cached to
+//   - n_total:   the number of tokens evaluated so far (including evicted tokens if there is any)
 //   - n_threads: number of threads to use
 //
 
 static bool bloom_model_eval_internal(model_context& lctx, const model_token* tokens, const int n_tokens,
-                                      const int n_past, const int n_threads) {
+                                      const int n_past, const int n_total, const int n_threads) {
   const int64_t t_start_us = ne_time_us();
 
   const int N = n_tokens;
@@ -62,7 +63,8 @@ static bool bloom_model_eval_internal(model_context& lctx, const model_token* to
 
   const int n_embd = hparams.n_embd;
   const int n_layer = hparams.n_layer;
-  const int n_ctx = hparams.n_ctx;
+  const int n_ctx = lctx.n_ctx;
+  const int n_keep = lctx.n_keep;
   const int n_head = hparams.n_head;
   const int n_vocab = hparams.n_vocab;
   const int n_rot = hparams.n_rot;
@@ -303,8 +305,9 @@ static bool bloom_model_eval_internal(model_context& lctx, const model_token* to
   return true;
 }
 
-int model_eval(struct model_context* ctx, const model_token* tokens, int n_tokens, int n_past, int n_threads) {
-  if (!bloom_model_eval_internal(*ctx, tokens, n_tokens, n_past, n_threads)) {
+int model_eval(struct model_context* ctx, const model_token* tokens, int n_tokens, int n_past, int n_total,
+               int n_threads) {
+  if (!bloom_model_eval_internal(*ctx, tokens, n_tokens, n_past, n_total, n_threads)) {
     fprintf(stderr, "%s: failed to eval\n", __func__);
     return 1;
   }

--- a/intel_extension_for_transformers/llm/runtime/graph/models/bloom/bloom.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/bloom/bloom.h
@@ -37,12 +37,12 @@ class BLOOM : public IModel {
   model_archs arch = MODEL_BLOOM;
   std::unique_ptr<model_model_loader> ml;
   uint32_t n_layer, n_embd, n_ff, n_vocab;
-  int n_ctx, n_gpu_layer;
+  int n_gpu_layer;
   bool use_mmap, use_mlock, vocab_only;
   model_scratch scratch;
 
  public:
-  void init(const char* path_model, model_context& lctx, int n_ctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
+  void init(const char* path_model, model_context& lctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
             bool vocab_only_) override;
   void load(model_context& lctx, model_progress_callback progress_callback, void* progress_callback_user_data) override;
 };

--- a/intel_extension_for_transformers/llm/runtime/graph/models/bloom/bloom_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/bloom/bloom_utils.cpp
@@ -39,21 +39,20 @@
 #include "models/model_utils/util.h"
 #include "models/models.h"
 
-void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_ctx, int n_gpu_layers,
+void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data) {
   lctx.t_start_us = ne_time_us();
 
   std::unique_ptr<IModel> ms(new BLOOM());
-  ms->init(fname.c_str(), lctx, n_ctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
+  ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
 
   lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 
-void BLOOM::init(const char* path_model, model_context& lctx, int n_ctx_, int n_gpu_layer_, bool use_mmap_,
-                 bool use_mlock_, bool vocab_only_) {
-  n_ctx = n_ctx_;
+void BLOOM::init(const char* path_model, model_context& lctx, int n_gpu_layer_, bool use_mmap_, bool use_mlock_,
+                 bool vocab_only_) {
   n_gpu_layer = n_gpu_layer_;
   use_mmap = use_mmap_;
   use_mlock = use_mlock_;
@@ -65,9 +64,7 @@ void BLOOM::init(const char* path_model, model_context& lctx, int n_ctx_, int n_
   model_file_version file_version = ml->file_loaders.at(0)->file_version;
   auto& hparams = model.hparams;
   n_ff = 4 * hparams.n_embd;
-  hparams.n_ctx = n_ctx;
   fprintf(stderr, "%s: n_vocab    = %u\n", __func__, hparams.n_vocab);
-  fprintf(stderr, "%s: n_ctx      = %u\n", __func__, hparams.n_ctx);
   fprintf(stderr, "%s: n_embd     = %u\n", __func__, hparams.n_embd);
   fprintf(stderr, "%s: n_mult     = %u\n", __func__, hparams.n_mult);
   fprintf(stderr, "%s: n_head     = %u\n", __func__, hparams.n_head);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/bloom/bloom_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/bloom/bloom_utils.cpp
@@ -42,13 +42,9 @@
 void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data) {
-  lctx.t_start_us = ne_time_us();
-
-  std::unique_ptr<IModel> ms(new BLOOM());
+  std::unique_ptr<BLOOM> ms(new BLOOM());
   ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
-
-  lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 
 void BLOOM::init(const char* path_model, model_context& lctx, int n_gpu_layer_, bool use_mmap_, bool use_mlock_,

--- a/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm.cpp
@@ -41,14 +41,15 @@
 //
 //   - lctx:      model context
 //   - tokens:    new batch of tokens to process
-//   - n_past:    the context size so far
+//   - n_past:    the offset to which the kv is cached to
+//   - n_total:   the number of tokens evaluated so far (including evicted tokens if there is any)
 //   - n_threads: number of threads to use
 //
 
 static int flag = 0;
 static int first_tokens_size = 0;
 static bool chatglm_model_eval_internal(model_context& lctx, const model_token* tokens, const int n_tokens,
-                                        const int n_past, const int n_threads) {
+                                        const int n_past, const int n_total, const int n_threads) {
   const int64_t t_start_us = ne_time_us();
 
   const int N = n_tokens;
@@ -63,7 +64,8 @@ static bool chatglm_model_eval_internal(model_context& lctx, const model_token* 
 
   const int n_embd = hparams.n_embd;
   const int n_layer = hparams.n_layer;
-  const int n_ctx = hparams.n_ctx;
+  const int n_ctx = lctx.n_ctx;
+  const int n_keep = lctx.n_keep;
 
   if (flag == 0) {
     first_tokens_size = n_tokens;
@@ -302,8 +304,9 @@ static bool chatglm_model_eval_internal(model_context& lctx, const model_token* 
   return true;
 }
 
-int model_eval(struct model_context* ctx, const model_token* tokens, int n_tokens, int n_past, int n_threads) {
-  if (!chatglm_model_eval_internal(*ctx, tokens, n_tokens, n_past, n_threads)) {
+int model_eval(struct model_context* ctx, const model_token* tokens, int n_tokens, int n_past, int n_total,
+               int n_threads) {
+  if (!chatglm_model_eval_internal(*ctx, tokens, n_tokens, n_past, n_total, n_threads)) {
     fprintf(stderr, "%s: failed to eval\n", __func__);
     return 1;
   }

--- a/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm.h
@@ -38,12 +38,12 @@ class CHATGLM : public IModel {
   model_archs name = MODEL_CHATGLM;
   std::unique_ptr<model_model_loader> ml;
   uint32_t n_layer, n_embd, n_ff, n_vocab;
-  int n_ctx, n_gpu_layer;
+  int n_gpu_layer;
   bool use_mmap, use_mlock, vocab_only;
   model_scratch scratch;
 
  public:
-  void init(const char* path_model, model_context& lctx, int n_ctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
+  void init(const char* path_model, model_context& lctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
             bool vocab_only_) override;
   void load(model_context& lctx, model_progress_callback progress_callback, void* progress_callback_user_data) override;
 };

--- a/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm2.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm2.cpp
@@ -42,12 +42,13 @@
 //
 //   - lctx:      model context
 //   - tokens:    new batch of tokens to process
-//   - n_past:    the context size so far
+//   - n_past:    the offset to which the kv is cached to
+//   - n_total:   the number of tokens evaluated so far (including evicted tokens if there is any)
 //   - n_threads: number of threads to use
 //
 
 static bool chatglm_model_eval_internal(model_context& lctx, const model_token* tokens, const int n_tokens,
-                                        const int n_past, const int n_threads) {
+                                        const int n_past, const int n_total, const int n_threads) {
   const int64_t t_start_us = ne_time_us();
 
   const int N = n_tokens;
@@ -61,7 +62,8 @@ static bool chatglm_model_eval_internal(model_context& lctx, const model_token* 
 
   const int n_embd = hparams.n_embd;
   const int n_layer = hparams.n_layer;
-  const int n_ctx = hparams.n_ctx;
+  const int n_ctx = lctx.n_ctx;
+  const int n_keep = lctx.n_keep;
   const int n_head = hparams.n_head;
   const int n_vocab = hparams.n_vocab;
   const int n_rot = n_embd / n_head / 2;
@@ -338,8 +340,9 @@ static bool chatglm_model_eval_internal(model_context& lctx, const model_token* 
   return true;
 }
 
-int model_eval(struct model_context* ctx, const model_token* tokens, int n_tokens, int n_past, int n_threads) {
-  if (!chatglm_model_eval_internal(*ctx, tokens, n_tokens, n_past, n_threads)) {
+int model_eval(struct model_context* ctx, const model_token* tokens, int n_tokens, int n_past, int n_total,
+               int n_threads) {
+  if (!chatglm_model_eval_internal(*ctx, tokens, n_tokens, n_past, n_total, n_threads)) {
     fprintf(stderr, "%s: failed to eval\n", __func__);
     return 1;
   }

--- a/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm2.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm2.h
@@ -37,12 +37,12 @@ class CHATGLM2 : public IModel {
   model_archs name = MODEL_CHATGLM2;
   std::unique_ptr<model_model_loader> ml;
   uint32_t n_layer, n_embd, n_ff, n_vocab;
-  int n_ctx, n_gpu_layer;
+  int n_gpu_layer;
   bool use_mmap, use_mlock, vocab_only;
   model_scratch scratch;
 
  public:
-  void init(const char* path_model, model_context& lctx, int n_ctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
+  void init(const char* path_model, model_context& lctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
             bool vocab_only_) override;
   void load(model_context& lctx, model_progress_callback progress_callback, void* progress_callback_user_data) override;
 };

--- a/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm2_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm2_utils.cpp
@@ -40,22 +40,21 @@
 #include "models/model_utils/util.h"
 #include "models/models.h"
 
-void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_ctx, int n_gpu_layers,
+void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data) {
   lctx.t_start_us = ne_time_us();
 
   std::unique_ptr<IModel> ms(new CHATGLM2());
-  ms->init(fname.c_str(), lctx, n_ctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
+  ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
 
   lctx.support_jblas_kv = true;
   lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 
-void CHATGLM2::init(const char* path_model, model_context& lctx, int n_ctx_, int n_gpu_layer_, bool use_mmap_,
-                    bool use_mlock_, bool vocab_only_) {
-  n_ctx = n_ctx_;
+void CHATGLM2::init(const char* path_model, model_context& lctx, int n_gpu_layer_, bool use_mmap_, bool use_mlock_,
+                    bool vocab_only_) {
   n_gpu_layer = n_gpu_layer_;
   use_mmap = use_mmap_;
   use_mlock = use_mlock_;
@@ -67,9 +66,7 @@ void CHATGLM2::init(const char* path_model, model_context& lctx, int n_ctx_, int
   model_file_version file_version = ml->file_loaders.at(0)->file_version;
   auto& hparams = model.hparams;
   n_ff = 4 * hparams.n_embd;
-  hparams.n_ctx = n_ctx;
   fprintf(stderr, "%s: n_vocab    = %u\n", __func__, hparams.n_vocab);
-  fprintf(stderr, "%s: n_ctx      = %u\n", __func__, hparams.n_ctx);
   fprintf(stderr, "%s: n_embd     = %u\n", __func__, hparams.n_embd);
   fprintf(stderr, "%s: n_mult     = %u\n", __func__, hparams.n_mult);
   fprintf(stderr, "%s: n_head     = %u\n", __func__, hparams.n_head);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm2_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm2_utils.cpp
@@ -45,7 +45,7 @@ void model_load_internal(const std::string& fname, model_archs arch, model_conte
                          void* progress_callback_user_data) {
   lctx.t_start_us = ne_time_us();
 
-  std::unique_ptr<IModel> ms(new CHATGLM2());
+  std::unique_ptr<CHATGLM2> ms(new CHATGLM2());
   ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
 

--- a/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm_utils.cpp
@@ -39,21 +39,20 @@
 #include "models/model_utils/util.h"
 #include "models/models.h"
 
-void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_ctx, int n_gpu_layers,
+void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data) {
   lctx.t_start_us = ne_time_us();
 
   std::unique_ptr<IModel> ms(new CHATGLM());
-  ms->init(fname.c_str(), lctx, n_ctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
+  ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
 
   lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 
-void CHATGLM::init(const char* path_model, model_context& lctx, int n_ctx_, int n_gpu_layer_, bool use_mmap_,
-                   bool use_mlock_, bool vocab_only_) {
-  n_ctx = n_ctx_;
+void CHATGLM::init(const char* path_model, model_context& lctx, int n_gpu_layer_, bool use_mmap_, bool use_mlock_,
+                   bool vocab_only_) {
   n_gpu_layer = n_gpu_layer_;
   use_mmap = use_mmap_;
   use_mlock = use_mlock_;
@@ -65,9 +64,7 @@ void CHATGLM::init(const char* path_model, model_context& lctx, int n_ctx_, int 
   model_file_version file_version = ml->file_loaders.at(0)->file_version;
   auto& hparams = model.hparams;
   n_ff = 4 * hparams.n_embd;
-  hparams.n_ctx = n_ctx;
   fprintf(stderr, "%s: n_vocab    = %u\n", __func__, hparams.n_vocab);
-  fprintf(stderr, "%s: n_ctx      = %u\n", __func__, hparams.n_ctx);
   fprintf(stderr, "%s: n_embd     = %u\n", __func__, hparams.n_embd);
   fprintf(stderr, "%s: n_mult     = %u\n", __func__, hparams.n_mult);
   fprintf(stderr, "%s: n_head     = %u\n", __func__, hparams.n_head);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm_utils.cpp
@@ -42,13 +42,9 @@
 void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data) {
-  lctx.t_start_us = ne_time_us();
-
-  std::unique_ptr<IModel> ms(new CHATGLM());
+  std::unique_ptr<CHATGLM> ms(new CHATGLM());
   ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
-
-  lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 
 void CHATGLM::init(const char* path_model, model_context& lctx, int n_gpu_layer_, bool use_mmap_, bool use_mlock_,

--- a/intel_extension_for_transformers/llm/runtime/graph/models/falcon/falcon.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/falcon/falcon.cpp
@@ -41,12 +41,13 @@
 //
 //   - lctx:      model context
 //   - tokens:    new batch of tokens to process
-//   - n_past:    the context size so far
+//   - n_past:    the offset to which the kv is cached to
+//   - n_total:   the number of tokens evaluated so far (including evicted tokens if there is any)
 //   - n_threads: number of threads to use
 //
 
 static bool falcon_model_eval_internal(model_context& lctx, const model_token* tokens, const int n_tokens,
-                                       const int n_past, const int n_threads) {
+                                       const int n_past, const int n_total, const int n_threads) {
   const int64_t t_start_us = ne_time_us();
 
   const int N = n_tokens;
@@ -62,7 +63,8 @@ static bool falcon_model_eval_internal(model_context& lctx, const model_token* t
 
   const int n_embd = hparams.n_embd;
   const int n_layer = hparams.n_layer;
-  const int n_ctx = hparams.n_ctx;
+  const int n_ctx = lctx.n_ctx;
+  const int n_keep = lctx.n_keep;
   const int n_head = hparams.n_head;
   const int n_head_kv = hparams.n_head_kv;
   const int n_vocab = hparams.n_vocab;
@@ -364,8 +366,9 @@ static bool falcon_model_eval_internal(model_context& lctx, const model_token* t
   return true;
 }
 
-int model_eval(struct model_context* ctx, const model_token* tokens, int n_tokens, int n_past, int n_threads) {
-  if (!falcon_model_eval_internal(*ctx, tokens, n_tokens, n_past, n_threads)) {
+int model_eval(struct model_context* ctx, const model_token* tokens, int n_tokens, int n_past, int n_total,
+               int n_threads) {
+  if (!falcon_model_eval_internal(*ctx, tokens, n_tokens, n_past, n_total, n_threads)) {
     fprintf(stderr, "%s: failed to eval\n", __func__);
     return 1;
   }

--- a/intel_extension_for_transformers/llm/runtime/graph/models/falcon/falcon.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/falcon/falcon.h
@@ -41,12 +41,12 @@ class FALCON : public IModel {
   model_archs arch = MODEL_FALCON;
   std::unique_ptr<model_model_loader> ml;
   uint32_t n_layer, n_embd, n_ff, n_vocab, n_head_kv;
-  int n_ctx, n_gpu_layer;
+  int n_gpu_layer;
   bool use_mmap, use_mlock, vocab_only;
   model_scratch scratch;
 
  public:
-  void init(const char* path_model, model_context& lctx, int n_ctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
+  void init(const char* path_model, model_context& lctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
             bool vocab_only_) override;
   void load(model_context& lctx, model_progress_callback progress_callback, void* progress_callback_user_data) override;
 };

--- a/intel_extension_for_transformers/llm/runtime/graph/models/falcon/falcon_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/falcon/falcon_utils.cpp
@@ -39,22 +39,21 @@
 #include "models/model_utils/util.h"
 #include "models/models.h"
 
-void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_ctx, int n_gpu_layers,
+void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data) {
   lctx.t_start_us = ne_time_us();
 
   std::unique_ptr<IModel> ms(new FALCON());
-  ms->init(fname.c_str(), lctx, n_ctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
+  ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
 
   lctx.support_jblas_kv = true;
   lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 
-void FALCON::init(const char* path_model, model_context& lctx, int n_ctx_, int n_gpu_layer_, bool use_mmap_,
-                  bool use_mlock_, bool vocab_only_) {
-  n_ctx = n_ctx_;
+void FALCON::init(const char* path_model, model_context& lctx, int n_gpu_layer_, bool use_mmap_, bool use_mlock_,
+                  bool vocab_only_) {
   n_gpu_layer = n_gpu_layer_;
   use_mmap = use_mmap_;
   use_mlock = use_mlock_;
@@ -66,9 +65,7 @@ void FALCON::init(const char* path_model, model_context& lctx, int n_ctx_, int n
   model_file_version file_version = ml->file_loaders.at(0)->file_version;
   auto& hparams = model.hparams;
   n_ff = 4 * hparams.n_embd;
-  hparams.n_ctx = n_ctx;
   fprintf(stderr, "%s: n_vocab    = %u\n", __func__, hparams.n_vocab);
-  fprintf(stderr, "%s: n_ctx      = %u\n", __func__, hparams.n_ctx);
   fprintf(stderr, "%s: n_embd     = %u\n", __func__, hparams.n_embd);
   fprintf(stderr, "%s: n_mult     = %u\n", __func__, hparams.n_mult);
   fprintf(stderr, "%s: n_head     = %u\n", __func__, hparams.n_head);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/falcon/falcon_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/falcon/falcon_utils.cpp
@@ -42,14 +42,11 @@
 void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data) {
-  lctx.t_start_us = ne_time_us();
-
-  std::unique_ptr<IModel> ms(new FALCON());
+  std::unique_ptr<FALCON> ms(new FALCON());
   ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
 
   lctx.support_jblas_kv = true;
-  lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 
 void FALCON::init(const char* path_model, model_context& lctx, int n_gpu_layer_, bool use_mmap_, bool use_mlock_,

--- a/intel_extension_for_transformers/llm/runtime/graph/models/gptj/gptj.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/gptj/gptj.cpp
@@ -46,11 +46,12 @@
 //
 //   - lctx:      model context
 //   - tokens:    new batch of tokens to process
-//   - n_past:    the context size so far
+//   - n_past:    the offset to which the kv is cached to
+//   - n_total:   the number of tokens evaluated so far (including evicted tokens if there is any)
 //   - n_threads: number of threads to use
 //
 static bool gptj_model_eval_internal(model_context& lctx, const model_token* tokens, const int n_tokens,
-                                     const int n_past, const int n_threads) {
+                                     const int n_past, const int n_total, const int n_threads) {
   const int64_t t_start_us = ne_time_us();
 
   const int batch_size = lctx.batch_size;  // num of beams of all batches
@@ -65,7 +66,8 @@ static bool gptj_model_eval_internal(model_context& lctx, const model_token* tok
 
   const int n_embd = hparams.n_embd;
   const int n_layer = hparams.n_layer;
-  const int n_ctx = hparams.n_ctx;
+  const int n_ctx = lctx.n_ctx;  // max number fo tokens to keep in the kv-cache
+  const int n_keep = lctx.n_keep;
   int n_head = hparams.n_head;
   const int head_size = n_embd / n_head;
   const int n_vocab = hparams.n_vocab;
@@ -513,8 +515,9 @@ static bool gptj_model_eval_internal(model_context& lctx, const model_token* tok
   return true;
 }
 
-int model_eval(struct model_context* ctx, const model_token* tokens, int n_tokens, int n_past, int n_threads) {
-  if (!gptj_model_eval_internal(*ctx, tokens, n_tokens, n_past, n_threads)) {
+int model_eval(struct model_context* ctx, const model_token* tokens, int n_tokens, int n_past, int n_total,
+               int n_threads) {
+  if (!gptj_model_eval_internal(*ctx, tokens, n_tokens, n_past, n_total, n_threads)) {
     fprintf(stderr, "%s: failed to eval\n", __func__);
     return 1;
   }

--- a/intel_extension_for_transformers/llm/runtime/graph/models/gptj/gptj.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/gptj/gptj.h
@@ -40,12 +40,12 @@ class GPTJ : public IModel {
   model_archs arch = MODEL_GPTJ;
   std::unique_ptr<model_model_loader> ml;
   uint32_t n_layer, n_embd, n_ff, n_vocab;
-  int n_ctx, n_gpu_layer;
+  int n_gpu_layer;
   bool use_mmap, use_mlock, vocab_only;
   model_scratch scratch;
 
  public:
-  void init(const char* path_model, model_context& lctx, int n_ctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
+  void init(const char* path_model, model_context& lctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
             bool vocab_only_) override;
   void load(model_context& lctx, model_progress_callback progress_callback, void* progress_callback_user_data) override;
 };

--- a/intel_extension_for_transformers/llm/runtime/graph/models/gptj/gptj_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/gptj/gptj_utils.cpp
@@ -39,22 +39,21 @@
 #include "models/model_utils/util.h"
 #include "models/models.h"
 
-void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_ctx, int n_gpu_layers,
+void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data) {
   lctx.t_start_us = ne_time_us();
 
   std::unique_ptr<IModel> ms(new GPTJ());
-  ms->init(fname.c_str(), lctx, n_ctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
+  ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
 
   lctx.support_jblas_kv = true;
   lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 
-void GPTJ::init(const char* path_model, model_context& lctx, int n_ctx_, int n_gpu_layer_, bool use_mmap_,
-                bool use_mlock_, bool vocab_only_) {
-  n_ctx = n_ctx_;
+void GPTJ::init(const char* path_model, model_context& lctx, int n_gpu_layer_, bool use_mmap_, bool use_mlock_,
+                bool vocab_only_) {
   n_gpu_layer = n_gpu_layer_;
   use_mmap = use_mmap_;
   use_mlock = use_mlock_;
@@ -66,9 +65,7 @@ void GPTJ::init(const char* path_model, model_context& lctx, int n_ctx_, int n_g
   model_file_version file_version = ml->file_loaders.at(0)->file_version;
   auto& hparams = model.hparams;
   n_ff = 4 * hparams.n_embd;
-  hparams.n_ctx = n_ctx;
   fprintf(stderr, "%s: n_vocab    = %u\n", __func__, hparams.n_vocab);
-  fprintf(stderr, "%s: n_ctx      = %u\n", __func__, hparams.n_ctx);
   fprintf(stderr, "%s: n_embd     = %u\n", __func__, hparams.n_embd);
   fprintf(stderr, "%s: n_mult     = %u\n", __func__, hparams.n_mult);
   fprintf(stderr, "%s: n_head     = %u\n", __func__, hparams.n_head);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/gptj/gptj_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/gptj/gptj_utils.cpp
@@ -42,14 +42,11 @@
 void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data) {
-  lctx.t_start_us = ne_time_us();
-
-  std::unique_ptr<IModel> ms(new GPTJ());
+  std::unique_ptr<GPTJ> ms(new GPTJ());
   ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
 
   lctx.support_jblas_kv = true;
-  lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 
 void GPTJ::init(const char* path_model, model_context& lctx, int n_gpu_layer_, bool use_mmap_, bool use_mlock_,

--- a/intel_extension_for_transformers/llm/runtime/graph/models/gptneox/gptneox.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/gptneox/gptneox.cpp
@@ -67,12 +67,13 @@ struct ne_tensor* gpt_neox_ff(const model_layer& layer, const int batch_size, co
 //
 //   - lctx:      model context
 //   - tokens:    new batch of tokens to process
-//   - n_past:    the context size so far
+//   - n_past:    the offset to which the kv is cached to
+//   - n_total:   the number of tokens evaluated so far (including evicted tokens if there is any)
 //   - n_threads: number of threads to use
 //
 
 static bool gptneox_model_eval_internal(model_context& lctx, const model_token* tokens, const int n_tokens,
-                                        const int n_past, const int n_threads) {
+                                        const int n_past, const int n_total, const int n_threads) {
   const int64_t t_start_us = ne_time_us();
 
   const int N = n_tokens;
@@ -89,7 +90,8 @@ static bool gptneox_model_eval_internal(model_context& lctx, const model_token* 
 
   const int n_embd = hparams.n_embd;
   const int n_layer = hparams.n_layer;
-  const int n_ctx = hparams.n_ctx;
+  const int n_ctx = lctx.n_ctx;
+  const int n_keep = lctx.n_keep;
   const int n_head = hparams.n_head;
   const int n_vocab = hparams.n_vocab;
   const int n_rot = hparams.n_rot;
@@ -339,8 +341,9 @@ static bool gptneox_model_eval_internal(model_context& lctx, const model_token* 
   return true;
 }
 
-int model_eval(struct model_context* ctx, const model_token* tokens, int n_tokens, int n_past, int n_threads) {
-  if (!gptneox_model_eval_internal(*ctx, tokens, n_tokens, n_past, n_threads)) {
+int model_eval(struct model_context* ctx, const model_token* tokens, int n_tokens, int n_past, int n_total,
+               int n_threads) {
+  if (!gptneox_model_eval_internal(*ctx, tokens, n_tokens, n_past, n_total, n_threads)) {
     fprintf(stderr, "%s: failed to eval\n", __func__);
     return 1;
   }

--- a/intel_extension_for_transformers/llm/runtime/graph/models/gptneox/gptneox.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/gptneox/gptneox.h
@@ -41,12 +41,12 @@ class GPTNEOX : public IModel {
   model_archs arch = MODEL_GPTNEOX;
   std::unique_ptr<model_model_loader> ml;
   uint32_t n_layer, n_embd, n_ff, n_vocab;
-  int n_ctx, n_gpu_layer;
+  int n_gpu_layer;
   bool use_mmap, use_mlock, vocab_only;
   model_scratch scratch;
 
  public:
-  void init(const char* path_model, model_context& lctx, int n_ctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
+  void init(const char* path_model, model_context& lctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
             bool vocab_only_) override;
   void load(model_context& lctx, model_progress_callback progress_callback, void* progress_callback_user_data) override;
 };

--- a/intel_extension_for_transformers/llm/runtime/graph/models/gptneox/gptneox_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/gptneox/gptneox_utils.cpp
@@ -39,9 +39,8 @@
 #include "models/model_utils/util.h"
 #include "models/models.h"
 
-void GPTNEOX::init(const char* path_model, model_context& lctx, int n_ctx_, int n_gpu_layer_, bool use_mmap_,
-                   bool use_mlock_, bool vocab_only_) {
-  n_ctx = n_ctx_;
+void GPTNEOX::init(const char* path_model, model_context& lctx, int n_gpu_layer_, bool use_mmap_, bool use_mlock_,
+                   bool vocab_only_) {
   n_gpu_layer = n_gpu_layer_;
   use_mmap = use_mmap_;
   use_mlock = use_mlock_;
@@ -53,9 +52,7 @@ void GPTNEOX::init(const char* path_model, model_context& lctx, int n_ctx_, int 
   model_file_version file_version = ml->file_loaders.at(0)->file_version;
   auto& hparams = model.hparams;
   n_ff = 4 * hparams.n_embd;
-  hparams.n_ctx = n_ctx;
   fprintf(stderr, "%s: n_vocab    = %u\n", __func__, hparams.n_vocab);
-  fprintf(stderr, "%s: n_ctx      = %u\n", __func__, hparams.n_ctx);
   fprintf(stderr, "%s: n_embd     = %u\n", __func__, hparams.n_embd);
   fprintf(stderr, "%s: n_mult     = %u\n", __func__, hparams.n_mult);
   fprintf(stderr, "%s: n_head     = %u\n", __func__, hparams.n_head);
@@ -282,13 +279,13 @@ class gptneox_beam_search_kv_cache_reorder : public beam_search_kv_cache_reorder
   }
 };
 
-void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_ctx, int n_gpu_layers,
+void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data) {
   lctx.t_start_us = ne_time_us();
 
   std::unique_ptr<IModel> ms(new GPTNEOX());
-  ms->init(fname.c_str(), lctx, n_ctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
+  ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
   if (lctx.beam_search) {
     lctx.bs_kv_reorder = std::make_shared<gptneox_beam_search_kv_cache_reorder>(&lctx);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/gptneox/gptneox_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/gptneox/gptneox_utils.cpp
@@ -282,9 +282,7 @@ class gptneox_beam_search_kv_cache_reorder : public beam_search_kv_cache_reorder
 void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data) {
-  lctx.t_start_us = ne_time_us();
-
-  std::unique_ptr<IModel> ms(new GPTNEOX());
+  std::unique_ptr<GPTNEOX> ms(new GPTNEOX());
   ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
   if (lctx.beam_search) {
@@ -293,6 +291,4 @@ void model_load_internal(const std::string& fname, model_archs arch, model_conte
     printf("get GPTNEOX beam search kv cache update function. \n");
 #endif
   }
-
-  lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }

--- a/intel_extension_for_transformers/llm/runtime/graph/models/llama/llama.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/llama/llama.cpp
@@ -73,6 +73,8 @@ static bool llama_model_eval_internal(model_context& lctx, const model_token* to
   const int n_layer = hparams.n_layer;
   const int n_ctx = lctx.n_ctx;  // max number fo tokens to keep in the kv-cache
   const int n_keep = lctx.n_keep;
+  const bool shift_roped_k = lctx.shift_roped_k;
+  const int n_cached = shift_roped_k ? std::min(n_total + N, n_ctx) : (n_past + N);  // #tokens cached after kv-append
   int n_head = hparams.n_head;
   int head_size = n_embd / n_head;
   int n_head_kv = hparams.n_head_kv;
@@ -120,7 +122,7 @@ static bool llama_model_eval_internal(model_context& lctx, const model_token* to
         /* .heads_kv = */ n_head_kv,
         /* .head_size = */ head_size,
         /* .sl_q = */ N,  // Note: make sure that jblas reordered attn supports next token inferencing
-        /* .sl_kv = */ n_past + N,
+        /* .sl_kv = */ n_cached,
     };
 
     NE_ASSERT(("jblas managed kv-cache not supported; use `--memory-f16 / --memory-f32` instead",
@@ -160,38 +162,28 @@ static bool llama_model_eval_internal(model_context& lctx, const model_token* to
       cur = ne_mul(ctx0, cur, model.layers[il].norm[0]);
     }
     ne_tensor *Qcur, *Kcur, *Vcur;
-    size_t qkv_size = head_size * n_head * N;
     if (jblas_fusion_QKV_f32f32_support(model.layers[il].attn[0]->data, model.layers[il].attn[1]->data,
                                         model.layers[il].attn[2]->data, N, model.layers[il].attn[0]->ne[1],
                                         model.layers[il].attn[0]->ne[0]) &&
         n_head == n_head_kv) {  // fused execution of QKV
       struct ne_tensor* QKVcur =
           ne_mul_qkv(ctx0, model.layers[il].attn[0], model.layers[il].attn[1], model.layers[il].attn[2], cur);
-      Qcur = ne_rope_inplace(
-          ctx0,
-          ne_reshape_3d(ctx0, ne_view_1d(ctx0, QKVcur, qkv_size, 0 * qkv_size * ne_element_size(QKVcur)), head_size,
-                        n_head, N),
-          n_past, n_rot, 0, 0);
-      Kcur = ne_rope_inplace(
-          ctx0,
-          ne_reshape_3d(ctx0, ne_view_1d(ctx0, QKVcur, qkv_size, 1 * qkv_size * ne_element_size(QKVcur)), head_size,
-                        n_head, N),
-          n_past, n_rot, 0, 0);
-      Vcur = ne_transpose(
-          ctx0, ne_reshape_2d(ctx0, ne_view_1d(ctx0, QKVcur, qkv_size, 2 * qkv_size * ne_element_size(QKVcur)),
-                              head_size * n_head, N));
+      const size_t qkv_size = head_size * n_head * N;
+      const size_t qkv_bytes = qkv_size * ne_element_size(QKVcur);
+      Qcur = ne_reshape_3d(ctx0, ne_view_1d(ctx0, QKVcur, qkv_size, 0 * qkv_bytes), head_size, n_head, N);
+      Kcur = ne_reshape_3d(ctx0, ne_view_1d(ctx0, QKVcur, qkv_size, 1 * qkv_bytes), head_size, n_head_kv, N);
+      Vcur = ne_view_1d(ctx0, QKVcur, qkv_size, 2 * qkv_bytes);
     } else {
-      Qcur = ne_rope_inplace(ctx0,
-                             ne_reshape_3d(ctx0, ne_mul_mat(ctx0, model.layers[il].attn[0], cur), head_size, n_head, N),
-                             n_past, head_size, 0, 0);
-      Kcur = ne_rope_inplace(
-          ctx0,
-          ne_reshape_3d(ctx0, ne_mul_mat(ctx0, model.layers[il].attn[1], cur), n_embd_gqa / n_head_kv, n_head_kv, N),
-          n_past, n_rot, 0, 0);
-      Vcur = ne_transpose(ctx0, ne_reshape_2d(ctx0, ne_mul_mat(ctx0, model.layers[il].attn[2], cur), n_embd_gqa, N));
+      Qcur = ne_reshape_3d(ctx0, ne_mul_mat(ctx0, model.layers[il].attn[0], cur), head_size, n_head, N);
+      Kcur = ne_reshape_3d(ctx0, ne_mul_mat(ctx0, model.layers[il].attn[1], cur), head_size, n_head_kv, N);
+      Vcur = ne_mul_mat(ctx0, model.layers[il].attn[2], cur);
     }
+    Qcur = ne_rope_inplace(ctx0, Qcur, std::max(n_cached - N, n_past), n_rot, 0, 0);
     ne_set_name(Qcur, "Qcur");
+    Kcur = ne_rope_inplace(  // n_ctx exceeds but it will be shift-roped back with cached K
+        ctx0, Kcur, (n_past == n_total ? n_past : n_ctx), n_rot, 0, 0);
     ne_set_name(Kcur, "Kcur");
+    Vcur = ne_transpose(ctx0, ne_reshape_2d(ctx0, Vcur, head_size * n_head_kv, N));
     ne_set_name(Vcur, "Vcur");
     // self-attention
     const float attn_scale = 1.0f / sqrtf(float(head_size));
@@ -211,14 +203,19 @@ static bool llama_model_eval_internal(model_context& lctx, const model_token* to
       struct ne_tensor* Q = ne_permute(ctx0, Qcur, 0, 2, 1, 3);
       ne_set_name(Q, "Q");
 
-      struct ne_tensor* K = ne_permute(ctx0,
-                                       ne_reshape_3d(ctx0,
-                                                     ne_view_1d(ctx0, kv_self.k, (n_past + N) * n_embd_gqa,
-                                                                il * n_ctx * ne_element_size(kv_self.k) * n_embd_gqa),
-                                                     n_embd_gqa / n_head_kv, n_head_kv, n_past + N),
-                                       0, 2, 1, 3);
+      struct ne_tensor* K = ne_reshape_3d(
+          ctx0,
+          ne_view_1d(ctx0, kv_self.k, n_cached * n_embd_gqa, il * n_ctx * ne_element_size(kv_self.k) * n_embd_gqa),
+          n_embd_gqa / n_head_kv, n_head_kv, n_cached);
+      if (shift_roped_k && n_total > n_past) {
+        struct ne_tensor* cossin_cache = nullptr;
+        // Currently we only cache cossin for N == 1 in model-wide; It may be worthwhile to cache cossin for other N in
+        // a single eval execution
+        if (N == 1) cossin_cache = kv_self.cossin;
+        K = ne_rope_shift_inplace(ctx0, K, -N, n_rot, 0, 0, n_keep, cossin_cache);
+      }
+      K = ne_permute(ctx0, K, 0, 2, 1, 3);
       ne_set_name(K, "K");
-
       // K * Q
       struct ne_tensor* KQ = ne_mul_mat(ctx0, K, Q);
       ne_set_name(KQ, "KQ");
@@ -227,21 +224,23 @@ static bool llama_model_eval_internal(model_context& lctx, const model_token* to
       struct ne_tensor* KQ_scale = ne_new_f32(ctx0, attn_scale);
       ne_set_name(KQ_scale, "1/sqrt(n_embd/n_head)");
 
-      // KQ_scaled shape [n_past + N, N, n_head, 1]
+      // KQ_scaled shape [n_cached, N, n_head, 1]
       struct ne_tensor* KQ_scaled = ne_scale_inplace(ctx0, KQ, KQ_scale);
       ne_set_name(KQ_scaled, "KQ_scaled");
 
       // KQ_masked = mask_past(KQ_scaled)
-      struct ne_tensor* KQ_masked = ne_diag_mask_inf_inplace(ctx0, KQ_scaled, n_past);
-      ne_set_name(KQ_masked, "KQ_masked");
+      if (n_total == 0) {
+        KQ_scaled = ne_diag_mask_inf_inplace(ctx0, KQ_scaled, n_past);
+        ne_set_name(KQ_scaled, "KQ_masked");
+      }
 
       // KQ = soft_max(KQ_masked)
-      struct ne_tensor* KQ_soft_max = ne_soft_max_inplace(ctx0, KQ_masked);
+      struct ne_tensor* KQ_soft_max = ne_soft_max_inplace(ctx0, KQ_scaled);
       ne_set_name(KQ_soft_max, "KQ_soft_max");
 
       // split cached V into n_head heads
       struct ne_tensor* V =
-          ne_view_3d(ctx0, kv_self.v, n_past + N, n_embd_gqa / n_head_kv, n_head_kv, n_ctx * ne_element_size(kv_self.v),
+          ne_view_3d(ctx0, kv_self.v, n_cached, n_embd_gqa / n_head_kv, n_head_kv, n_ctx * ne_element_size(kv_self.v),
                      n_ctx * ne_element_size(kv_self.v) * n_embd_gqa / n_head_kv,
                      n_ctx * ne_element_size(kv_self.v) * n_embd_gqa * il);
       ne_set_name(V, "V");
@@ -260,8 +259,7 @@ static bool llama_model_eval_internal(model_context& lctx, const model_token* to
       // projection (no bias)
       cur = ne_mul_mat(ctx0, model.layers[il].attn[3], cur);
     } else {
-      const auto seq_kv = n_past + N;
-
+      NE_ASSERT(("Fused-attention does not support ring-ed K-cache!", n_past == n_total));
       const auto k_size = kv_cache_info.k_bytes;
       const auto v_size = kv_cache_info.v_bytes;
       // store key and value to memory
@@ -285,14 +283,14 @@ static bool llama_model_eval_internal(model_context& lctx, const model_token* to
 
       struct ne_tensor* K =
           ne_view_3d(ctx0, kv_self.k,                                             // tensor
-                     head_size, seq_kv, n_head,                                   // ne
+                     head_size, n_cached, n_head,                                 // ne
                      kv_cache_info.stride_k_sl, kv_cache_info.stride_k_head_num,  // nb (jblas managed)
                      il * k_size);                                                // offset
       *reinterpret_cast<ATTN_FWD_LAYOUT*>(&K->nb[0]) = kv_cache_info.k_layout;    // us nb0 for layout
       ne_set_name(K, "K");
       struct ne_tensor* V =
           ne_view_3d(ctx0, kv_self.v,                                                    // tensor
-                     seq_kv, head_size, n_head,                                          // ne
+                     n_cached, head_size, n_head,                                        // ne
                      kv_cache_info.stride_v_head_size, kv_cache_info.stride_v_head_num,  // nb (jblas managed)
                      il * v_size);                                                       // offset
       *reinterpret_cast<ATTN_FWD_LAYOUT*>(&V->nb[0]) = kv_cache_info.v_layout;           // us nb0 for layout
@@ -387,7 +385,7 @@ static bool llama_model_eval_internal(model_context& lctx, const model_token* to
 #endif
 
   // update kv token count
-  lctx.model.kv_self.n = n_past + N;
+  lctx.model.kv_self.n = n_cached;
 
   // extract logits
   {

--- a/intel_extension_for_transformers/llm/runtime/graph/models/llama/llama.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/llama/llama.h
@@ -46,12 +46,12 @@ class Llama : public IModel {
   model_archs arch = MODEL_LLAMA;
   std::unique_ptr<model_model_loader> ml;
   uint32_t n_layer, n_embd, n_ff, n_vocab, n_head, n_head_kv;
-  int n_ctx, n_gpu_layer;
+  int n_gpu_layer;
   bool use_mmap, use_mlock, vocab_only;
   model_scratch scratch;
 
  public:
-  void init(const char* path_model, model_context& lctx, int n_ctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
+  void init(const char* path_model, model_context& lctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
             bool vocab_only_) override;
   void load(model_context& lctx, model_progress_callback progress_callback, void* progress_callback_user_data) override;
 };

--- a/intel_extension_for_transformers/llm/runtime/graph/models/llama/llama_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/llama/llama_utils.cpp
@@ -42,14 +42,11 @@
 void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data) {
-  lctx.t_start_us = ne_time_us();
-
-  std::unique_ptr<IModel> ms(new Llama());
+  std::unique_ptr<Llama> ms(new Llama());
   ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
 
   lctx.support_jblas_kv = true;
-  lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 
 void Llama::init(const char* path_model, model_context& lctx, int n_gpu_layer_, bool use_mmap_, bool use_mlock_,

--- a/intel_extension_for_transformers/llm/runtime/graph/models/llama/llama_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/llama/llama_utils.cpp
@@ -39,22 +39,21 @@
 #include "models/model_utils/util.h"
 #include "models/models.h"
 
-void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_ctx, int n_gpu_layers,
+void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data) {
   lctx.t_start_us = ne_time_us();
 
   std::unique_ptr<IModel> ms(new Llama());
-  ms->init(fname.c_str(), lctx, n_ctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
+  ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
 
   lctx.support_jblas_kv = true;
   lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 
-void Llama::init(const char* path_model, model_context& lctx, int n_ctx_, int n_gpu_layer_, bool use_mmap_,
-                 bool use_mlock_, bool vocab_only_) {
-  n_ctx = n_ctx_;
+void Llama::init(const char* path_model, model_context& lctx, int n_gpu_layer_, bool use_mmap_, bool use_mlock_,
+                 bool vocab_only_) {
   n_gpu_layer = n_gpu_layer_;
   use_mmap = use_mmap_;
   use_mlock = use_mlock_;
@@ -65,14 +64,12 @@ void Llama::init(const char* path_model, model_context& lctx, int n_ctx_, int n_
   model.hparams = ml->file_loaders.at(0)->hparams;
   model_file_version file_version = ml->file_loaders.at(0)->file_version;
   auto& hparams = model.hparams;
-  hparams.n_ctx = n_ctx;
   n_ff = hparams.ffn_hidden_size;
   fprintf(stderr, "%s: n_vocab    = %u\n", __func__, hparams.n_vocab);
-  fprintf(stderr, "%s: n_ctx      = %u\n", __func__, hparams.n_ctx);
   fprintf(stderr, "%s: n_embd     = %u\n", __func__, hparams.n_embd);
   fprintf(stderr, "%s: n_mult     = %u\n", __func__, hparams.n_mult);
   fprintf(stderr, "%s: n_head     = %u\n", __func__, hparams.n_head);
-  fprintf(stderr, "%s: n_head_kv    = %u\n", __func__, hparams.n_head_kv);
+  fprintf(stderr, "%s: n_head_kv  = %u\n", __func__, hparams.n_head_kv);
   fprintf(stderr, "%s: n_layer    = %u\n", __func__, hparams.n_layer);
   fprintf(stderr, "%s: n_rot      = %u\n", __func__, hparams.n_rot);
   fprintf(stderr, "%s: n_ff       = %u\n", __func__, n_ff);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/arg_parse.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/arg_parse.cpp
@@ -247,6 +247,8 @@ bool gpt_params_parse(int argc, char** argv, gpt_params& params) {
         break;
       }
       params.n_discard = std::stoi(argv[i]);
+    } else if (arg == "--shift-roped-k") {
+      params.shift_roped_k = true;
     } else if (arg == "-m" || arg == "--model") {
       if (++i >= argc) {
         invalid_param = true;
@@ -465,6 +467,9 @@ void gpt_print_usage(int /*argc*/, char** argv, const gpt_params& params) {
           "  --n_discard           number of tokens will be discarded (default: %d, -1 = half of tokens will be "
           "discarded)\n",
           params.n_discard);
+  fprintf(stderr,
+          "  --shift-roped-k       RoPE-shift the cache K instead of recomputing after reaching context size (default: "
+          "disabled)\n");
   if (model_mlock_supported()) {
     fprintf(stderr, "  --mlock               force system to keep model in RAM rather than swapping or compressing\n");
   }

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/arg_parse.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/arg_parse.cpp
@@ -468,8 +468,8 @@ void gpt_print_usage(int /*argc*/, char** argv, const gpt_params& params) {
           "discarded)\n",
           params.n_discard);
   fprintf(stderr,
-          "  --shift-roped-k       RoPE-shift the cache K instead of recomputing after reaching context size (default: "
-          "disabled)\n");
+          "  --shift-roped-k       use ring-buffer and thus do not need re-computing after reaching context size "
+          "(default: disabled)\n");
   if (model_mlock_supported()) {
     fprintf(stderr, "  --mlock               force system to keep model in RAM rather than swapping or compressing\n");
   }

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_config.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_config.h
@@ -34,10 +34,12 @@ struct gpt_params {
   int n_layers;
   int32_t seed = -1;  // RNG seed
   int32_t n_threads = get_num_physical_cores();
-  int32_t n_predict = -1;    // new tokens to predict
-  int32_t n_ctx = 512;       // context size
+  int32_t n_predict = -1;  // new tokens to predict
+  int32_t n_ctx = 512;     // context size
+  // start size to keep; n_ctx = n_keep + n_recent; refer the streaming-llm paper for details:
+  // https://arxiv.org/abs/2309.17453
+  int32_t n_keep = 0;
   int32_t n_batch = 512;     // batch size for prompt processing (must be >=32 to use BLAS)
-  int32_t n_keep = 0;        // number of tokens to keep from initial prompt
   int32_t n_discard = -1;    // number of tokens to drop when reaching n_ctx
   int32_t n_gpu_layers = 0;  // number of layers to store in VRAM
 
@@ -111,5 +113,5 @@ std::vector<model_token> model_tokenize(struct model_context* ctx, const std::st
 struct model_context* model_init_from_gpt_params(const gpt_params& params);
 
 // KV cache elements per layer per batch per beam
-void get_batch_kv_elements_from_gpt_params(const struct model_hparams& hparams, ne_type wtype, int32_t* k_size,
+void get_batch_kv_elements_from_gpt_params(int heads_kv, int head_size, int n_ctx, ne_type wtype, int32_t* k_size,
                                            int32_t* v_size);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_config.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_config.h
@@ -75,6 +75,7 @@ struct gpt_params {
   std::string lora_base = "";     // base model path for the lora adapter
 
   KV_MEM_TYPE memory_type = KV_MEM_TYPE_AUTO;  // Memory kv data type
+  bool shift_roped_k = false;                  // whether to store non-RoPEd K cache
   bool random_prompt = false;                  // do not randomize prompt if none provided
   bool use_color = false;                      // use color to distinguish generations and inputs
   bool interactive = false;                    // interactive mode

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_types.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_types.h
@@ -111,7 +111,6 @@ enum model_file_version {
 // default hparams (LLaMA 7B)
 struct model_hparams {
   uint32_t n_vocab = 32000;
-  uint32_t n_ctx = 512;  // this is provided as user input?
   uint32_t n_embd = 4096;
   uint32_t n_mult = 256;
   uint32_t n_head = 32;
@@ -251,6 +250,11 @@ struct model_context {
   int32_t n_eval = 0;    // number of eval calls
   int32_t n_p_eval = 0;  // number of tokens in eval calls for the prompt (with batch size > 1)
 
+  int32_t n_ctx = 512;  // number of tokens to keep as context
+  // start size to keep; n_ctx = n_keep + n_recent; refer the streaming-llm paper for details:
+  // https://arxiv.org/abs/2309.17453
+  int32_t n_keep = 0;
+
   model_struct model;
   model_vocab vocab;
   int batch_size = 1;
@@ -336,8 +340,11 @@ typedef struct model_token_data_array {
 typedef void (*model_progress_callback)(float progress, void* ctx);
 
 struct model_context_params {
-  model_archs arch;     // arch of models (GPT-J, LLAMA)
-  int n_ctx;            // text context
+  model_archs arch;  // arch of models (GPT-J, LLAMA)
+  int n_ctx;         // text context
+  // start size to keep; n_ctx = n_keep + n_recent; refer the streaming-llm paper for details:
+  // https://arxiv.org/abs/2309.17453
+  int n_keep;
   int n_gpu_layers;     // number of layers to store in VRAM
   int seed;             // RNG seed, -1 for random
   KV_MEM_TYPE kv_type;  // KV cache type specification

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_types.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_types.h
@@ -154,6 +154,7 @@ struct model_layer {
 struct model_kv_cache {
   struct ne_tensor* k;
   struct ne_tensor* v;
+  struct ne_tensor* cossin = NULL;  // cached cos/-sin value for shifting RoPE
 
   struct ne_context* ctx = NULL;
 
@@ -259,6 +260,7 @@ struct model_context {
   model_vocab vocab;
   int batch_size = 1;
   bool beam_search = false;
+  bool shift_roped_k = false;     // whether to store non-RoPEd K cache
   bool support_jblas_kv = false;  // whether the model graph supports jblas-kvcache
   int beam_size = 1;
   int kv_n_ctx_block = 1;
@@ -356,6 +358,7 @@ struct model_context_params {
   int batch_size;       // batch_size of prompt
   bool beam_search;     // beam search or not
   int beam_size;        // number of beams for beam search
+  bool shift_roped_k;   // whether to store non-RoPEd K cache
 
   // called with a progress value between 0 and 1, pass NULL to disable
   model_progress_callback progress_callback;

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_types.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_types.h
@@ -154,7 +154,7 @@ struct model_layer {
 struct model_kv_cache {
   struct ne_tensor* k;
   struct ne_tensor* v;
-  struct ne_tensor* cossin = NULL;  // cached cos/-sin value for shifting RoPE
+  struct ne_tensor* cossin = NULL;  // cached cos/sin value for shifting RoPE
 
   struct ne_context* ctx = NULL;
 

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_utils.cpp
@@ -135,21 +135,21 @@ static bool kv_cache_init(const struct model_hparams& hparams, struct model_kv_c
   if (shift_roped_k) {  // prepare rope helper for fused-attention
     const auto cossin_dtype = wtype == NE_TYPE_JBLAS ? NE_TYPE_F16 : wtype;
     cache.cossin = ne_new_tensor_1d(cache.ctx, cossin_dtype, head_size, NE_SIZE_CALC);
-    ne_set_name(cache.cossin, "cos-sin(-1)");
+    ne_set_name(cache.cossin, "cossin(-1)");
     float theta = -1;
     float theta_scale = std::pow(10000.f, -2.0f / head_size);
     if (cossin_dtype == NE_TYPE_F16) {
       const auto data = reinterpret_cast<ne_fp16_t*>(cache.cossin->data);
       for (int i = 0; i < head_size; i += 2) {
         data[i + 0] = NE_FP32_TO_FP16(std::cos(theta));
-        data[i + 1] = NE_FP32_TO_FP16(std::sin(-theta));
+        data[i + 1] = NE_FP32_TO_FP16(std::sin(theta));
         theta *= theta_scale;
       }
     } else if (cossin_dtype == NE_TYPE_F32) {
       const auto data = reinterpret_cast<float*>(cache.cossin->data);
       for (int i = 0; i < head_size; i += 2) {
         data[i + 0] = std::cos(theta);
-        data[i + 1] = std::sin(-theta);
+        data[i + 1] = std::sin(theta);
         theta *= theta_scale;
       }
     } else {

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_utils.cpp
@@ -208,9 +208,11 @@ static bool model_load(const std::string& fname, model_archs arch, model_context
                        bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                        void* progress_callback_user_data) {
   try {
+    lctx.t_start_us = ne_time_us();
     lctx.model.arch = arch;
     model_load_internal(fname, arch, lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only, progress_callback,
                         progress_callback_user_data);
+    lctx.t_load_us = ne_time_us() - lctx.t_start_us;
     return true;
   } catch (const std::string& err) {
     fprintf(stderr, "error loading model: %s\n", err.c_str());

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_utils.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_utils.h
@@ -94,7 +94,7 @@ MODEL_API int model_apply_lora_from_file(struct model_context* ctx, const char* 
                                          int n_threads);
 
 // Returns the number of tokens in the KV cache
-MODEL_API int model_get_kv_cache_token_total(const struct model_context* ctx);
+MODEL_API int model_get_kv_cache_token_count(const struct model_context* ctx);
 
 // Sets the current rng seed.
 MODEL_API void model_set_rng_seed(struct model_context* ctx, int seed);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_utils.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_utils.h
@@ -50,7 +50,7 @@
 #define MODEL_SESSION_MAGIC MODEL_FILE_MAGIC_GGSN
 #define MODEL_SESSION_VERSION 1
 
-void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_ctx, int n_gpu_layers,
+void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data);
 
@@ -94,7 +94,7 @@ MODEL_API int model_apply_lora_from_file(struct model_context* ctx, const char* 
                                          int n_threads);
 
 // Returns the number of tokens in the KV cache
-MODEL_API int model_get_kv_cache_token_count(const struct model_context* ctx);
+MODEL_API int model_get_kv_cache_token_total(const struct model_context* ctx);
 
 // Sets the current rng seed.
 MODEL_API void model_set_rng_seed(struct model_context* ctx, int seed);
@@ -114,15 +114,17 @@ MODEL_API size_t model_set_state_data(struct model_context* ctx, uint8_t* src);
 
 // Save/load session file
 MODEL_API bool model_load_session_file(struct model_context* ctx, const char* path_session, model_token* tokens_out,
-                                       size_t n_token_capacity, size_t* n_token_count_out);
+                                       size_t n_token_capacity, size_t* n_token_total_out);
 MODEL_API bool model_save_session_file(struct model_context* ctx, const char* path_session, const model_token* tokens,
-                                       size_t n_token_count);
+                                       size_t n_token_total);
 
 // Run the model inference to obtain the logits and probabilities for the next
 // token. tokens + n_tokens is the provided batch of new tokens to process
-// n_past is the number of tokens to use from previous eval calls
+// n_past is the offset to which the kv is cached to
+// n_total is the number of tokens evaluated in previous eval calls
 // Returns 0 on success
-MODEL_API int model_eval(struct model_context* ctx, const model_token* tokens, int n_tokens, int n_past, int n_threads);
+MODEL_API int model_eval(struct model_context* ctx, const model_token* tokens, int n_tokens, int n_past, int n_total,
+                         int n_threads);
 
 // Convert the provided text into tokens.
 // The tokens pointer must be large enough to hold the resulting tokens.
@@ -369,7 +371,7 @@ class beam_search_kv_cache_reorder {
  public:
   explicit beam_search_kv_cache_reorder(model_context* lctx)
       : ctx(lctx),
-        n_ctx(lctx->model.hparams.n_ctx),
+        n_ctx(lctx->n_ctx),
         n_embd(lctx->model.hparams.n_embd),
         head_dim(lctx->model.hparams.n_embd / lctx->model.hparams.n_head),
         n_head(lctx->model.hparams.n_head),
@@ -419,6 +421,7 @@ class beam_search_flow {
   std::vector<beam_hypotheses> beam_hypos;
   std::vector<bool> requests_done;
   uint32_t n_past = 0;
+  uint32_t n_total = 0;
   uint32_t n_prompt_tokens = 0;
   int num_threads = 4;  // default by 4
   logits_processor lp;

--- a/intel_extension_for_transformers/llm/runtime/graph/models/models.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/models.h
@@ -17,8 +17,8 @@
 #include "models/model_utils/model_types.h"
 
 struct IModel {
-  virtual void init(const char* path_model, model_context& lctx, int n_ctx, int n_gpu_layers, bool use_mmap,
-                    bool use_mlock, bool vocab_only) = 0;
+  virtual void init(const char* path_model, model_context& lctx, int n_gpu_layers, bool use_mmap, bool use_mlock,
+                    bool vocab_only) = 0;
   virtual void load(model_context& lctx, model_progress_callback progress_callback,
                     void* progress_callback_user_data) = 0;
 };

--- a/intel_extension_for_transformers/llm/runtime/graph/models/mpt/mpt.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/mpt/mpt.cpp
@@ -41,11 +41,12 @@
 //
 //   - lctx:      model context
 //   - tokens:    new batch of tokens to process
-//   - n_past:    the context size so far
+//   - n_past:    the offset to which the kv is cached to
+//   - n_total:   the number of tokens evaluated so far (including evicted tokens if there is any)
 //   - n_threads: number of threads to use
 //
 static bool mpt_model_eval_internal(model_context& lctx, const model_token* tokens, const int n_tokens,
-                                    const int n_past, const int n_threads) {
+                                    const int n_past, const int n_total, const int n_threads) {
   const int64_t t_start_us = ne_time_us();
 
   const int N = n_tokens;
@@ -61,7 +62,8 @@ static bool mpt_model_eval_internal(model_context& lctx, const model_token* toke
 
   const int n_embd = hparams.n_embd;
   const int n_layer = hparams.n_layer;
-  const int n_ctx = hparams.n_ctx;
+  const int n_ctx = lctx.n_ctx;
+  const int n_keep = lctx.n_keep;
   const int n_head = hparams.n_head;
   const int n_vocab = hparams.n_vocab;
   const int head_dim = hparams.n_embd / hparams.n_head;
@@ -347,8 +349,9 @@ static bool mpt_model_eval_internal(model_context& lctx, const model_token* toke
   return true;
 }
 
-int model_eval(struct model_context* ctx, const model_token* tokens, int n_tokens, int n_past, int n_threads) {
-  if (!mpt_model_eval_internal(*ctx, tokens, n_tokens, n_past, n_threads)) {
+int model_eval(struct model_context* ctx, const model_token* tokens, int n_tokens, int n_past, int n_total,
+               int n_threads) {
+  if (!mpt_model_eval_internal(*ctx, tokens, n_tokens, n_past, n_total, n_threads)) {
     fprintf(stderr, "%s: failed to eval\n", __func__);
     return 1;
   }

--- a/intel_extension_for_transformers/llm/runtime/graph/models/mpt/mpt.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/mpt/mpt.h
@@ -40,12 +40,12 @@ class MPT : public IModel {
   model_archs arch = MODEL_MPT;
   std::unique_ptr<model_model_loader> ml;
   uint32_t n_layer, n_embd, n_ff, n_vocab;
-  int n_ctx, n_gpu_layer;
+  int n_gpu_layer;
   bool use_mmap, use_mlock, vocab_only;
   model_scratch scratch;
 
  public:
-  void init(const char* path_model, model_context& lctx, int n_ctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
+  void init(const char* path_model, model_context& lctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
             bool vocab_only_) override;
   void load(model_context& lctx, model_progress_callback progress_callback, void* progress_callback_user_data) override;
 };

--- a/intel_extension_for_transformers/llm/runtime/graph/models/mpt/mpt_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/mpt/mpt_utils.cpp
@@ -42,14 +42,11 @@
 void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data) {
-  lctx.t_start_us = ne_time_us();
-
-  std::unique_ptr<IModel> ms(new MPT());
+  std::unique_ptr<MPT> ms(new MPT());
   ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
 
   lctx.support_jblas_kv = true;
-  lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 
 void MPT::init(const char* path_model, model_context& lctx, int n_gpu_layer_, bool use_mmap_, bool use_mlock_,

--- a/intel_extension_for_transformers/llm/runtime/graph/models/mpt/mpt_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/mpt/mpt_utils.cpp
@@ -39,22 +39,21 @@
 #include "models/model_utils/util.h"
 #include "models/models.h"
 
-void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_ctx, int n_gpu_layers,
+void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data) {
   lctx.t_start_us = ne_time_us();
 
   std::unique_ptr<IModel> ms(new MPT());
-  ms->init(fname.c_str(), lctx, n_ctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
+  ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
 
   lctx.support_jblas_kv = true;
   lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 
-void MPT::init(const char* path_model, model_context& lctx, int n_ctx_, int n_gpu_layer_, bool use_mmap_,
-               bool use_mlock_, bool vocab_only_) {
-  n_ctx = n_ctx_;
+void MPT::init(const char* path_model, model_context& lctx, int n_gpu_layer_, bool use_mmap_, bool use_mlock_,
+               bool vocab_only_) {
   n_gpu_layer = n_gpu_layer_;
   use_mmap = use_mmap_;
   use_mlock = use_mlock_;
@@ -66,9 +65,7 @@ void MPT::init(const char* path_model, model_context& lctx, int n_ctx_, int n_gp
   model_file_version file_version = ml->file_loaders.at(0)->file_version;
   auto& hparams = model.hparams;
   n_ff = 4 * hparams.n_embd;
-  hparams.n_ctx = n_ctx;
   fprintf(stderr, "%s: n_vocab    = %u\n", __func__, hparams.n_vocab);
-  fprintf(stderr, "%s: n_ctx      = %u\n", __func__, hparams.n_ctx);
   fprintf(stderr, "%s: n_embd     = %u\n", __func__, hparams.n_embd);
   fprintf(stderr, "%s: n_mult     = %u\n", __func__, hparams.n_mult);
   fprintf(stderr, "%s: n_head     = %u\n", __func__, hparams.n_head);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/opt/opt.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/opt/opt.h
@@ -59,13 +59,13 @@ class OPT : public IModel {
   std::unique_ptr<model_model_loader> ml;
   uint32_t n_layer, n_embd, n_ff, n_vocab, word_embed_proj_dim, max_seq_len;
   bool do_layer_norm_before = true;
-  int n_ctx, n_gpu_layer;
+  int n_gpu_layer;
   ne_type memory_type;
   bool use_mmap, use_mlock, vocab_only;
   model_scratch scratch;
 
  public:
-  void init(const char* path_model, model_context& lctx, int n_ctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
+  void init(const char* path_model, model_context& lctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
             bool vocab_only_) override;
   void load(model_context& lctx, model_progress_callback progress_callback, void* progress_callback_user_data) override;
 };

--- a/intel_extension_for_transformers/llm/runtime/graph/models/opt/opt_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/opt/opt_utils.cpp
@@ -38,21 +38,20 @@
 #include "models/model_utils/model_utils.h"
 #include "models/model_utils/util.h"
 #include "models/models.h"
-void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_ctx, int n_gpu_layers,
+void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data) {
   lctx.t_start_us = ne_time_us();
 
   std::unique_ptr<IModel> ms(new OPT());
-  ms->init(fname.c_str(), lctx, n_ctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
+  ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
 
   lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 
-void OPT::init(const char* path_model, model_context& lctx, int n_ctx_, int n_gpu_layer_, bool use_mmap_,
-               bool use_mlock_, bool vocab_only_) {
-  n_ctx = n_ctx_;
+void OPT::init(const char* path_model, model_context& lctx, int n_gpu_layer_, bool use_mmap_, bool use_mlock_,
+               bool vocab_only_) {
   n_gpu_layer = n_gpu_layer_;
   use_mmap = use_mmap_;
   use_mlock = use_mlock_;
@@ -64,9 +63,7 @@ void OPT::init(const char* path_model, model_context& lctx, int n_ctx_, int n_gp
   model_file_version file_version = ml->file_loaders.at(0)->file_version;
   auto& hparams = model.hparams;
   n_ff = 4 * hparams.n_embd;
-  hparams.n_ctx = n_ctx;
   fprintf(stderr, "%s: n_vocab                  = %u\n", __func__, hparams.n_vocab);
-  fprintf(stderr, "%s: n_ctx                    = %u\n", __func__, hparams.n_ctx);
   fprintf(stderr, "%s: n_embd                   = %u\n", __func__, hparams.n_embd);
   fprintf(stderr, "%s: n_head                   = %u\n", __func__, hparams.n_head);
   fprintf(stderr, "%s: n_layer                  = %u\n", __func__, hparams.n_layer);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/opt/opt_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/opt/opt_utils.cpp
@@ -41,13 +41,9 @@
 void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data) {
-  lctx.t_start_us = ne_time_us();
-
-  std::unique_ptr<IModel> ms(new OPT());
+  std::unique_ptr<OPT> ms(new OPT());
   ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
-
-  lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 
 void OPT::init(const char* path_model, model_context& lctx, int n_gpu_layer_, bool use_mmap_, bool use_mlock_,

--- a/intel_extension_for_transformers/llm/runtime/graph/models/starcoder/starcoder.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/starcoder/starcoder.cpp
@@ -41,11 +41,12 @@
 //
 //   - lctx:      model context
 //   - tokens:    new batch of tokens to process
-//   - n_past:    the context size so far
+//   - n_past:    the offset to which the kv is cached to
+//   - n_total:   the number of tokens evaluated so far (including evicted tokens if there is any)
 //   - n_threads: number of threads to use
 //
 static bool starcoder_model_eval_internal(model_context& lctx, const model_token* tokens, const int n_tokens,
-                                          const int n_past, const int n_threads) {
+                                          const int n_past, const int n_total, const int n_threads) {
   const int64_t t_start_us = ne_time_us();
 
   const int N = n_tokens;
@@ -61,7 +62,8 @@ static bool starcoder_model_eval_internal(model_context& lctx, const model_token
 
   const int n_embd = hparams.n_embd;
   const int n_layer = hparams.n_layer;
-  const int n_ctx = hparams.n_ctx;
+  const int n_ctx = lctx.n_ctx;
+  const int n_keep = lctx.n_keep;
   const int n_head = hparams.n_head;
   const int n_vocab = hparams.n_vocab;
   const int n_rot = hparams.n_rot;
@@ -372,8 +374,9 @@ static bool starcoder_model_eval_internal(model_context& lctx, const model_token
   return true;
 }
 
-int model_eval(struct model_context* ctx, const model_token* tokens, int n_tokens, int n_past, int n_threads) {
-  if (!starcoder_model_eval_internal(*ctx, tokens, n_tokens, n_past, n_threads)) {
+int model_eval(struct model_context* ctx, const model_token* tokens, int n_tokens, int n_past, int n_total,
+               int n_threads) {
+  if (!starcoder_model_eval_internal(*ctx, tokens, n_tokens, n_past, n_total, n_threads)) {
     fprintf(stderr, "%s: failed to eval\n", __func__);
     return 1;
   }

--- a/intel_extension_for_transformers/llm/runtime/graph/models/starcoder/starcoder.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/starcoder/starcoder.h
@@ -44,12 +44,12 @@ class STARCODER : public IModel {
   model_archs arch = MODEL_STARCODER;
   std::unique_ptr<model_model_loader> ml;
   uint32_t n_layer, n_embd, n_ff, n_vocab;
-  int n_ctx, n_gpu_layer;
+  int n_gpu_layer;
   bool use_mmap, use_mlock, vocab_only;
   model_scratch scratch;
 
  public:
-  void init(const char* path_model, model_context& lctx, int n_ctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
+  void init(const char* path_model, model_context& lctx, int n_gpu_layers, bool use_mmap_, bool use_mlock_,
             bool vocab_only_) override;
   void load(model_context& lctx, model_progress_callback progress_callback, void* progress_callback_user_data) override;
 };

--- a/intel_extension_for_transformers/llm/runtime/graph/models/starcoder/starcoder_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/starcoder/starcoder_utils.cpp
@@ -42,13 +42,9 @@
 void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data) {
-  lctx.t_start_us = ne_time_us();
-
-  std::unique_ptr<IModel> ms(new STARCODER());
+  std::unique_ptr<STARCODER> ms(new STARCODER());
   ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
-
-  lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 
 void STARCODER::init(const char* path_model, model_context& lctx, int n_gpu_layer_, bool use_mmap_, bool use_mlock_,

--- a/intel_extension_for_transformers/llm/runtime/graph/models/starcoder/starcoder_utils.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/starcoder/starcoder_utils.cpp
@@ -39,21 +39,20 @@
 #include "models/model_utils/util.h"
 #include "models/models.h"
 
-void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_ctx, int n_gpu_layers,
+void model_load_internal(const std::string& fname, model_archs arch, model_context& lctx, int n_gpu_layers,
                          bool use_mmap, bool use_mlock, bool vocab_only, model_progress_callback progress_callback,
                          void* progress_callback_user_data) {
   lctx.t_start_us = ne_time_us();
 
   std::unique_ptr<IModel> ms(new STARCODER());
-  ms->init(fname.c_str(), lctx, n_ctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
+  ms->init(fname.c_str(), lctx, n_gpu_layers, use_mmap, use_mlock, vocab_only);
   ms->load(lctx, progress_callback, progress_callback_user_data);
 
   lctx.t_load_us = ne_time_us() - lctx.t_start_us;
 }
 
-void STARCODER::init(const char* path_model, model_context& lctx, int n_ctx_, int n_gpu_layer_, bool use_mmap_,
-                     bool use_mlock_, bool vocab_only_) {
-  n_ctx = n_ctx_;
+void STARCODER::init(const char* path_model, model_context& lctx, int n_gpu_layer_, bool use_mmap_, bool use_mlock_,
+                     bool vocab_only_) {
   n_gpu_layer = n_gpu_layer_;
   use_mmap = use_mmap_;
   use_mlock = use_mlock_;
@@ -65,9 +64,7 @@ void STARCODER::init(const char* path_model, model_context& lctx, int n_ctx_, in
   model_file_version file_version = ml->file_loaders.at(0)->file_version;
   auto& hparams = model.hparams;
   n_ff = 4 * hparams.n_embd;
-  hparams.n_ctx = n_ctx;
   fprintf(stderr, "%s: n_vocab    = %u\n", __func__, hparams.n_vocab);
-  fprintf(stderr, "%s: n_ctx      = %u\n", __func__, hparams.n_ctx);
   fprintf(stderr, "%s: n_embd     = %u\n", __func__, hparams.n_embd);
   fprintf(stderr, "%s: n_mult     = %u\n", __func__, hparams.n_mult);
   fprintf(stderr, "%s: n_head     = %u\n", __func__, hparams.n_head);


### PR DESCRIPTION
## Type of Change: feature
API change: add switch `--shift-roped-k` to the C++ API 

## Description
Support shifting RoPE-ed K-cache after the KV-cache is filled up **for llama**.

Per-model changes:
- `n_ctx` is now a field of `model_context` rathe then model class themselves, together with the added `n_keep` and `shift_roped_k`. It is also more semantic as `n_ctx` is read from args rather than model files. 
- Added an extra argument `n_total` for `xxx_model_eval_internal`, which provides the number of tokens evaluated so far (including evicted tokens if there is any). Note: `n_past` is used as the offset to which the KV is cached to even before this PR
- in `xxx_utils.cpp`, the template argument of the `unique_ptr` in `model_load_internal` are corrected to the derived classes
- Time are calculated outside of the `xxx_utils.cpp`

Note: The version for fused-attention will be implemented in a later PR

## Expected Behavior & Potential Risk
N/A

## How has this PR been tested?
<details>
<summary>Accuracy Tests Details:</summary>

- <details>
  <summary>
  graph-streaming-llm-shift-rope <code>numactl -m 1 -C 56-111 bin/run_llama -m /home_local/dingyi/data/llama-7b-hf-pr573-q4j-sym-int8-fp32-g128.bin --seed 1234 -t 56 -b 1024 -c 64 -n 128 --keep 4 --memory-f16 --shift-roped-k -p "$GIRL_PROMPT"</code>
  </summary>

  > Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun.
Then one day, her parents took the little girl on an adventure, that she would never forget. They drove their tiny car, through a dark tunnel, where nothing could be seen, but the stars above. Afterwards, as the days went by, the little girl thought of this place, and how she felt there, inside of it. It was not a place to get lost, or to find treasure. The child wondered at its vastness, with so many people there, and yet no one ever spoke, or even moved very much, except those who were in service.
She did know, though,
  </details>
</details>

## Dependency Change?
No