### PR TITLE
fix tokenizer for code generation eval

### DIFF
--- a/intel_extension_for_transformers/llm/finetuning/finetuning.py
+++ b/intel_extension_for_transformers/llm/finetuning/finetuning.py
@@ -523,6 +523,8 @@ class Finetuning:
                         training_args.output_dir, state_dict=unwrapped_model.state_dict()
                     )
         if finetune_args.do_lm_eval and finetune_args.task == "code-generation":
+            tokenizer.padding_side = "right" # padding on the right is needed to cut off padding in `complete_code`
+            tokenizer.truncation_side = "left"
             unwrapped_model.eval()
             class Eval_Args:
                 n_samples = 20
@@ -530,7 +532,7 @@ class Finetuning:
                 allow_code_execution = True
                 prefix = ""
                 generation_only = False
-                postprocess = False
+                postprocess = True
                 save_references = False
                 save_generations = False
                 instruction_tokens = None
@@ -547,7 +549,7 @@ class Finetuning:
                 max_memory_per_gpu = None
                 modeltype = "causal"
                 limit_start = 0
-                batch_size = 20 # batch_size >= n_samples if do_sample.
+                batch_size = 20 # batch_size <= n_samples if do_sample.
             eval_args = Eval_Args()
             from intel_extension_for_transformers.llm.evaluation.lm_code_eval import evaluate
             with training_args.main_process_first(desc="lm_eval"):


### PR DESCRIPTION
## Type of Change

fix tokenizer for code generation evaluation

## Description
fix codellama acc=0 when finetuning
set `postprocess` to True (by default) so that batch_size can be set to smaller

## Expected Behavior & Potential Risk

## How has this PR been tested?
local test passed

## Dependency Change?
