### PR TITLE
[LLM] Adapt to transformers 4.34

### DIFF
--- a/intel_extension_for_transformers/transformers/utils/utility.py
+++ b/intel_extension_for_transformers/transformers/utils/utility.py
@@ -88,6 +88,7 @@ def generate_dummy_past_key_values(input_bs, model):
     num_attention_heads = normalized_config.num_attention_heads
     hidden_size = normalized_config.hidden_size
     d_k = hidden_size // num_attention_heads
+    num_key_value_heads = num_attention_heads
     if hasattr(normalized_config, "num_key_value_heads"):
         num_key_value_heads = normalized_config.num_key_value_heads
 
@@ -95,18 +96,20 @@ def generate_dummy_past_key_values(input_bs, model):
         pkv = ()
         for nb_pkv in range(nb_pkv):
             if nb_pkv % 2 == 0:
-                new_shape = [input_bs * num_attention_heads, d_k, 1]
+                new_shape = [input_bs * num_key_value_heads, d_k, 1]
             else:
-                new_shape = [input_bs * num_attention_heads, 1, d_k]
+                new_shape = [input_bs * num_key_value_heads, 1, d_k]
             pkv = pkv + (torch.ones(size=new_shape),)
     elif model.config.model_type == "mistral":
         new_shape = [input_bs, num_key_value_heads, 1, d_k]
+        dummy_tensor = torch.ones(size=new_shape)
+        pkv = tuple(dummy_tensor for _ in range(nb_pkv))
     elif model.config.model_type == "qwen":
-        new_shape = [input_bs, 1, num_attention_heads, d_k]
+        new_shape = [input_bs, 1, num_key_value_heads, d_k]
         dummy_tensor = torch.ones(size=new_shape)
         pkv = tuple(dummy_tensor for _ in range(nb_pkv))
     else:
-        new_shape = [input_bs, num_attention_heads, 1, d_k]
+        new_shape = [input_bs, num_key_value_heads, 1, d_k]
         dummy_tensor = torch.ones(size=new_shape)
         pkv = tuple(dummy_tensor for _ in range(nb_pkv))
     past_key_values = tuple(tuple(pkv) for _ in range(num_layers))


### PR DESCRIPTION
## Type of Change
summary:
transformers version >=4.34.0, num_key_values_heads is used to decrease past-kv shape to reduce memory.
details:
most model change num_attention_heads to num_key_values_heads, usually they are same, but when the size is large, such as 70b, they are different, num_key_values_heads is smaller than num_attention_heads to reduce memory.

## Description

detail description 
JIRA ticket: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed