### PR TITLE
[LLM Runtime] Optmized dropout operator

### DIFF
--- a/.github/workflows/unit-test-kernel.yml
+++ b/.github/workflows/unit-test-kernel.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - intel_extension_for_transformers/llm/library/kernels/**
+      - intel_extension_for_transformers/llm/library/jblas/**
       - .github/workflows/unit-test-kernel.yml
       - .github/workflows/script/unitTest/**
       - '!intel_extension_for_transformers/llm/library/kernels/docs/**'

--- a/.github/workflows/unit-test-optimize.yml
+++ b/.github/workflows/unit-test-optimize.yml
@@ -11,6 +11,7 @@ on:
       - intel_extension_for_transformers/llm/evaluation/**
       - intel_extension_for_transformers/llm/quantization/**
       - intel_extension_for_transformers/llm/runtime/graph/**
+      - intel_extension_for_transformers/llm/operator/**
       - tests/**
       - .github/workflows/unit-test-optimize.yml
       - .github/workflows/script/unitTest/**

--- a/intel_extension_for_transformers/llm/library/jblas/jblas/kernel_avx512_bf16.h
+++ b/intel_extension_for_transformers/llm/library/jblas/jblas/kernel_avx512_bf16.h
@@ -20,11 +20,11 @@ namespace jblas {
 namespace kernel {
 namespace avx512_bf16 {
 
+#if CompileBF16()
 #pragma GCC push_options
 #pragma GCC target("avx512bf16")
 static inline JBLAS_CODE bf16_cvt_fp32_2D_write_back(const utils::bf16* src_ptr, float* dst_ptr, int row, int col,
                                                      int src_step, int dst_step, bool zeropadding) {
-#if CompileBF16()
   const int npadding = (dst_step - col) * sizeof(float);
   constexpr int simd_proc_elt = 16;
   auto col_body = col / simd_proc_elt * simd_proc_elt;
@@ -45,13 +45,10 @@ static inline JBLAS_CODE bf16_cvt_fp32_2D_write_back(const utils::bf16* src_ptr,
     if (zeropadding && npadding) std::memset(dst + col, 0, npadding);
   }
   return JblasSuccess;
-#endif
-  return avx512f::bf16_cvt_fp32_2D_write_back(src_ptr, dst_ptr, row, col, src_step, dst_step, zeropadding);
 }
 
 static inline JBLAS_CODE fp32_cvt_bf16_2D_write_back(const void* raw_srcptr, void* raw_dstptr, int row, int col,
                                                      int srcstride, int dststride, bool zeropadding) {
-#if CompileBF16()
   char* srcptr = (char*)raw_srcptr;
   char* dstptr = (char*)raw_dstptr;
   constexpr int simd_proc_elt = 32;
@@ -80,10 +77,10 @@ static inline JBLAS_CODE fp32_cvt_bf16_2D_write_back(const void* raw_srcptr, voi
       std::memset(dst + col * sizeof(utils::bf16), 0, npadding);
     }
   }
-#endif
-  return avx512f::fp32_cvt_bf16_2D_write_back(raw_srcptr, raw_dstptr, row, col, srcstride, dststride, zeropadding);
+  return JblasSuccess;
 }
 #pragma GCC pop_options
+#endif
 }  // namespace avx512_bf16
 }  // namespace kernel
 }  // namespace jblas

--- a/intel_extension_for_transformers/llm/library/jblas/jblas/kernel_avx512f.h
+++ b/intel_extension_for_transformers/llm/library/jblas/jblas/kernel_avx512f.h
@@ -39,12 +39,8 @@ namespace avx512f {
 #endif
 
 inline __m512 zmm_cvt_bf16_fp32(__m256i vbf16) {
-#if CompileBF16()
-  return _mm512_cvtpbh_ps((__m256bh)vbf16);
-#else
   auto vf32 = _mm512_cvtepu16_epi32(vbf16);
   return _mm512_castsi512_ps(_mm512_slli_epi32(vf32, 16));
-#endif
 }
 
 inline __m256i zmm_cvt_fp32_bf16(__m512 vfp32) {

--- a/intel_extension_for_transformers/llm/library/jblas/jblas/kernel_avx512f.h
+++ b/intel_extension_for_transformers/llm/library/jblas/jblas/kernel_avx512f.h
@@ -40,7 +40,7 @@ namespace avx512f {
 
 inline __m512 zmm_cvt_bf16_fp32(__m256i vbf16) {
 #if CompileBF16()
-  return _mm512_cvtph_ps(vbf16);
+  return _mm512_cvtpbh_ps((__m256bh)vbf16);
 #else
   auto vf32 = _mm512_cvtepu16_epi32(vbf16);
   return _mm512_castsi512_ps(_mm512_slli_epi32(vf32, 16));

--- a/intel_extension_for_transformers/llm/operator/csrc/CMakeLists.txt
+++ b/intel_extension_for_transformers/llm/operator/csrc/CMakeLists.txt
@@ -35,7 +35,8 @@ NO_DEFAULT_PATH)
 
 add_subdirectory(dispatcher)
 
-file(GLOB qbits_src ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+file(GLOB HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp)
+file(GLOB qbits_src ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp)
 # Define our library target
 add_library(qbits SHARED ${qbits_src})
 # Enable C++14

--- a/intel_extension_for_transformers/llm/operator/csrc/dispatcher/include/jblas_weightonly_dispatcher.hpp
+++ b/intel_extension_for_transformers/llm/operator/csrc/dispatcher/include/jblas_weightonly_dispatcher.hpp
@@ -19,6 +19,12 @@
 #include <assert.h>
 #include <iostream>
 
+inline bool check_amx() { return jblas::utils::parallel::CpuDevice::getInstance()->AMX_BF16(); }
+inline bool check_avx512_vnni() { return jblas::utils::parallel::CpuDevice::getInstance()->AVX512_VNNI(); }
+inline bool check_avx_vnni() { return jblas::utils::parallel::CpuDevice::getInstance()->AVX_VNNI(); };
+inline bool check_avx512f() { return jblas::utils::parallel::CpuDevice::getInstance()->AVX512F(); }
+inline bool check_avx2() { return jblas::utils::parallel::CpuDevice::getInstance()->AVX2(); }
+
 enum QBITS_TASK {
   QBITS_QUANTIZE,
   QBITS_DEQUANTIZE,

--- a/intel_extension_for_transformers/llm/operator/csrc/include/dropout.hpp
+++ b/intel_extension_for_transformers/llm/operator/csrc/include/dropout.hpp
@@ -1,0 +1,159 @@
+//  Copyright (c) 2023 Intel Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+#include "../dispatcher/include/jblas_weightonly_dispatcher.hpp"
+#include "jblas/jit_blas_utils.h"
+#include <ATen/core/TensorBody.h>
+#include <cstddef>
+#include <cstdint>
+#include <ctime>
+#include <immintrin.h>
+#include <iostream>
+#include <omp.h>
+#include <torch/script.h>
+#include <torch/torch.h>
+#include <torch/types.h>
+#include <vector>
+
+class RandBuffer {
+ public:
+  RandBuffer() {
+    std::srand((int)std::time(0));
+    auto thread_num = omp_get_max_threads();
+    load_buffer = jblas::utils::amalloc<uint32_t>(thread_num * 16);
+    iws = jblas::utils::amalloc<int>(thread_num * 16);
+    for (int i = 0; i < thread_num; i++) initMWC(rand(), i);
+  }
+
+  ~RandBuffer() {
+    if (iws != NULL) jblas::utils::afree(iws);
+    if (load_buffer != NULL) jblas::utils::afree(load_buffer);
+  }
+
+#pragma GCC push_options
+#pragma GCC target("avx512f", "avx512bw", "avx512vl", "avx512vbmi", "avx512dq")
+  __m512 gen_randfp(int thread_idx) {
+    auto zmm_one = _mm512_set1_epi32(0x3F800000);
+    auto rand = next1(thread_idx);
+    auto r1 = _mm512_sub_epi32(
+        zmm_one, _mm512_and_epi32(_mm512_srl_epi32(rand, _mm_cvtsi32_si128((int32_t)8)), _mm512_set1_epi32(1)));
+    auto r2 = _mm512_or_epi32(_mm512_srl_epi32(rand, _mm_cvtsi32_si128((int32_t)9)), zmm_one);
+    auto ans = _mm512_sub_ps(_mm512_castsi512_ps(r2), _mm512_castsi512_ps(r1));
+    return ans;
+  }
+#pragma GCC pop_options
+
+#pragma GCC push_options
+#pragma GCC target("avx2")
+  __m256 gen_randfp_avx2(int thread_idx) {
+    auto ymm_one = _mm256_set1_epi32(0x3F800000);
+    auto rand = next1_avx2(thread_idx);
+    auto r1 = _mm256_sub_epi32(
+        ymm_one, _mm256_and_si256(_mm256_srl_epi32(rand, _mm_cvtsi32_si128((int32_t)8)), _mm256_set1_epi32(1)));
+    auto r2 = _mm256_or_si256(_mm256_srl_epi32(rand, _mm_cvtsi32_si128((int32_t)9)), ymm_one);
+    auto ans = _mm256_sub_ps(_mm256_castsi256_ps(r2), _mm256_castsi256_ps(r1));
+    return ans;
+  }
+#pragma GCC pop_options
+
+ private:
+  enum constants : uint32_t {
+    // Factors for MWC generators
+    mwcfac0 = 4294963023u,  // Factor for each MWC generator
+    mwcfac1 = 3947008974u,
+    mwcfac2 = 4162943475u,
+    mwcfac3 = 2654432763u,
+    mwcfac4 = 3874257210u,
+    mwcfac5 = 2936881968u,
+    mwcfac6 = 4294957665u,
+    mwcfac7 = 2811536238u,
+    shw1 = 30,  // Shift counts for MWC tempering
+    shw2 = 35,
+    shw3 = 13
+  };
+
+  uint32_t* load_buffer;
+  int* iws;
+
+  const uint32_t MWCFactors[16] = {  // Factor for MWC
+      mwcfac0, 0, mwcfac1, 0, mwcfac2, 0, mwcfac3, 0, mwcfac4, 0, mwcfac5, 0, mwcfac6, 0, mwcfac7, 0};
+
+#pragma GCC push_options
+#pragma GCC target("avx512f", "avx512bw", "avx512vl", "avx512vbmi", "avx512dq")
+  __m512i next1(int thread_idx) {  // Get 512 bits from MWC
+    uint32_t* buffer = load_buffer + 16 * thread_idx;
+    // Factors for multiply-with-carry
+    __m512i x, f, y, y_cp;
+    x = _mm512_loadu_si512(buffer);      // previous x and carry
+    f = _mm512_loadu_si512(MWCFactors);  // factors
+    y = _mm512_mul_epu32(x, f);          // 32*32->64 bit unsigned multiply
+    // add old carry
+    x = _mm512_srl_epi64(x, _mm_cvtsi32_si128((int32_t)32u));
+    y = _mm512_add_epi64(x, y);
+    _mm512_storeu_si512(buffer, y);  // new x and carry
+    // The uppermost bits of the carry are not sufficiently random. Randomize
+    // some more for output
+    y_cp = _mm512_sll_epi64(y, _mm_cvtsi32_si128(shw1));
+    y = _mm512_xor_epi32(y, y_cp);
+    y_cp = _mm512_srl_epi64(y, _mm_cvtsi32_si128((int32_t)shw2));
+    y = _mm512_xor_epi32(y, y_cp);
+    y_cp = _mm512_sll_epi64(y, _mm_cvtsi32_si128(shw3));
+    y = _mm512_xor_epi32(y, y_cp);
+    return y;
+  }
+#pragma GCC pop_options
+
+#pragma GCC push_options
+#pragma GCC target("avx2")
+  __m256i next1_avx2(int thread_idx) {  // Get 256 bits from MWC
+    uint32_t* buffer = load_buffer + 8 * thread_idx;
+    auto iw = iws[thread_idx * 16];
+    __m256i x, f, y, y_cp;
+    x = _mm256_loadu_si256((__m256i_u*)(buffer + iw));
+    f = _mm256_loadu_si256((__m256i_u*)(MWCFactors + iw));
+    y = _mm256_mul_epu32(x, f);
+    x = _mm256_srl_epi64(x, _mm_cvtsi32_si128((int32_t)32u));
+    y = _mm256_add_epi64(x, y);
+    _mm256_storeu_si256((__m256i_u*)(buffer + iw), y);
+    y_cp = _mm256_sll_epi64(y, _mm_cvtsi32_si128(shw1));
+    y = _mm256_xor_si256(y, y_cp);
+    y_cp = _mm256_srl_epi64(y, _mm_cvtsi32_si128((int32_t)shw2));
+    y = _mm256_xor_si256(y, y_cp);
+    y_cp = _mm256_sll_epi64(y, _mm_cvtsi32_si128(shw3));
+    y = _mm256_xor_si256(y, y_cp);
+    iws[thread_idx * 16] = (iw + 8) & 15;
+    return y;
+  }
+
+  void initMWC(int seed, int thread_idx) {
+    uint32_t* buffer = load_buffer + 16 * thread_idx;
+    iws[thread_idx * 16] = 0;
+    int i;
+    // Fill buffer with function of seed
+    uint32_t tmp = seed;
+
+    // Seeds (0,0) and (-1,factor-1) will degenerate into constant output.
+    // This seeding method should avoid these forbidden seeds:
+
+    for (i = 0; i < 16; i++) {
+      tmp = buffer[i] = 1566083941u * (tmp ^ (tmp >> 27)) + i;
+    }
+    // Randomize 4 rounds
+    for (i = 0; i < 8; i++) next1_avx2(thread_idx);
+    iws[thread_idx * 16] = 0;
+  }
+#pragma GCC pop_options
+};
+static RandBuffer rand_generator;
+void dropout_bwd(torch::Tensor& grad, torch::Tensor& mask);
+torch::Tensor dropout_fwd(torch::Tensor& output, double p);

--- a/intel_extension_for_transformers/llm/operator/csrc/include/dropout.hpp
+++ b/intel_extension_for_transformers/llm/operator/csrc/include/dropout.hpp
@@ -41,7 +41,7 @@ class RandBuffer {
   }
 
 #pragma GCC push_options
-#pragma GCC target("avx512f", "avx512bw", "avx512vl", "avx512vbmi", "avx512dq")
+#pragma GCC target("avx512f")
   __m512 gen_randfp(int thread_idx) {
     auto zmm_one = _mm512_set1_epi32(0x3F800000);
     auto rand = next1(thread_idx);
@@ -89,7 +89,7 @@ class RandBuffer {
       mwcfac0, 0, mwcfac1, 0, mwcfac2, 0, mwcfac3, 0, mwcfac4, 0, mwcfac5, 0, mwcfac6, 0, mwcfac7, 0};
 
 #pragma GCC push_options
-#pragma GCC target("avx512f", "avx512bw", "avx512vl", "avx512vbmi", "avx512dq")
+#pragma GCC target("avx512f")
   __m512i next1(int thread_idx) {  // Get 512 bits from MWC
     uint32_t* buffer = load_buffer + 16 * thread_idx;
     // Factors for multiply-with-carry

--- a/intel_extension_for_transformers/llm/operator/csrc/qbits_ut/dropout_test.py
+++ b/intel_extension_for_transformers/llm/operator/csrc/qbits_ut/dropout_test.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ut_utils import *
+
+
+@capture_args
+def test(m, n, data_type, p,  dump_info=False):
+    weight = torch.rand(m, n, dtype=torch.float)
+    grad = torch.rand(m, n, dtype=torch.float)
+    if data_type == "bf16":
+        weight = weight.to(torch.bfloat16)
+        grad = grad.to(torch.bfloat16)
+    bk_grad = grad.clone()
+    mask = torch.ops.qbits_customop.qbits_dropout_fwd(weight, p)
+    num_zero = (m*n-torch.nonzero(mask.reshape(-1)).numel())
+    dropout_p = num_zero/(m*n)
+    if dump_info:
+        print("input p:"+str(p))
+        print("dropout p:"+str(dropout_p))
+    if not torch.allclose(torch.tensor(p), torch.tensor(dropout_p), 0.03):
+        print("fail")
+    torch.ops.qbits_customop.qbits_dropout_bwd(grad, mask)
+    bk_grad = torch.mul(bk_grad, mask)
+    if dump_info:
+        print(grad)
+        print(bk_grad)
+    if torch.allclose(grad, bk_grad, 0.01):
+        print("ok")
+    else:
+        print("fail")
+
+
+m_list = [151, 11008]
+n_list = [87, 4096]
+dt_list = ["fp32", "bf16"]
+p_list = [0.2, 0.8]
+
+for m in m_list:
+    for n in n_list:
+        for dt in dt_list:
+            for p in p_list:
+                test(m, n, dt, p)

--- a/intel_extension_for_transformers/llm/operator/csrc/qbits_ut/ut_utils.py
+++ b/intel_extension_for_transformers/llm/operator/csrc/qbits_ut/ut_utils.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import inspect
+import time
+from functools import wraps
+torch.ops.load_library("../build/libqbits.so")
+
+def capture_args(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        sig = inspect.signature(f)
+        bound_args = sig.bind(*args, **kwargs)
+        bound_args.apply_defaults()
+        arg_strs = []
+        for name, value in bound_args.arguments.items():
+            arg_strs.append(f'{name}={value}')
+        result = ', '.join(arg_strs)
+        print(result)
+        return f(*args, **kwargs)
+    return wrapper

--- a/intel_extension_for_transformers/llm/operator/csrc/qbits_ut/weightonly_test.py
+++ b/intel_extension_for_transformers/llm/operator/csrc/qbits_ut/weightonly_test.py
@@ -14,26 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import torch
-import inspect
-from functools import wraps
-torch.ops.load_library("../build/libqbits.so")
 
-
-def capture_args(f):
-    @wraps(f)
-    def wrapper(*args, **kwargs):
-        sig = inspect.signature(f)
-        bound_args = sig.bind(*args, **kwargs)
-        bound_args.apply_defaults()
-        arg_strs = []
-        for name, value in bound_args.arguments.items():
-            arg_strs.append(f'{name}={value}')
-        result = ', '.join(arg_strs)
-        print(result)
-        return f(*args, **kwargs)
-    return wrapper
-
+from ut_utils import *
 
 @capture_args
 def test(m, n, k, blocksize, compute_type, weight_type, transpose, add_bias, src_dt, dst_dt, dump_tensor_info=False):

--- a/intel_extension_for_transformers/llm/operator/csrc/src/dropout.cpp
+++ b/intel_extension_for_transformers/llm/operator/csrc/src/dropout.cpp
@@ -1,0 +1,277 @@
+//  Copyright (c) 2023 Intel Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+#include <ATen/core/TensorBody.h>
+#include <emmintrin.h>
+#include <immintrin.h>
+#include <xmmintrin.h>
+
+#include <cassert>
+
+#include "../include/dropout.hpp"
+#include "jblas/jit_blas_utils.h"
+#include "jblas/kernel_avx2.h"
+
+#pragma GCC push_options
+#pragma GCC target("avx512f", "avx512bw", "avx512vl", "avx512vbmi", "avx512dq", "avx512bf16")
+template <bool BF16>
+static inline void write_rand(char* data, int thread_idx, int64_t elt_num, int dt_size, double p, char* mask_ptr) {
+  int i = 0;
+  auto zmm_scale = _mm512_set1_ps(1.f / (1.f - p));
+  auto zmm_p = _mm512_set1_ps(float(p));
+  int align_elt_num = elt_num / 16 * 16;
+  for (; i < align_elt_num; i += 16) {
+    auto randv = rand_generator.gen_randfp(thread_idx);
+    auto mul_scale = _mm512_set1_ps(0.f);
+    auto zero_mask = _mm512_cmplt_ps_mask(zmm_p, randv);
+    mul_scale = _mm512_mask_mov_ps(mul_scale, zero_mask, zmm_scale);
+    if constexpr (!BF16) {
+      auto ans = _mm512_loadu_ps(data + i * dt_size);
+      ans = _mm512_mul_ps(ans, mul_scale);
+      _mm512_storeu_ps(data + i * dt_size, ans);
+      _mm512_storeu_ps(mask_ptr + i * dt_size, mul_scale);
+    } else {
+      auto ans = _mm512_cvtpbh_ps((__m256bh)_mm256_loadu_ps(reinterpret_cast<float*>(data + i * dt_size)));
+      ans = _mm512_mul_ps(ans, mul_scale);
+      auto bf16_ans = (__m256i)_mm512_cvtneps_pbh(ans);
+      auto bf16_mul_scale = (__m256i)_mm512_cvtneps_pbh(mul_scale);
+      _mm256_storeu_epi16(data + i * dt_size, bf16_ans);
+      _mm256_storeu_epi16(mask_ptr + i * dt_size, bf16_mul_scale);
+    }
+  }
+  if (i < elt_num) {
+    auto randv = rand_generator.gen_randfp(thread_idx);
+    auto ls_mask = _cvtu32_mask16(0xffff >> (16 - elt_num + i));
+    auto mul_scale = _mm512_set1_ps(0.f);
+    auto zero_mask = _mm512_cmplt_ps_mask(zmm_p, randv);
+    mul_scale = _mm512_mask_mov_ps(mul_scale, zero_mask, zmm_scale);
+    if constexpr (!BF16) {
+      __m512 ans;
+      ans = _mm512_mask_loadu_ps(ans, ls_mask, data + i * dt_size);
+      ans = _mm512_mul_ps(ans, mul_scale);
+      _mm512_mask_storeu_ps(data + i * dt_size, ls_mask, ans);
+      _mm512_mask_storeu_ps(mask_ptr + i * dt_size, ls_mask, mul_scale);
+    } else {
+      __m256i ymm_tmp;
+      auto ans = _mm512_cvtpbh_ps((__m256bh)_mm256_mask_loadu_epi16(ymm_tmp, ls_mask, data + i * dt_size));
+      ans = _mm512_mul_ps(ans, mul_scale);
+      auto bf16_ans = (__m256i)_mm512_cvtneps_pbh(ans);
+      auto bf16_mul_scale = (__m256i)_mm512_cvtneps_pbh(mul_scale);
+      _mm256_mask_storeu_epi16(data + i * dt_size, ls_mask, bf16_ans);
+      _mm256_mask_storeu_epi16(mask_ptr + i * dt_size, ls_mask, bf16_mul_scale);
+    }
+  }
+}
+
+template <bool BF16>
+static inline void mul(char* grad, int thread_idx, int64_t elt_num, int dt_size, char* mask_ptr) {
+  int i = 0;
+  int align_elt_num = elt_num / 16 * 16;
+  for (; i < align_elt_num; i += 16) {
+    if constexpr (!BF16) {
+      auto ans = _mm512_loadu_ps(grad + i * dt_size);
+      ans = _mm512_mul_ps(ans, _mm512_loadu_ps(mask_ptr + i * dt_size));
+      _mm512_storeu_ps(grad + i * dt_size, ans);
+    } else {
+      auto ans = _mm512_cvtpbh_ps((__m256bh)_mm256_loadu_ps(reinterpret_cast<float*>(grad + i * dt_size)));
+      auto zmm_mask = _mm512_cvtpbh_ps((__m256bh)_mm256_loadu_ps(reinterpret_cast<float*>(mask_ptr + i * dt_size)));
+      ans = _mm512_mul_ps(ans, zmm_mask);
+      auto bf16_ans = (__m256i)_mm512_cvtneps_pbh(ans);
+      _mm256_storeu_epi16(grad + i * dt_size, bf16_ans);
+    }
+  }
+  if (i < elt_num) {
+    auto ls_mask = _cvtu32_mask16(0xffff >> (16 - elt_num + i));
+    if constexpr (!BF16) {
+      __m512 ans, zmm_mask;
+      ans = _mm512_mask_loadu_ps(ans, ls_mask, grad + i * dt_size);
+      ans = _mm512_mul_ps(ans, _mm512_mask_loadu_ps(zmm_mask, ls_mask, mask_ptr + i * dt_size));
+      _mm512_mask_storeu_ps(grad + i * dt_size, ls_mask, ans);
+    } else {
+      __m256i ymm_tmp;
+      auto ans = _mm512_cvtpbh_ps((__m256bh)_mm256_mask_loadu_epi16(ymm_tmp, ls_mask, grad + i * dt_size));
+      auto zmm_mask = _mm512_cvtpbh_ps((__m256bh)_mm256_mask_loadu_epi16(ymm_tmp, ls_mask, mask_ptr + i * dt_size));
+      ans = _mm512_mul_ps(ans, zmm_mask);
+      auto bf16_ans = (__m256i)_mm512_cvtneps_pbh(ans);
+      _mm256_mask_storeu_epi16(grad + i * dt_size, ls_mask, bf16_ans);
+    }
+  }
+}
+#pragma GCC pop_options
+
+#pragma GCC push_options
+#pragma GCC target("avx2")
+template <bool BF16>
+static inline void write_rand_avx2(char* data, int thread_idx, int64_t elt_num, int dt_size, double p, char* mask_ptr) {
+  int i = 0;
+  auto ymm_scale = _mm256_set1_ps(1.f / (1.f - p));
+  auto ymm_p = _mm256_set1_ps(float(p));
+  int align_elt_num = elt_num / 8 * 8;
+  auto bf16_and_helper = _mm256_set1_epi32(0X00000001);
+  auto bf16_add_helper = _mm256_set1_epi32(0x00007FFF);
+  for (; i < align_elt_num; i += 8) {
+    auto randv = rand_generator.gen_randfp_avx2(thread_idx);
+    auto mul_scale = _mm256_set1_ps(0.f);
+    auto zero_mask = _mm256_cmp_ps(ymm_p, randv, 1);
+    mul_scale = _mm256_blendv_ps(mul_scale, ymm_scale, zero_mask);
+    if constexpr (!BF16) {
+      auto ans = _mm256_load_ps(reinterpret_cast<float*>(data + i * dt_size));
+      ans = _mm256_mul_ps(ans, mul_scale);
+      _mm256_store_ps(reinterpret_cast<float*>(data + i * dt_size), ans);
+      _mm256_store_ps(reinterpret_cast<float*>(mask_ptr + i * dt_size), mul_scale);
+    } else {
+      auto bf16_v = _mm_loadu_si128(reinterpret_cast<__m128i*>(data + i * dt_size));
+      auto fp32_v = _mm256_castsi256_ps(_mm256_bslli_epi128(_mm256_cvtepu16_epi32(bf16_v), 2));
+      fp32_v = _mm256_mul_ps(fp32_v, mul_scale);
+      auto ans = jblas::kernel::avx2::cvt_fp32_to_bf16(fp32_v, &bf16_and_helper, &bf16_add_helper);
+      auto bf16_scale = jblas::kernel::avx2::cvt_fp32_to_bf16(mul_scale, &bf16_and_helper, &bf16_add_helper);
+      _mm_store_ps(reinterpret_cast<float*>(data + i * dt_size), (__m128)ans);
+      _mm_store_ps(reinterpret_cast<float*>(mask_ptr + i * dt_size), (__m128)bf16_scale);
+    }
+  }
+  if (i < elt_num) {
+    auto randv = rand_generator.gen_randfp_avx2(thread_idx);
+    auto mul_scale = _mm256_set1_ps(0.f);
+    auto zero_mask = _mm256_cmp_ps(ymm_p, randv, 1);
+    if constexpr (!BF16) {
+      float* fp_data_ptr = reinterpret_cast<float*>(data);
+      float* fp_mask_ptr = reinterpret_cast<float*>(mask_ptr);
+      mul_scale = _mm256_blendv_ps(mul_scale, ymm_scale, zero_mask);
+      for (int j = 0; j < (elt_num - align_elt_num); j++) {
+        fp_data_ptr[i + j] = fp_data_ptr[i + j] * mul_scale[j];
+        fp_mask_ptr[i + j] = mul_scale[j];
+      }
+    } else {
+      jblas::utils::bf16* bf16_data_ptr = reinterpret_cast<jblas::utils::bf16*>(data);
+      jblas::utils::bf16* bf16_mask_ptr = reinterpret_cast<jblas::utils::bf16*>(mask_ptr);
+      mul_scale = _mm256_blendv_ps(mul_scale, ymm_scale, zero_mask);
+      for (int j = 0; j < (elt_num - align_elt_num); j++) {
+        bf16_data_ptr[i + j].fromfloat(bf16_data_ptr[i + j].tofloat() * mul_scale[j]);
+        bf16_mask_ptr[i + j].fromfloat(mul_scale[j]);
+      }
+    }
+  }
+}
+
+template <bool BF16>
+static inline void mul_avx2(char* grad, int thread_idx, int64_t elt_num, int dt_size, char* mask_ptr) {
+  int i = 0;
+  int align_elt_num = elt_num / 8 * 8;
+  auto bf16_and_helper = _mm256_set1_epi32(0X00000001);
+  auto bf16_add_helper = _mm256_set1_epi32(0x00007FFF);
+  for (; i < align_elt_num; i += 8) {
+    if constexpr (!BF16) {
+      auto ans = _mm256_load_ps(reinterpret_cast<float*>(grad + i * dt_size));
+      ans = _mm256_mul_ps(ans, _mm256_load_ps(reinterpret_cast<float*>(mask_ptr + i * dt_size)));
+      _mm256_store_ps(reinterpret_cast<float*>(grad + i * dt_size), ans);
+    } else {
+      auto bf16_grad = _mm_loadu_si128(reinterpret_cast<__m128i*>(grad + i * dt_size));
+      auto bf16_mask = _mm_loadu_si128(reinterpret_cast<__m128i*>(mask_ptr + i * dt_size));
+      auto fp32_grad = _mm256_castsi256_ps(_mm256_bslli_epi128(_mm256_cvtepu16_epi32(bf16_grad), 2));
+      auto fp32_mask = _mm256_castsi256_ps(_mm256_bslli_epi128(_mm256_cvtepu16_epi32(bf16_mask), 2));
+      fp32_grad = _mm256_mul_ps(fp32_grad, fp32_mask);
+      auto ans = jblas::kernel::avx2::cvt_fp32_to_bf16(fp32_grad, &bf16_and_helper, &bf16_add_helper);
+      _mm_store_ps(reinterpret_cast<float*>(grad + i * dt_size), (__m128)ans);
+    }
+  }
+  if (i < elt_num) {
+    if constexpr (!BF16) {
+      float* fp_data_ptr = reinterpret_cast<float*>(grad);
+      float* fp_mask_ptr = reinterpret_cast<float*>(mask_ptr);
+      for (int j = 0; j < (elt_num - align_elt_num); j++) {
+        fp_data_ptr[i + j] = fp_data_ptr[i + j] * fp_mask_ptr[i + j];
+      }
+    } else {
+      jblas::utils::bf16* bf16_data_ptr = reinterpret_cast<jblas::utils::bf16*>(grad);
+      jblas::utils::bf16* bf16_mask_ptr = reinterpret_cast<jblas::utils::bf16*>(mask_ptr);
+      for (int j = 0; j < (elt_num - align_elt_num); j++) {
+        bf16_data_ptr[i + j].fromfloat(bf16_data_ptr[i + j].tofloat() * bf16_mask_ptr[i + j].tofloat());
+      }
+    }
+  }
+}
+#pragma GCC pop_options
+
+torch::Tensor dropout_fwd(torch::Tensor& output, double p) {
+  auto elt_num = output.numel();
+  auto core_num = omp_get_max_threads();
+  auto task_each_core = jblas::utils::updiv(int(elt_num / core_num), 16) * 16;
+  torch::Tensor mask = torch::empty_like(output);
+#pragma omp parallel
+  {
+    auto ker_idx = omp_get_thread_num();
+    auto tasks =
+        elt_num - ker_idx * task_each_core > task_each_core ? task_each_core : elt_num - ker_idx * task_each_core;
+    if (output.scalar_type() == torch::kFloat32) {
+      if (check_avx512f()) {
+        write_rand<false>(reinterpret_cast<char*>(output.data_ptr()) + ker_idx * task_each_core * output.element_size(),
+                          ker_idx, tasks, output.element_size(), p,
+                          reinterpret_cast<char*>(mask.data_ptr()) + ker_idx * task_each_core * output.element_size());
+      } else {
+        write_rand_avx2<false>(
+            reinterpret_cast<char*>(output.data_ptr()) + ker_idx * task_each_core * output.element_size(), ker_idx,
+            tasks, output.element_size(), p,
+            reinterpret_cast<char*>(mask.data_ptr()) + ker_idx * task_each_core * output.element_size());
+      }
+    } else if (output.scalar_type() == torch::kBFloat16) {
+      if (check_avx512f()) {
+        write_rand<true>(reinterpret_cast<char*>(output.data_ptr()) + ker_idx * task_each_core * output.element_size(),
+                         ker_idx, tasks, output.element_size(), p,
+                         reinterpret_cast<char*>(mask.data_ptr()) + ker_idx * task_each_core * output.element_size());
+      } else {
+        write_rand_avx2<true>(
+            reinterpret_cast<char*>(output.data_ptr()) + ker_idx * task_each_core * output.element_size(), ker_idx,
+            tasks, output.element_size(), p,
+            reinterpret_cast<char*>(mask.data_ptr()) + ker_idx * task_each_core * output.element_size());
+      }
+    } else {
+      TORCH_CHECK(false, "Qbits: unsupported input data type in dropout operator.");
+    }
+  }
+  return mask;
+}
+
+void dropout_bwd(torch::Tensor& grad, torch::Tensor& mask) {
+  auto elt_num = grad.numel();
+  auto core_num = omp_get_max_threads();
+  auto task_each_core = jblas::utils::updiv(int(elt_num / core_num), 16) * 16;
+#pragma omp parallel
+  {
+    auto ker_idx = omp_get_thread_num();
+    auto tasks =
+        elt_num - ker_idx * task_each_core > task_each_core ? task_each_core : elt_num - ker_idx * task_each_core;
+    if (grad.scalar_type() == torch::kFloat32) {
+      if (check_avx512f()) {
+        mul<false>(reinterpret_cast<char*>(grad.data_ptr()) + ker_idx * task_each_core * grad.element_size(), ker_idx,
+                   tasks, grad.element_size(),
+                   reinterpret_cast<char*>(mask.data_ptr()) + ker_idx * task_each_core * grad.element_size());
+      } else {
+        mul_avx2<false>(reinterpret_cast<char*>(grad.data_ptr()) + ker_idx * task_each_core * grad.element_size(),
+                        ker_idx, tasks, grad.element_size(),
+                        reinterpret_cast<char*>(mask.data_ptr()) + ker_idx * task_each_core * grad.element_size());
+      }
+    } else if (grad.scalar_type() == torch::kBFloat16) {
+      if (check_avx512f()) {
+        mul<true>(reinterpret_cast<char*>(grad.data_ptr()) + ker_idx * task_each_core * grad.element_size(), ker_idx,
+                  tasks, grad.element_size(),
+                  reinterpret_cast<char*>(mask.data_ptr()) + ker_idx * task_each_core * grad.element_size());
+      } else {
+        mul_avx2<true>(reinterpret_cast<char*>(grad.data_ptr()) + ker_idx * task_each_core * grad.element_size(),
+                       ker_idx, tasks, grad.element_size(),
+                       reinterpret_cast<char*>(mask.data_ptr()) + ker_idx * task_each_core * grad.element_size());
+      }
+    } else {
+      TORCH_CHECK(false, "Qbits: unsupported input data type in dropout operator.");
+    }
+  }
+}

--- a/intel_extension_for_transformers/llm/operator/csrc/src/dropout.cpp
+++ b/intel_extension_for_transformers/llm/operator/csrc/src/dropout.cpp
@@ -21,7 +21,7 @@
 #include "jblas/kernel_avx2.h"
 
 #pragma GCC push_options
-#pragma GCC target("avx512f", , "avx512bw", "avx512vl", "avx512bf16")
+#pragma GCC target("avx512f", "avx512bw", "avx512vl", "avx512bf16")
 template <bool BF16>
 static inline void write_rand(char* data, int thread_idx, int64_t elt_num, int dt_size, double p, char* mask_ptr) {
   int i = 0;


### PR DESCRIPTION
## Type of Change

feature or bug fix or documentation or others: feature
API changed or not: Yes
user can call optimized fwd/bwd dropout operator in QBits, 3X+ perf improvement compared to pytorch.
e.g.
```
torch.ops.qbits_customop.qbits_dropout_fwd(weight, p)
torch.ops.qbits_customop.qbits_dropout_bwd(grad, mask)
```
## Description

detail description 
JIRA ticket: https://jira.devtools.intel.com/browse/NLPTOOLKIU-958
optmized fwd/bwd dropout operator under AVX512/AVX2 ISA, including a high-performance rand-generator.
change QBits log from cout to torch::LOG.

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)
tested on 335T(spr) & desktop(Core i9-10900)
## Dependency Change?
any library dependency introduced or removed
No.