### PR TITLE
[Neural Chat] Fix neuralchat woq UT

### DIFF
--- a/intel_extension_for_transformers/neural_chat/tests/ci/optimization/test_optimization_llmruntime.py
+++ b/intel_extension_for_transformers/neural_chat/tests/ci/optimization/test_optimization_llmruntime.py
@@ -40,41 +40,10 @@ class TestChatbotBuilder(unittest.TestCase):
                     print(f"Error deleting file {filename}: {str(e)}")
         return super().tearDown()
 
-    def test_build_chatbot_with_AMP(self):
+    def test_build_chatbot_with_llm_runtime(self):
+        loading_config = LoadingModelConfig(use_llm_runtime=True)
         config = PipelineConfig(model_name_or_path="facebook/opt-125m",
-                                optimization_config = MixedPrecisionConfig())
-        chatbot = build_chatbot(config)
-        self.assertIsNotNone(chatbot)
-        response = chatbot.predict(query="Tell me about Intel Xeon Scalable Processors.")
-        print(response)
-        print("Inference with streaming mode.")
-        for new_text in chatbot.predict_stream(query="Tell me about Intel Xeon Scalable Processors."):
-            print(new_text, end="", flush=True)
-        print("\n")
-        self.assertIsNotNone(response)
-
-    def test_build_chatbot_with_bitsandbytes_quant(self):
-        if is_bitsandbytes_available() and torch.cuda.is_available():
-            config = PipelineConfig(
-                model_name_or_path="facebook/opt-125m",
-                device='cuda',
-                optimization_config=BitsAndBytesConfig(
-                        load_in_4bit=True,
-                        bnb_4bit_quant_type='nf4',
-                        bnb_4bit_use_double_quant=True,
-                        bnb_4bit_compute_dtype="bfloat16"
-                )
-            )
-            chatbot = build_chatbot(config)
-            self.assertIsNotNone(chatbot)
-            response = chatbot.predict(query="Tell me about Intel Xeon Scalable Processors.")
-            print(response)
-            self.assertIsNotNone(response)
-
-    def test_build_chatbot_with_weight_only_quant(self):
-        loading_config = LoadingModelConfig(use_llm_runtime=False)
-        config = PipelineConfig(model_name_or_path="facebook/opt-125m",
-            optimization_config=WeightOnlyQuantConfig(compute_dtype="fp32", weight_dtype="int4_fullrange"),
+            optimization_config=WeightOnlyQuantConfig(compute_dtype="int8", weight_dtype="int8"),
             loading_config=loading_config
         )
         chatbot = build_chatbot(config)
@@ -82,6 +51,7 @@ class TestChatbotBuilder(unittest.TestCase):
         response = chatbot.predict(query="Tell me about Intel Xeon Scalable Processors.")
         print(response)
         self.assertIsNotNone(response)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Type of Change

There is the core dump raised when itrex woq use_llmruntime=False and True in one UT, the probable for doubt is they both use the same jblas which some objects are static and sharing, so split the ut now.

## Description

detail description 
JIRA ticket: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed