### PR TITLE
[LLM Runtime] Fix LLaMA after discarding KV-cache

### DIFF
--- a/intel_extension_for_transformers/llm/runtime/graph/models/llama/llama.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/llama/llama.cpp
@@ -74,6 +74,7 @@ static bool llama_model_eval_internal(model_context& lctx, const model_token* to
   const int n_ctx = lctx.n_ctx;  // max number fo tokens to keep in the kv-cache
   const int n_keep = lctx.n_keep;
   const bool shift_roped_k = lctx.shift_roped_k;
+  const bool is_full_ring = shift_roped_k && n_total > n_past;
   const int n_cached = shift_roped_k ? std::min(n_total + N, n_ctx) : (n_past + N);  // #tokens cached after kv-append
   int n_head = hparams.n_head;
   int head_size = n_embd / n_head;
@@ -181,7 +182,7 @@ static bool llama_model_eval_internal(model_context& lctx, const model_token* to
     Qcur = ne_rope_inplace(ctx0, Qcur, std::max(n_cached - N, n_past), n_rot, 0, 0);
     ne_set_name(Qcur, "Qcur");
     Kcur = ne_rope_inplace(  // n_ctx exceeds but it will be shift-roped back with cached K
-        ctx0, Kcur, (n_past == n_total ? n_past : n_ctx), n_rot, 0, 0);
+        ctx0, Kcur, (is_full_ring ? n_ctx : n_past), n_rot, 0, 0);
     ne_set_name(Kcur, "Kcur");
     Vcur = ne_transpose(ctx0, ne_reshape_2d(ctx0, Vcur, head_size * n_head_kv, N));
     ne_set_name(Vcur, "Vcur");
@@ -207,7 +208,7 @@ static bool llama_model_eval_internal(model_context& lctx, const model_token* to
           ctx0,
           ne_view_1d(ctx0, kv_self.k, n_cached * n_embd_gqa, il * n_ctx * ne_element_size(kv_self.k) * n_embd_gqa),
           n_embd_gqa / n_head_kv, n_head_kv, n_cached);
-      if (shift_roped_k && n_total > n_past) {
+      if (is_full_ring) {
         struct ne_tensor* cossin_cache = nullptr;
         // Currently we only cache cossin for N == 1 in model-wide; It may be worthwhile to cache cossin for other N in
         // a single eval execution
@@ -229,7 +230,7 @@ static bool llama_model_eval_internal(model_context& lctx, const model_token* to
       ne_set_name(KQ_scaled, "KQ_scaled");
 
       // KQ_masked = mask_past(KQ_scaled)
-      if (n_total == 0) {
+      if (n_total == 0 || !shift_roped_k) {  // TODO(Yi): shift roped-k with N > 1 next-token
         KQ_scaled = ne_diag_mask_inf_inplace(ctx0, KQ_scaled, n_past);
         ne_set_name(KQ_scaled, "KQ_masked");
       }


### PR DESCRIPTION
## Type of Change: bug fix

API not changed

## Description
Fix of #580.

## Expected Behavior & Potential Risk
N/A

## How has this PR been tested?
`./build/bin/run_llama -m ne_llama_qj.bin -p "[INST]tell me about intel[\INST]" -c 100 --seed 1 -n 1000` on ICX with GCC9.

Where is `q4j-int8-g32`.

Result is now the same of that before the merging of #580.

![image](https://github.com/intel/intel-extension-for-transformers/assets/28386673/ec880f7a-95e3-4715-ab7c-41ec991fce25)

## Dependency Change?
No