### PR TITLE
Fix latest chromadb version issue

### DIFF
--- a/intel_extension_for_transformers/neural_chat/requirements.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements.txt
@@ -23,7 +23,7 @@ farm-haystack
 librosa
 beautifulsoup4
 InstructorEmbedding
-chromadb
+chromadb==0.4.15
 fastapi==0.103.2
 pydantic==1.10.13
 starlette

--- a/intel_extension_for_transformers/neural_chat/requirements_cpu.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements_cpu.txt
@@ -21,7 +21,7 @@ farm-haystack
 librosa
 beautifulsoup4
 InstructorEmbedding
-chromadb
+chromadb==0.4.15
 fastapi==0.103.2
 pydantic==1.10.13
 starlette

--- a/intel_extension_for_transformers/neural_chat/requirements_hpu.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements_hpu.txt
@@ -20,7 +20,7 @@ farm-haystack>=1.20.1
 librosa
 beautifulsoup4
 InstructorEmbedding
-chromadb
+chromadb==0.4.15
 fastapi==0.103.2
 pydantic==1.10.13
 starlette

--- a/intel_extension_for_transformers/neural_chat/requirements_pc.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements_pc.txt
@@ -20,7 +20,7 @@ farm-haystack
 librosa
 beautifulsoup4
 InstructorEmbedding
-chromadb
+chromadb==0.4.15
 fastapi==0.103.2
 pydantic==1.10.13
 starlette

--- a/intel_extension_for_transformers/neural_chat/requirements_xpu.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements_xpu.txt
@@ -18,7 +18,7 @@ farm-haystack
 librosa
 beautifulsoup4
 InstructorEmbedding
-chromadb
+chromadb==0.4.15
 fastapi==0.103.2
 pydantic==1.10.13
 starlette

--- a/intel_extension_for_transformers/neural_chat/tests/requirements.txt
+++ b/intel_extension_for_transformers/neural_chat/tests/requirements.txt
@@ -23,7 +23,7 @@ farm-haystack
 librosa
 beautifulsoup4
 InstructorEmbedding
-chromadb
+chromadb==0.4.15
 fastapi==0.103.2
 pydantic==1.10.13
 starlette


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description



Latest chromadb 0.4.16 API changed which caused the CI failed, fix the chromadb version to 0.4.15.
======================================================================
[8127](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8128)ERROR: test_retrieval (__main__.UnitTest)
[8128](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8129)----------------------------------------------------------------------
[8129](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8130)Traceback (most recent call last):
[8130](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8131)  File "/intel-extension-for-transformers/intel_extension_for_transformers/neural_chat/tests/ci/api/test_inference.py", line 47, in test_retrieval
[8131](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8132)    chatbot = build_chatbot(config)
[8132](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8133)  File "/usr/local/lib/python3.10/dist-packages/intel_extension_for_transformers/neural_chat/chatbot.py", line 112, in build_chatbot
[8133](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8134)    plugins[plugin_name]["instance"] = plugins[plugin_name]['class'](**plugin_value['args'])
[8134](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8135)  File "/usr/local/lib/python3.10/dist-packages/intel_extension_for_transformers/neural_chat/pipeline/plugins/retrieval/retrieval_agent.py", line 57, in __init__
[8135](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8136)    self.db = self.doc_parser.KB_construct(self.input_path)
[8136](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8137)  File "/usr/local/lib/python3.10/dist-packages/intel_extension_for_transformers/neural_chat/pipeline/plugins/retrieval/indexing/indexing.py", line 135, in KB_construct
[8137](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8138)    vectordb = Chroma.from_documents(documents=documents, embedding=self.embeddings,
[8138](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8139)  File "/usr/local/lib/python3.10/dist-packages/langchain/vectorstores/chroma.py", line 684, in from_documents
[8139](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8140)    return cls.from_texts(
[8140](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8141)  File "/usr/local/lib/python3.10/dist-packages/langchain/vectorstores/chroma.py", line 620, in from_texts
[8141](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8142)    chroma_collection = cls(
[8142](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8143)  File "/usr/local/lib/python3.10/dist-packages/langchain/vectorstores/chroma.py", line 125, in __init__
[8143](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8144)    self._collection = self._client.get_or_create_collection(
[8144](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8145)  File "/usr/local/lib/python3.10/dist-packages/chromadb/api/client.py", line 226, in get_or_create_collection
[8145](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8146)    return self._server.get_or_create_collection(
[8146](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8147)  File "/usr/local/lib/python3.10/dist-packages/chromadb/telemetry/opentelemetry/__init__.py", line 127, in wrapper
[8147](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8148)    return f(*args, **kwargs)
[8148](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8149)  File "/usr/local/lib/python3.10/dist-packages/chromadb/api/segment.py", line 216, in get_or_create_collection
[8149](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8150)    return self.create_collection(  # type: ignore
[8150](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8151)  File "/usr/local/lib/python3.10/dist-packages/chromadb/telemetry/opentelemetry/__init__.py", line 127, in wrapper
[8151](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8152)    return f(*args, **kwargs)
[8152](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8153)  File "/usr/local/lib/python3.10/dist-packages/chromadb/api/segment.py", line 190, in create_collection
[8153](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8154)    return Collection(
[8154](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8155)  File "/usr/local/lib/python3.10/dist-packages/chromadb/api/models/Collection.py", line 85, in __init__
[8155](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8156)    validate_embedding_function(embedding_function)
[8156](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8157)  File "/usr/local/lib/python3.10/dist-packages/chromadb/api/types.py", line 210, in validate_embedding_function
[8157](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8158)    raise ValueError(
[8158](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8159)ValueError: Expected EmbeddingFunction.__call__ to have the following signature: odict_keys(['self', 'input']), got odict_keys(['self', 'args', 'kwargs'])
[8159](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8160)Please see https://docs.trychroma.com/embeddings for details of the EmbeddingFunction interface.
[8160](https://github.com/intel/intel-extension-for-transformers/actions/runs/6794388851/job/18470729429#step:8:8161)Please note the recent change to the EmbeddingFunction interface: https://docs.trychroma.com/migration#migration-to-0416---november-7-2023

## Expected Behavior & Potential Risk

The CI can be recovered.

## How has this PR been tested?

Local test and pre-CI test.

## Dependency Change?

None.