### PR TITLE
Fix workflow generate.py import issue

### DIFF
--- a/workflows/chatbot/inference/generate.py
+++ b/workflows/chatbot/inference/generate.py
@@ -20,9 +20,10 @@ import os
 import time
 from intel_extension_for_transformers.neural_chat.chatbot import build_chatbot
 from intel_extension_for_transformers.neural_chat.config import (
-    PipelineConfig, GenerationConfig, MixedPrecisionConfig, LoadingModelConfig
+    PipelineConfig, GenerationConfig, LoadingModelConfig
 )
 
+from intel_extension_for_transformers.transformers import MixedPrecisionConfig
 
 def parse_args():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

Fix workflow generate.py import issue.

Directory  /root /.deepface/weights created
    from intel_extension_for_transformers.neural_chat.config import (
ImportError: cannot import name 'MixedPrecisionConfig' from 'intel_extension_for_transformers.neural_chat.config' (/opt/conda/envs/neuralchat/lib/python3.9/site-packages/intel_extension_for_transformers-0.1.dev1+g108d761-py3.9-linux-x86_64.egg/intel_extension_for_transformers/neural_chat/config.py)

## Expected Behavior & Potential Risk

This import issue reported by CI can be fixed.

## How has this PR been tested?

Local test and pre-CI test.

## Dependency Change?

None.