### PR TITLE
Add Assisted Generation Example

### DIFF
--- a/examples/huggingface/pytorch/text-generation/assisted_generation/README.md
+++ b/examples/huggingface/pytorch/text-generation/assisted_generation/README.md
@@ -1,0 +1,68 @@
+# Assisted Generation
+
+IPEX supports assisted generation using the HugginFace API, to speedup inference by up to 3x.
+
+Assisted decoding uses an assistant model with the same tokenizer (ideally a much smaller model) to greedily generate a few candidate tokens. The main model then validates the candidate tokens in a single forward pass, which speeds up the decoding process.  Note that the speedup increases as the size of the main model increases.
+
+See [here](https://huggingface.co/blog/assisted-generation) for more info on assisted generation.
+
+
+## Setup
+
+Create a conda environment (recommended):
+
+```bash
+conda create -n llm python=3.9 -y && conda activate llm
+```
+
+Copy these commands into the shell:
+
+```bash
+conda install ninja mkl mkl-include -y
+conda install gperftools -c conda-forge -y
+
+python -m pip install torch==2.1 --index-url https://download.pytorch.org/whl/cpu
+python -m pip install intel_extension_for_pytorch
+
+# install others deps
+python -m pip install cpuid transformers accelerate onnx sentencepiece
+python -m pip install --no-deps optimum
+python -m pip install --no-deps git+https://github.com/huggingface/optimum-intel.git@main
+
+# Setup Environment Variables for best performance on Xeon
+export KMP_BLOCKTIME=1
+export KMP_SETTINGS=1
+export KMP_AFFINITY=granularity=fine,compact,1,0
+export LD_PRELOAD=${LD_PRELOAD}:${CONDA_PREFIX}/lib/libiomp5.so # Intel OpenMP
+# Tcmalloc is a recommended malloc implementation that emphasizes fragmentation avoidance and scalable concurrency support.
+export LD_PRELOAD=${LD_PRELOAD}:${CONDA_PREFIX}/lib/libtcmalloc.so
+```
+
+## Usage 
+
+```bash
+# Support single socket and multiple sockets
+OMP_NUM_THREADS=<physical cores num> numactl -m <node N> -C <physical cores list> python run_assisted_generation.py -m facebook/opt-13b
+```
+
+These are the default assistant models used in the script:
+
+```python
+"OPTForCausalLM": "facebook/opt-125m",
+"LlamaForCausalLM": "PY007/TinyLlama-1.1B-intermediate-step-715k-1.5T",
+"GPTBigCodeForCausalLM": "bigcode/tiny_starcoder_py"
+```
+
+To specify a different assistant model:
+
+```bash
+OMP_NUM_THREADS=<physical cores num> numactl -m <node N> -C <physical cores list> python run_assisted_generation.py -m "facebook/opt-13b" --assistant-model "facebook/opt-350m"
+```
+
+
+
+To turn off assisted generation feature (for benchmarking purposes):
+
+```bash
+OMP_NUM_THREADS=<physical cores num> numactl -m <node N> -C <physical cores list> python run_assisted_generation.py -m "facebook/opt-13b" --no-assisted
+```

--- a/examples/huggingface/pytorch/text-generation/assisted_generation/run_assisted_generation.py
+++ b/examples/huggingface/pytorch/text-generation/assisted_generation/run_assisted_generation.py
@@ -1,0 +1,120 @@
+import torch
+import time
+import argparse
+
+# import logging
+# logging.disable(logging.WARNING)
+
+from transformers import (
+    pipeline,
+    AutoModelForCausalLM,
+    LlamaForCausalLM,
+    AutoTokenizer,
+    LlamaTokenizer,
+)
+
+MODEL_CLASSES = {
+    "auto": (AutoModelForCausalLM, AutoTokenizer),
+    "llama": (LlamaForCausalLM, LlamaTokenizer),
+}
+
+DEFAULT_ASSISTANT_MODELS = {
+    "OPTForCausalLM": "facebook/opt-125m",
+    "LlamaForCausalLM": "PY007/TinyLlama-1.1B-intermediate-step-715k-1.5T",
+    "GPTBigCodeForCausalLM": "bigcode/tiny_starcoder_py"
+}
+
+# args
+parser = argparse.ArgumentParser("Text generation script", add_help=False)
+parser.add_argument(
+    "-m", "--model-id", type=str, required=True, help="huggingface model")
+parser.add_argument(
+    "-n", "--no-assisted", default=False, action=argparse.BooleanOptionalAction, help='Disable assisted generation.')
+parser.add_argument(
+    "--assistant-model", type=str, default=None, help="Override the default assistant model")
+parser.add_argument("--dtype", type=str, default="bfloat16", choices=["bfloat16", "float32"])
+parser.add_argument("--max-new-tokens", default=128, type=int, help="max new tokens")
+
+args = parser.parse_args()
+print(args)
+
+# device
+device = torch.device("cpu")
+
+# torch dtype
+if args.dtype == "bfloat16":
+    amp_enabled = True
+    amp_dtype = torch.bfloat16
+else:
+    amp_enabled = False
+    amp_dtype = torch.float32
+
+def load_model(model_id):
+    model_type = next((x for x in MODEL_CLASSES.keys() if x in model_id.lower()), 'auto')
+    model_class = MODEL_CLASSES[model_type]
+    print("Load model via", model_class)
+    model = model_class[0].from_pretrained(model_id, low_cpu_mem_usage=True, torch_dtype=amp_dtype)
+    print("Model dtype:", model.config.torch_dtype)
+    model = model.eval().to(device)
+    model = model.to(memory_format=torch.channels_last)
+    return model, model_class
+
+model, model_class = load_model(args.model_id)
+tokenizer = model_class[1].from_pretrained(args.model_id)
+
+if args.no_assisted:
+    assistant_model = None
+else:
+    if args.assistant_model is not None:
+        assistant_model_name = args.assistant_model
+    else:
+        assistant_model_name = DEFAULT_ASSISTANT_MODELS.get(model.config.architectures[0])
+        if assistant_model_name is None:
+            raise ValueError(f"No default assistant model associated with {args.model_id}, please specify using `--assistant_model`.")
+
+    print(f"Assistant model: {assistant_model_name}")
+    assistant_model, _ = load_model(assistant_model_name)
+
+# generate args
+generate_kwargs = dict(
+    do_sample=False, max_new_tokens=args.max_new_tokens, assistant_model=assistant_model
+)
+text_generator = pipeline(
+    "text-generation", model=model, tokenizer=tokenizer, **generate_kwargs
+)
+
+# input prompt
+if "code" in model.config.architectures[0].lower():
+    prompt = """def string_sequence(n: int) -> str: \"\"\" Return a string containing space-delimited numbers starting from 0 upto n inclusive. >>> string_sequence(0) '0' >>> string_sequence(5) '0 1 2 3 4 5' \"\"\""""
+else:
+    prompt = "DeepSpeed is a machine learning framework for deep neural networks and deep reinforcement learning. It is written in C++ and is available for Linux, Mac OS X,"
+prompt = [prompt]
+input_size = tokenizer(prompt, return_tensors="pt").input_ids.size(dim=1)
+print("---- Prompt size:", input_size)
+
+# start
+num_iter = 10
+num_warmup = 3
+
+
+def torch_generation():
+    total_time = 0.0
+    with torch.inference_mode(), torch.autocast(
+        "cpu", enabled=amp_enabled, dtype=amp_dtype if amp_enabled else None
+    ):
+        for i in range(num_iter):
+            tic = time.perf_counter()
+            output = text_generator(prompt)
+            toc = time.perf_counter()
+            print(output, flush=True)
+            if i >= num_warmup:
+                total_time += toc - tic
+    return total_time, num_iter - num_warmup
+
+
+total_time, total_iter = torch_generation()
+latency = total_time / total_iter
+print(
+    "\nSentence latency: %.3f sec, Token latency: %.3f sec, Token throughput: %.2f tokens/s.\n"
+    % (latency, latency / args.max_new_tokens, args.max_new_tokens / latency)
+)


### PR DESCRIPTION
Added an example script for running Assisted Generation.

## Description

This example showcases the usage of Assisted Generation (AG) to accelerate generation.
The example uses the HuggingFace API for assisted generation. 
A smaller, assistant model, is used to generate a few tokens which are then validated by the large, target model in a single batch. Thus, the output tokens (and accuracy) with AG are identical to the output tokens when running without AG.
The example script defines default assistant models for 3 popular model families: `Llama`, `OPT` and `starcoder`.
AG can speedup generation by up to `4.5x` (tested separately on `Xeon(R) 8580`).

## How has this PR been tested?

Manual testing:

Tested configurations:
`python run_assisted_generation.py -m <model_id>`
Where `<model_id> = facebook/opt-13b | meta-llama/Llama-2-13b-chat-hf | bigcode/starcoder`

`python run_assisted_generation.py -m <model_id> --assistant-model <assistant_id>`
Where `<model_id> = facebook/opt-13b and <assistant_id> = facebook/opt-350m`

`python run_assisted_generation.py -m <model_id> --no-assisted`
Where `<model_id> = facebook/opt-13b`

Config:
`Intel(R) Xeon(R) Platinum 8380`
`Ubuntu 20.04.4 LTS`

## Dependency Change?

No changes.

cc @kevinintel @changwangss @PenghuiCheng