### PR TITLE
[LLM] Add op_name_dict attribute to SmoothQuantConfig

### DIFF
--- a/examples/huggingface/pytorch/text-generation/quantization/run_generation.py
+++ b/examples/huggingface/pytorch/text-generation/quantization/run_generation.py
@@ -109,6 +109,8 @@ elif args.sq:
             "add": {"weight": {"dtype": ["fp32"]}, "activation": {"dtype": ["fp32"]}},
             "<built-in function linear>":{"weight": {"dtype": ["fp32"]}, "activation": {"dtype": ["fp32"]}},
         }
+    elif re.search("mistral", config.model_type) or re.search("baichuan", config.model_type):
+        op_type_dict = {".*": {"activation": {"algorithm": "minmax"}}}
     else:
         op_type_dict = {}
     excluded_precisions = [] if args.int8_bf16_mixed else ["bf16"]

--- a/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
+++ b/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
@@ -247,6 +247,7 @@ class _BaseQBitsAutoModelClass:
                 backend="ipex",
                 excluded_precisions=quantization_config.excluded_precisions,
                 op_type_dict=quantization_config.op_type_dict,
+                op_name_dict=quantization_config.op_name_dict,
                 recipes=recipes,
                 example_inputs=example_inputs,
             )

--- a/intel_extension_for_transformers/transformers/utils/quantization_config.py
+++ b/intel_extension_for_transformers/transformers/utils/quantization_config.py
@@ -255,4 +255,5 @@ class SmoothQuantConfig:
     calib_iters: int = 100
     alpha: float = 0.5
     op_type_dict: dict = None
+    op_name_dict: dict = None
     excluded_precisions: list = field(default_factory=list)


### PR DESCRIPTION
## Type of Change

add op_name_dict to check which observer(kl, minmax) sq should use.
INC will check op_type_dict first and then check op_name_dict
## Description

detail description 
JIRA ticket: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed