### PR TITLE
fixed bf16 error in convert_llama.py

### DIFF
--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_llama.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_llama.py
@@ -827,7 +827,8 @@ SAFETENSORS_DATA_TYPES: Dict[str, DataType] = {
     'F16': DT_F16,
     'F32': DT_F32,
     'I32': DT_I32,
-    'BOOL': DT_BOOL
+    'BOOL': DT_BOOL,
+    'BF16': DT_BF16
 }
 
 


### PR DESCRIPTION
Loading a safetensors model like [CodeLlama-13B-hf](https://huggingface.co/codellama/CodeLlama-13b-hf), I got an error: "Key Error: BF16". 
This was also observed in the llama.cpp repository and the issue is described [here](https://github.com/ggerganov/llama.cpp/issues/1473). 

I have tested this change and the models now work just fine.


## Expected Behavior & Potential Risk

Safetensors BF16 can load without errors.

## How has this PR been tested?

Load a model with safetensors bf16 and use the convert.py script on that model, the error should be visible.

## Dependency Change?

No changes in dependencies