### PR TITLE
[LLM Runtime] Beam Search Support of Fused Attention

### DIFF
--- a/intel_extension_for_transformers/llm/runtime/graph/README.md
+++ b/intel_extension_for_transformers/llm/runtime/graph/README.md
@@ -108,7 +108,7 @@ Argument description of WeightOnlyQuantConfig:
 | weight_dtype      | String      | Data type of quantized weight: int4/int8 (default int4)                                 |
 | alg               | String      | Quantization algorithm: sym/asym (default sym)                                          |
 | group_size        | Int         | Group size: Int (default: 32)                                                           |
-| scale_dtype       | String      | Data type of scales: fp32/bf16 (dafault fp32)                                           |
+| scale_dtype       | String      | Data type of scales: fp32/bf16 (default fp32)                                           |
 | use_ggml          | Bool        | Enable ggml for quantization and inference (default: False)                             |
 | use_quant         | Bool        | Determine whether or not the model will be quantized. (default: True)                  |
 | use_cache         | Bool        | Use local quantized model if file exists (default: False)                               |
@@ -125,7 +125,8 @@ Argument description of generate function:
 | batch_size        | Int         | Batch size for prompt processing (default: 512)                                         |
 | ctx_size          | Int         | Size of the prompt context (default: 512)                                               |
 | seed              | Int         | NG seed (default: -1, use random seed for < 0)                                          |
-| threads           | Int         | Number of threads to use during computation (default: 8)                                |
+| threads           | Int         | Number of threads to use during computation (default: min(available_core_num, OMP_NUM_THREADS))                                       |
+| memory_dtype      | str         | Data type of the KV memory; one of f16, f32, auto (enables Fused Attention when possible otherwise fallback to f16) (default: auto)   |
 | repetition_penalty| Float       | Please refer to [Transformer's generate](https://huggingface.co/docs/transformers/v4.35.0/en/main_classes/text_generation#generation) |
 | num_beams         | Int         | Please refer to [Transformer's generate](https://huggingface.co/docs/transformers/v4.35.0/en/main_classes/text_generation#generation) |
 | do_sample         | Int         | Please refer to [Transformer's generate](https://huggingface.co/docs/transformers/v4.35.0/en/main_classes/text_generation#generation) |
@@ -138,6 +139,7 @@ Argument description of generate function:
 | max_new_tokens    | Int         | Please refer to [Transformer's generate](https://huggingface.co/docs/transformers/v4.35.0/en/main_classes/text_generation#generation) |
 | streamer          | Class       | Please refer to [Transformer's generate](https://huggingface.co/docs/transformers/v4.35.0/en/main_classes/text_generation#generation) |
 | stopping_criteria | Class       | Please refer to [Transformer's generate](https://huggingface.co/docs/transformers/v4.35.0/en/main_classes/text_generation#generation) |
+| pad_token         | Int         | pad_token_id of [Transformer's generate](https://huggingface.co/docs/transformers/v4.35.0/en/main_classes/text_generation#generation) |
 
 ### 3. Multi-Round Chat
 

--- a/intel_extension_for_transformers/llm/runtime/graph/application/main_pybind.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/application/main_pybind.cpp
@@ -156,7 +156,7 @@ void Model::init_model(const std::string& model_path, int max_new_tokens, int n_
   params.beam_size = num_beams;
   params.do_sample = do_sample;
   params.batch_size = batch_size;
-  params.beam_search = (num_beams > 1 && !do_sample) ? true : false;
+  params.beam_search = (num_beams > 1 && !do_sample);
   params.top_k = top_k;
   params.top_p = top_p;
   params.temp = temperature;
@@ -171,7 +171,7 @@ void Model::init_model(const std::string& model_path, int max_new_tokens, int n_
     params.memory_type = KV_MEM_TYPE_AUTO;
   else
     fprintf(stderr, "Unexpected memory dtype!");
-  if (params.beam_search) params.memory_type = KV_MEM_TYPE_F16;  // TODO(Yi): NO MHA IN BEAM SEARCH
+  if (batch_size > 1) params.memory_type = KV_MEM_TYPE_F16;  // TODO(Yi): NO MHA IN MULTI-BATCH
 
   printf("beam_size: %d, do_sample: %d, top_k: %d, top_p: %f\n", params.beam_size, params.do_sample, params.top_k,
          params.top_p);

--- a/intel_extension_for_transformers/llm/runtime/graph/application/pybind_gptj.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/application/pybind_gptj.cpp
@@ -78,7 +78,7 @@ void* init_gptj(int seed, int n_predict, int n_batch, int top_k, float top_p, fl
   params.batch_size = batch_size;
   params.beam_search = beam_search;
   params.beam_size = beam_size;
-  params.memory_type = KV_MEM_TYPE_F16;  // TODO MEMORY_AUTO for MHA
+  if (batch_size > 1) params.memory_type = KV_MEM_TYPE_F16;  // TODO(Yi): NO MHA IN MULTI-BATCH
   // params.use_mmap = false;
   // params.use_mlock= true;
   model_init_backend();

--- a/intel_extension_for_transformers/llm/runtime/graph/core/layers/mha_dense.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/layers/mha_dense.h
@@ -139,6 +139,17 @@ void jblas_reordered_attn_fp32_update_v(const jblas_fusion_attn_fp32_update_kv_a
 void jblas_reordered_attn_fp32_shift_rope_k(char* cache, const ne_fp16_t* cossin, int batch_size, int heads_kv,
                                             int head_size, int seq_max, int seq_keep);
 
+typedef struct jblas_fusion_attn_fp32_batch_cpy_kv_args_t {
+  char* src;
+  char* dst;
+  int heads_kv, head_size, seq_off, seq_size, seq_max;
+  bool no_zeroing;  // set to true to prevent zeroing unaligned seq
+} jblas_fusion_attn_fp32_batch_cpy_kv_args_t;
+// copy k-cache across batch from seq_off to (seq_off + seq_size)
+void jblas_fusion_attn_fp32_batch_cpy_k(const jblas_fusion_attn_fp32_batch_cpy_kv_args_t* params);
+// copy v-cache across batch from seq_off to (seq_off + seq_size)
+void jblas_fusion_attn_fp32_batch_cpy_v(const jblas_fusion_attn_fp32_batch_cpy_kv_args_t* params);
+
 typedef struct jblas_reordered_attn_fp32_fp32_fwd_args_t {
   float* Q;
   char* K;  // K/V should be of type and layout used in corrsponding jblas_reordered_attn_xxx_update_kv


### PR DESCRIPTION
## Type of Change: Feature
API not changed

## Description
As title.

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR

## How has this PR been tested?
### MLPerf accuracy
q4_j1_bf16_pc: {'rouge1': 42.8563, 'rouge2': 19.8546, 'rougeL': 29.4987, 'rougeLsum': 40.0661, 'gen_len': 4581237, 'gen_num': 13368}
> A bit low, but probably due to the calculation precision itself

### Local Run
<details>
<summary>`python -m unittest tests/test_llm_runtime.py -vk beam` with single prompt:</summary>

```diff
diff --git a/intel_extension_for_transformers/llm/runtime/graph/tests/test_llm_runtime.py b/intel_extension_for_transformers/llm/runtime/graph/tests/test_llm_runtime.py
index 5c93edaa07..0bc2392534 100644
--- a/intel_extension_for_transformers/llm/runtime/graph/tests/test_llm_runtime.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/tests/test_llm_runtime.py
@@ -49,7 +49,7 @@ class TestLLMRUNTIME(unittest.TestCase):
 
         tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
         inputs = tokenizer(prompt, return_tensors="pt")
-        
+
         pt_logits = torch.load("/tf_dataset2/inc-ut/nlptoolkit_ut_model/llama2_pt_logits.pth")[:,-1]
         pt_generate_ids = torch.load("/tf_dataset2/inc-ut/nlptoolkit_ut_model/llama2_pt_generate_ids.pth")[0].tolist()
         print(tokenizer.decode(pt_generate_ids))
@@ -70,22 +70,22 @@ class TestLLMRUNTIME(unittest.TestCase):
             # "jblas_int8": WeightOnlyQuantConfig(compute_dtype="bf16", weight_dtype="int8", use_cache=True),
             }
         for config_type in woq_configs:
-            itrex_model = AutoModel.from_pretrained(model_name, quantization_config=woq_configs[config_type], 
+            itrex_model = AutoModel.from_pretrained(model_name, quantization_config=woq_configs[config_type],
                                                     use_llm_runtime=True, trust_remote_code=True)
             itrex_logits = itrex_model(inputs.input_ids)
             print(config_type, cmpData(pt_logits.detach().numpy().flatten(), itrex_logits.flatten()))
 
 
     def test_beam_search(self):
-        model_name = "/tf_dataset2/models/pytorch/gpt-j-6B"  # or local path to model
+        model_name = "/home/dingyi/gpt-j-6B"  # or local path to model
         prompts = [
            "she opened the door and see",
-           "tell me 10 things about jazz music",
-           "What is the meaning of life?",
-           "To be, or not to be, that is the question: Whether 'tis nobler in the mind to suffer"\
-            " The slings and arrows of outrageous fortune, "\
-            "Or to take arms against a sea of troubles."\
-            "And by opposing end them. To die—to sleep,"
+        #    "tell me 10 things about jazz music",
+        #    "What is the meaning of life?",
+        #    "To be, or not to be, that is the question: Whether 'tis nobler in the mind to suffer"\
+        #     " The slings and arrows of outrageous fortune, "\
+        #     "Or to take arms against a sea of troubles."\
+        #     "And by opposing end them. To die—to sleep,"
             ]
 
         tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True,
@@ -95,7 +95,10 @@ class TestLLMRUNTIME(unittest.TestCase):
         inputs = tokenizer(prompts, padding=True, return_tensors='pt')
 
         # pytorch fp32
-        pt_generate_ids = torch.load("/tf_dataset2/inc-ut/nlptoolkit_ut_model/beam_pt_generate_ids.pth").tolist()
+        pt_model = AutoModelForCausalLM.from_pretrained(model_name, trust_remote_code=True)
+        pt_model.eval()
+        pt_generate_ids = pt_model.generate(**inputs, max_new_tokens=128, min_new_tokens=30,
+                                            early_stopping=True, num_beams=4).tolist()
 
         # llm runtime fp32
         woq_config = WeightOnlyQuantConfig(not_quant=True, use_cache=True)
```
</details>

```
FP32 model will be used.
ARCH_REQ_XCOMP_PERM XTILE_DATA successful.
AVX:1 AVX2:1 AVX512F:1 AVX_VNNI:1 AVX512_VNNI:1 AMX_INT8:1 AMX_BF16:1 AVX512_BF16:1 AVX512_FP16:1
beam_size: 4, do_sample: 0, top_k: 40, top_p: 0.950000
model.cpp: loading model from runtime_outs/ne_gptj_f32.bin
init: n_vocab    = 50400
init: n_embd     = 4096
init: n_mult     = 256
init: n_head     = 16
init: n_layer    = 28
init: n_rot      = 64
init: n_ff       = 16384
init: n_parts    = 1
load: ne ctx size = 23082.36 MB
load: mem required  = 31274.36 MB (+ memory per state)
............................................................................................
model_init_from_file: support_jblas_kv = 1
model_init_from_file: kv self size =  966.00 MB
ok

----------------------------------------------------------------------
Ran 1 test in 632.999s

OK
```

## Dependency Change?
No