### PR TITLE
Add skip for UT

### DIFF
--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -4,10 +4,14 @@ import unittest
 import subprocess
 import torch
 import optimum.version
+import platform
 from transformers import AutoModelForCausalLM, AutoModelForSeq2SeqLM
 from packaging.version import Version
 OPTIMUM114_VERSION = Version("1.14.0")
+PYTHON_VERSION = Version(platform.python_version())
 
+@unittest.skipIf(PYTHON_VERSION.release < Version("3.9.0").release,
+    "Please use Python 3.9 or higher version for lm-eval")
 class TestLmEvaluationHarness(unittest.TestCase):
     @classmethod
     def setUpClass(self):

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -24,6 +24,7 @@ from transformers import (
     Seq2SeqTrainingArguments,
 )
 import neural_compressor.adaptor.pytorch as nc_torch
+from packaging.version import Version
 
 os.environ["WANDB_DISABLED"] = "true"
 os.environ["DISABLE_MLFLOW_INTEGRATION"] = "true"

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -23,10 +23,12 @@ from transformers import (
     AutoModelForSeq2SeqLM,
     Seq2SeqTrainingArguments,
 )
+import neural_compressor.adaptor.pytorch as nc_torch
 
 os.environ["WANDB_DISABLED"] = "true"
 os.environ["DISABLE_MLFLOW_INTEGRATION"] = "true"
 MODEL_NAME = "distilbert-base-uncased-finetuned-sst-2-english"
+PT_VERSION = nc_torch.get_torch_version()
 
 class DummyDataset(data.Dataset):
     def __init__(self):
@@ -287,7 +289,9 @@ class TestQuantization(unittest.TestCase):
             if 'MatMul' in tensor.name:
                 self.assertEqual(tensor.data_type, TensorProto.BFLOAT16)
                 break
-
+    
+    @unittest.skipIf(PT_VERSION.release < Version("2.1.0").release,
+            "Please use PyTroch 2.1.0 or higher version for executor backend")
     def test_quantization_for_llm(self):
         model_name_or_path = "facebook/opt-125m"
         tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)


### PR DESCRIPTION
## Type of Change
add skip operator for nightly or weekly unit test.
lm-eval requests python version higher or equal than 3.9.0.
llm sq requests pytorch version higher or equal than 2.1.0.

## Description

detail description 
JIRA ticket: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed