### PR TITLE
update ut value due to gcc change

### DIFF
--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -357,7 +357,7 @@ class TestQuantization(unittest.TestCase):
                                                      use_llm_runtime=False
                                                 )
         output = bit4_model(dummy_input)
-        self.assertTrue(isclose(float(output[0][0][0][0]), -8.059162139892578, rel_tol=1e-04))
+        self.assertTrue(isclose(float(output[0][0][0][0]), -8.6834, rel_tol=1e-04))
 
         # load_in_8bit
         bit8_model = AutoModelForCausalLM.from_pretrained(model_name_or_path,


### PR DESCRIPTION
## Type of Change

https://github.com/intel/intel-extension-for-transformers/pull/655 this PR support gcc 11 compile and have some affects on jblas, woq quantization use the qbitsLinear which based jblas, so the output value change.
the optimization ut test based gcc 11 now.

## Description

detail description 
JIRA ticket: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed