### PR TITLE
[LLM Runtime] Compare cpp logits with pytorch

### DIFF
--- a/intel_extension_for_transformers/llm/runtime/graph/__init__.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/__init__.py
@@ -167,3 +167,9 @@ class Model:
 
     def is_token_end(self):
         return self.model.is_token_end()
+
+    def forward(self, input_ids):
+        if self.model is None:
+            self.init_from_bin(self.model_type, self.bin_file)
+        import pdb; pdb.set_trace()
+        return self.model.forward(input_ids.numpy())

--- a/intel_extension_for_transformers/llm/runtime/graph/__init__.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/__init__.py
@@ -171,5 +171,4 @@ class Model:
     def forward(self, input_ids):
         if self.model is None:
             self.init_from_bin(self.model_type, self.bin_file)
-        import pdb; pdb.set_trace()
         return self.model.forward(input_ids.numpy())

--- a/intel_extension_for_transformers/llm/runtime/graph/__init__.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/__init__.py
@@ -156,6 +156,8 @@ class Model:
                 streamer.put(torch.tensor([response[0]]))
             for i in range(len(response)):
                 ret[i].extend(response[i])
+            if beam_search:
+                break
             if stopping_criteria is not None:
                 if stopping_criteria(torch.tensor(ret), None):
                     break

--- a/intel_extension_for_transformers/llm/runtime/graph/application/main_pybind.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/application/main_pybind.cpp
@@ -92,9 +92,7 @@ class Model {
     }};
     model_eval(ctx, inputs.data(), inputs.size(), params.n_threads);
     float* logits = model_get_logits(ctx);
-    for (int i = 0; i < n_vocab; i++) {
-      dst_ptr[i] = logits[i];
-    }
+    memcpy(dst_ptr, logits, n_vocab * sizeof(float));
     return dst;
   }          
 

--- a/intel_extension_for_transformers/llm/runtime/graph/application/main_pybind.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/application/main_pybind.cpp
@@ -30,6 +30,7 @@
 #include <utility>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/numpy.h>
 #include "common.h"
 #include "models/model_utils/model_types.h"
 #include "models/model_utils/model_config.h"
@@ -44,6 +45,8 @@
 #include <windows.h>
 #include <signal.h>
 #endif
+
+namespace py = pybind11;
 
 std::shared_ptr<quant_layer_base> get_model_quant_layer(const std::string model_name) {
   return ql_registry::create_ql(model_name);
@@ -71,6 +74,30 @@ class Model {
     curr_input_ids.clear();
     generate_count = 0;
   }
+
+  py::array_t<float> forward(const std::vector<std::vector<model_token>>& input_ids) {         
+    // py::array_t<float> dst                                            
+    // 获取NumPy数组的指针
+    // PyArrayObject* array = PyArray_New(NPY_FLOAT32, 10, 1, NULL, NULL, 0);
+    // float *foo = new float[size];
+    // auto data = py::array_t<float>(
+    //         {100, 1000, 1000}, // shape
+    //         {1000*1000*8, 1000*8, 8}, // C-style contiguous strides for double
+    //         foo, // the data pointer
+    //         free_when_done); // numpy array references this parent
+    // // float* w_ptr = src_w.mutable_data();
+    // // float* scales_ptr = src_scales.mutable_data();
+    // // float* dst_ptr = dst.mutable_data();
+    // // // std::cout << ptr << std::endl;
+    // // for(int i = 0; i < 4; i++)
+    // //   dst_ptr[i] = w_ptr[i] * scales_ptr[i];
+
+    // // 填充数组
+    // for (int i = 0; i < 10; i++) {
+    //   PyArray_SetItem(array, i, PyFloat_FromDouble(i));
+    // }
+    return py::array_t<float>(200);
+  }          
 
  private:
   model_context* ctx = nullptr;
@@ -435,8 +462,6 @@ int Model::quant_model(const std::string& model_path, const std::string& out_pat
   return 0;
 }
 
-namespace py = pybind11;
-
 #if MODEL_NAME_ID == 1
 
 PYBIND11_MODULE(gptj_cpp, m)
@@ -511,5 +536,6 @@ PYBIND11_MODULE(mistral_cpp, m)
                   py::arg("scale_dtype") = "fp32", py::arg("compute_dtype") = "int8", py::arg("use_ggml") = false)
       .def("is_token_end", &Model::is_token_end)
       .def("reset_token_end", &Model::reset_token_end)
+      .def("forward", &Model::forward)
       .def("reinit", &Model::reinit);
 }

--- a/intel_extension_for_transformers/llm/runtime/graph/application/main_pybind.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/application/main_pybind.cpp
@@ -76,26 +76,6 @@ class Model {
   }
 
   py::array_t<float> forward(const std::vector<std::vector<model_token>>& input_ids) {         
-    // py::array_t<float> dst                                            
-    // 获取NumPy数组的指针
-    // PyArrayObject* array = PyArray_New(NPY_FLOAT32, 10, 1, NULL, NULL, 0);
-    // float *foo = new float[size];
-    // auto data = py::array_t<float>(
-    //         {100, 1000, 1000}, // shape
-    //         {1000*1000*8, 1000*8, 8}, // C-style contiguous strides for double
-    //         foo, // the data pointer
-    //         free_when_done); // numpy array references this parent
-    // // float* w_ptr = src_w.mutable_data();
-    // // float* scales_ptr = src_scales.mutable_data();
-    // // float* dst_ptr = dst.mutable_data();
-    // // // std::cout << ptr << std::endl;
-    // // for(int i = 0; i < 4; i++)
-    // //   dst_ptr[i] = w_ptr[i] * scales_ptr[i];
-
-    // // 填充数组
-    // for (int i = 0; i < 10; i++) {
-    //   PyArray_SetItem(array, i, PyFloat_FromDouble(i));
-    // }
     auto dst = py::array_t<float>(n_vocab);
     float* dst_ptr = dst.mutable_data();
 

--- a/intel_extension_for_transformers/llm/runtime/graph/application/main_pybind.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/application/main_pybind.cpp
@@ -96,7 +96,26 @@ class Model {
     // for (int i = 0; i < 10; i++) {
     //   PyArray_SetItem(array, i, PyFloat_FromDouble(i));
     // }
-    return py::array_t<float>(200);
+    auto dst = py::array_t<float>(n_vocab);
+    float* dst_ptr = dst.mutable_data();
+
+    std::vector<model_input> inputs = {model_input{
+        /*.tokens              =*/input_ids[0].data(),
+        /*.n_tokens           =*/(uint32_t)input_ids[0].size(),
+        /*.n_prompt_tokens    =*/0,
+        /*.n_past             =*/(uint32_t)n_past,
+        /*.n_total            =*/(uint32_t)n_total,
+        /*.request_idx        =*/0,
+        /*.beam_idx           =*/0,
+        /*.padding_side       =*/0,
+        /*n_padding           =*/0,
+    }};
+    model_eval(ctx, inputs.data(), inputs.size(), params.n_threads);
+    float* logits = model_get_logits(ctx);
+    for (int i = 0; i < n_vocab; i++) {
+      dst_ptr[i] = logits[i];
+    }
+    return dst;
   }          
 
  private:

--- a/tests/test_llm_runtime.py
+++ b/tests/test_llm_runtime.py
@@ -17,53 +17,85 @@ class TestLLMRUNTIME(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        shutil.rmtree("./ne_chatglm_q.bin", ignore_errors=True)
-        shutil.rmtree("./gptj_fp32.bin", ignore_errors=True)
+        # shutil.rmtree("./runtime_outs/ne_chatglm_q.bin", ignore_errors=True)
+        # shutil.rmtree("./runtime_outs/ne_gptj_f32.bin", ignore_errors=True)
+        pass
+
+    # def test_llm_runtime(self):
+
+    #     model_name = "/mnt/disk1/data2/zhenweil/models/chatglm2-6b"  # or local path to model
+    #     woq_config = WeightOnlyQuantConfig(compute_dtype="int8", weight_dtype="int4", use_cache=True)
+    #     prompt = "小明的妈妈有三个孩子，老大叫大毛，老二叫二毛，老三叫什么？"
+
+    #     tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+    #     input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+    #     streamer = TextStreamer(tokenizer)
+
+    #     model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, use_llm_runtime=True, trust_remote_code=True)
+    #     gen_tokens = model.generate(input_ids, streamer=streamer, max_new_tokens=300, seed=1)
+    #     outputs = tokenizer.batch_decode(gen_tokens)
+    #     print(outputs)
+    #     self.assertTrue("小明" in outputs[0])
+
+    # def test_beam_search(self):
+    #     model_name = "/mnt/disk1/data2/zhenweil/models/gpt_j/gpt-j-6B"  # or local path to model
+    #     prompts = [
+    #        "she opened the door and see",
+    #        "tell me 10 things about jazz music",
+    #        "What is the meaning of life?",
+    #        "To be, or not to be, that is the question: Whether 'tis nobler in the mind to suffer"\
+    #         " The slings and arrows of outrageous fortune, "\
+    #         "Or to take arms against a sea of troubles."\
+    #         "And by opposing end them. To die—to sleep,"
+    #         ]
+
+    #     tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True,
+    #                                               padding_side="left")
+    #     tokenizer.pad_token = tokenizer.eos_token
+    #     pad_token = tokenizer(tokenizer.pad_token)['input_ids'][0]
+    #     inputs = tokenizer(prompts, padding=True, return_tensors='pt')
+
+    #     # pytorch fp32
+    #     # pt_model = AutoModelForCausalLM.from_pretrained(model_name, trust_remote_code=True)
+    #     # pt_model.eval() 
+    #     # pt_generate_ids = pt_model.generate(**inputs, max_new_tokens=128, min_new_tokens=30,
+    #     #                                     early_stopping=True, num_beams=4).tolist()
+    #     # llm runtime fp32
+    #     woq_config = WeightOnlyQuantConfig(not_quant=True, use_cache=True)
+    #     itrex_model = AutoModelForCausalLM.from_pretrained(model_name, quantization_config=woq_config, trust_remote_code=True)
+    #     itrex_generate_ids = itrex_model.generate(inputs.input_ids, num_beams=4, # batch_size=4, 
+    #                               max_new_tokens=128, min_new_tokens=30, early_stopping=True,
+    #                               pad_token=pad_token)
+    #     # for i in range(len(itrex_generate_ids)):
+    #     #     self.assertListEqual(pt_generate_ids[i], itrex_generate_ids[i])
+
 
     def test_llm_runtime(self):
 
-        model_name = "/tf_dataset2/models/pytorch/chatglm2-6b"  # or local path to model
-        woq_config = WeightOnlyQuantConfig(compute_dtype="int8", weight_dtype="int4")
-        prompt = "小明的妈妈有三个孩子，老大叫大毛，老二叫二毛，老三叫什么？"
+        model_name = "/mnt/disk1/data2/zhenweil/models/chatglm2-6b"  # or local path to model
+        woq_config = WeightOnlyQuantConfig(compute_dtype="int8", weight_dtype="int4", use_cache=True)
+        prompt = "hi, tell me about Intel"
 
         tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
-        input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+        inputs = tokenizer(prompt, return_tensors="pt")
         streamer = TextStreamer(tokenizer)
-
-        model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, use_llm_runtime=True, trust_remote_code=True)
-        gen_tokens = model.generate(input_ids, streamer=streamer, max_new_tokens=300, seed=1)
-        outputs = tokenizer.batch_decode(gen_tokens)
-        print(outputs)
-        self.assertTrue("小明" in outputs[0])
-
-    def test_beam_search(self):
-        model_name = "/tf_dataset2/models/pytorch/gpt-j-6B"  # or local path to model
-        prompts = [
-           "she opened the door and see",
-           "tell me 10 things about jazz music",
-           "What is the meaning of life?",
-           "To be, or not to be, that is the question: Whether 'tis nobler in the mind to suffer"\
-            " The slings and arrows of outrageous fortune, "\
-            "Or to take arms against a sea of troubles."\
-            "And by opposing end them. To die—to sleep,"
-            ]
-
-        tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True,
-                                                  padding_side="left")
-        tokenizer.pad_token = tokenizer.eos_token
-        pad_token = tokenizer(tokenizer.pad_token)['input_ids'][0]
-        inputs = tokenizer(prompts, padding=True, return_tensors='pt')
 
         # pytorch fp32
         pt_model = AutoModelForCausalLM.from_pretrained(model_name, trust_remote_code=True)
-        pt_model.eval()
-        pt_generate_ids = pt_model.generate(**inputs, max_new_tokens=128, min_new_tokens=30,
-                                            early_stopping=True, num_beams=4).tolist()
-        # llm runtime fp32
-        woq_config = WeightOnlyQuantConfig(not_quant=True)
-        itrex_model = AutoModelForCausalLM.from_pretrained(model_name, quantization_config=woq_config, trust_remote_code=True)
-        itrex_generate_ids = itrex_model.generate(inputs.input_ids, batch_size=4, num_beams=4,
-                                  max_new_tokens=128, min_new_tokens=30, early_stopping=True,
-                                  pad_token=pad_token)
-        for i in range(len(itrex_generate_ids)):
-            self.assertListEqual(pt_generate_ids[i], itrex_generate_ids[i])
+        pt_model.eval() 
+        pt_generate_ids = pt_model.generate(**inputs, max_new_tokens=100)
+        pt_outputs = tokenizer.batch_decode(pt_generate_ids)
+        print(pt_outputs)
+        logits = pt_model(**inputs).logits
+
+        import pdb; pdb.set_trace()
+
+        model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, use_llm_runtime=True, trust_remote_code=True)
+        outputs = model.forward(inputs.input_ids)
+        # gen_tokens = model.generate(inputs.input_ids, streamer=streamer, max_new_tokens=100)
+        # outputs = tokenizer.batch_decode(gen_tokens)
+        print(outputs)
+        # self.assertTrue("小明" in outputs[0])
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_runtime.py
+++ b/tests/test_llm_runtime.py
@@ -1,6 +1,3 @@
-import numpy
-import shutil
-import torch
 import unittest
 
 from transformers import AutoTokenizer, TextStreamer
@@ -8,6 +5,15 @@ from intel_extension_for_transformers.transformers import AutoModel, WeightOnlyQ
 from intel_extension_for_transformers.llm.runtime.graph.scripts.convert import convert_model
 from intel_extension_for_transformers.llm.runtime.graph import Model
 
+import numpy as np
+import sys
+
+def cmpData(numa, numb):
+    if (numa.shape != numb.shape):
+        return 1
+    totalErr = ((np.abs(numa - numb))**2).sum()
+    totalNum = (np.abs(numa)**2).sum()
+    return np.sqrt(totalErr/totalNum)
 
 class TestLLMRUNTIME(unittest.TestCase):
 
@@ -78,23 +84,15 @@ class TestLLMRUNTIME(unittest.TestCase):
 
         tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
         inputs = tokenizer(prompt, return_tensors="pt")
-        streamer = TextStreamer(tokenizer)
 
         # pytorch fp32
         pt_model = AutoModelForCausalLM.from_pretrained(model_name, trust_remote_code=True)
         pt_model.eval() 
-        # pt_generate_ids = pt_model.generate(**inputs, max_new_tokens=100)
-        # pt_outputs = tokenizer.batch_decode(pt_generate_ids)
-        # print(pt_outputs)
         logits = pt_model(**inputs).logits[:,-1]
 
         model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, use_llm_runtime=True, trust_remote_code=True)
         outputs = model.forward(inputs.input_ids)
-        # gen_tokens = model.generate(inputs.input_ids, streamer=streamer, max_new_tokens=100)
-        # outputs = tokenizer.batch_decode(gen_tokens)
-        import pdb; pdb.set_trace()
-        print(outputs)
-        # self.assertTrue("小明" in outputs[0])
+        print(cmpData(logits.detach().numpy().flatten(), outputs.flatten()))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_llm_runtime.py
+++ b/tests/test_llm_runtime.py
@@ -38,37 +38,38 @@ class TestLLMRUNTIME(unittest.TestCase):
     #     print(outputs)
     #     self.assertTrue("小明" in outputs[0])
 
-    # def test_beam_search(self):
-    #     model_name = "/mnt/disk1/data2/zhenweil/models/gpt_j/gpt-j-6B"  # or local path to model
-    #     prompts = [
-    #        "she opened the door and see",
-    #        "tell me 10 things about jazz music",
-    #        "What is the meaning of life?",
-    #        "To be, or not to be, that is the question: Whether 'tis nobler in the mind to suffer"\
-    #         " The slings and arrows of outrageous fortune, "\
-    #         "Or to take arms against a sea of troubles."\
-    #         "And by opposing end them. To die—to sleep,"
-    #         ]
+    def test_beam_search(self):
+        model_name = "/home/zhentao/gpt-j-6b" #"/mnt/disk1/data2/zhenweil/models/gpt_j/gpt-j-6B"  # or local path to model
+        prompts = [
+           "she opened the door and see",
+           "tell me 10 things about jazz music",
+           "What is the meaning of life?",
+           "To be, or not to be, that is the question: Whether 'tis nobler in the mind to suffer"\
+            " The slings and arrows of outrageous fortune, "\
+            "Or to take arms against a sea of troubles."\
+            "And by opposing end them. To die—to sleep,"
+            ]
 
-    #     tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True,
-    #                                               padding_side="left")
-    #     tokenizer.pad_token = tokenizer.eos_token
-    #     pad_token = tokenizer(tokenizer.pad_token)['input_ids'][0]
-    #     inputs = tokenizer(prompts, padding=True, return_tensors='pt')
+        tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True,
+                                                  padding_side="left")
+        tokenizer.pad_token = tokenizer.eos_token
+        pad_token = tokenizer.pad_token_id
+        inputs = tokenizer(prompts, padding=True, return_tensors='pt')
 
-    #     # pytorch fp32
-    #     # pt_model = AutoModelForCausalLM.from_pretrained(model_name, trust_remote_code=True)
-    #     # pt_model.eval() 
-    #     # pt_generate_ids = pt_model.generate(**inputs, max_new_tokens=128, min_new_tokens=30,
-    #     #                                     early_stopping=True, num_beams=4).tolist()
-    #     # llm runtime fp32
-    #     woq_config = WeightOnlyQuantConfig(not_quant=True, use_cache=True)
-    #     itrex_model = AutoModelForCausalLM.from_pretrained(model_name, quantization_config=woq_config, trust_remote_code=True)
-    #     itrex_generate_ids = itrex_model.generate(inputs.input_ids, num_beams=4, # batch_size=4, 
-    #                               max_new_tokens=128, min_new_tokens=30, early_stopping=True,
-    #                               pad_token=pad_token)
-    #     # for i in range(len(itrex_generate_ids)):
-    #     #     self.assertListEqual(pt_generate_ids[i], itrex_generate_ids[i])
+        # pytorch fp32
+        pt_model = AutoModelForCausalLM.from_pretrained(model_name, trust_remote_code=True)
+        pt_model.eval()
+        pt_generate_ids = pt_model.generate(**inputs, max_new_tokens=128, min_new_tokens=30,
+                                            early_stopping=True, num_beams=4).tolist()
+        # llm runtime fp32
+        woq_config = WeightOnlyQuantConfig(not_quant=True, use_cache=True)
+        itrex_model = AutoModelForCausalLM.from_pretrained(model_name, quantization_config=woq_config,
+                                                            trust_remote_code=True)
+        itrex_generate_ids = itrex_model.generate(inputs.input_ids, num_beams=4,
+                                  max_new_tokens=128, min_new_tokens=30, early_stopping=True,
+                                  pad_token=pad_token)
+        for i in range(len(itrex_generate_ids)):
+            self.assertListEqual(pt_generate_ids[i], itrex_generate_ids[i])
 
 
     def test_llm_runtime(self):

--- a/tests/test_llm_runtime.py
+++ b/tests/test_llm_runtime.py
@@ -83,17 +83,16 @@ class TestLLMRUNTIME(unittest.TestCase):
         # pytorch fp32
         pt_model = AutoModelForCausalLM.from_pretrained(model_name, trust_remote_code=True)
         pt_model.eval() 
-        pt_generate_ids = pt_model.generate(**inputs, max_new_tokens=100)
-        pt_outputs = tokenizer.batch_decode(pt_generate_ids)
-        print(pt_outputs)
-        logits = pt_model(**inputs).logits
-
-        import pdb; pdb.set_trace()
+        # pt_generate_ids = pt_model.generate(**inputs, max_new_tokens=100)
+        # pt_outputs = tokenizer.batch_decode(pt_generate_ids)
+        # print(pt_outputs)
+        logits = pt_model(**inputs).logits[:,-1]
 
         model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, use_llm_runtime=True, trust_remote_code=True)
         outputs = model.forward(inputs.input_ids)
         # gen_tokens = model.generate(inputs.input_ids, streamer=streamer, max_new_tokens=100)
         # outputs = tokenizer.batch_decode(gen_tokens)
+        import pdb; pdb.set_trace()
         print(outputs)
         # self.assertTrue("小明" in outputs[0])
 


### PR DESCRIPTION
## Type of Change

feature

## Description

Compare logits with pytorch logits for monitoring accuracy:

- [x] Introducing the output comparison method: `cmpData`
- [ ] fp32 output of cpp graph should be very close to that of pytorch: diff < 0.1%

cmpData:
`diff = sqrt(sum((out - ref) ^ 2) / sum((ref) ^ 2))`

## Expected Behavior & Potential Risk

diff of llama2 vs pytorch fp32
- fp32            0.00067020295
- q4_0            0.17200278
- q4_j_32       0.271983
- q8_j_bf16    1 (error  outputs)

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed