### PR TITLE
allow group_size -1 in quantization_config

### DIFF
--- a/intel_extension_for_transformers/transformers/utils/quantization_config.py
+++ b/intel_extension_for_transformers/transformers/utils/quantization_config.py
@@ -133,8 +133,8 @@ class WeightOnlyQuantConfig:
         if self.scale_dtype not in ["fp32", "fp16"]:
             raise ValueError("scale_dtype must be 'fp32', 'fp16'.")
 
-        if self.group_size not in [32, 128]:
-            raise ValueError("group_size must be an integer in [32, 128]")
+        if self.group_size not in [-1, 32, 128]:
+            raise ValueError("group_size must be an integer in [-1, 32, 128]")
 
         if self.scheme not in ["sym", "asym"]:
             raise ValueError("scheme must be 'sym', 'asym'.")


### PR DESCRIPTION
## Type of Change

Bug Fix

## Description

Before, `-1` as group size in `WeightOnlyQuantConfig` was rejected. However, this is the recommended value for several ISAs when using LLM Runtime according to https://github.com/intel/intel-extension-for-transformers/blob/main/intel_extension_for_transformers/llm/runtime/graph/core/README.md. 

## Expected Behavior & Potential Risk

group size -1 is now accepted when creating a `WeightOnlyQuantConfig`.

## How has this PR been tested?

Creating a quantization config with corresponding group size and using it for inference: `config = intel_extension_for_transformers.transformers.WeightOnlyQuantConfig(compute_dtype='int8', weight_dtype='int4', group_size=-1, use_cache=True)`

## Dependency Change?

none