### PR TITLE
fix tts ut random issue

### DIFF
--- a/intel_extension_for_transformers/neural_chat/pipeline/plugins/audio/tts.py
+++ b/intel_extension_for_transformers/neural_chat/pipeline/plugins/audio/tts.py
@@ -37,7 +37,7 @@ class TextToSpeech():
     3) Customized voice (Original model + User's customized input voice embedding)
     """
     def __init__(self, output_audio_path="./response.wav", voice="default", stream_mode=False, device="cpu",
-                 reduce_noise=True):
+                 reduce_noise=False):
         """Make sure your export LD_PRELOAD=<path to libiomp5.so and libtcmalloc> beforehand."""
         # default setting
         self.device = device

--- a/intel_extension_for_transformers/neural_chat/tests/ci/plugins/audio/test_tts.py
+++ b/intel_extension_for_transformers/neural_chat/tests/ci/plugins/audio/test_tts.py
@@ -22,6 +22,7 @@ import shutil
 import os
 import time
 import torch
+from transformers import set_seed
 
 class TestTTS(unittest.TestCase):
     @classmethod
@@ -53,6 +54,7 @@ class TestTTS(unittest.TestCase):
     def test_tts(self):
         text = "Welcome to Neural Chat"
         output_audio_path = os.path.join(os.getcwd(), "tmp_audio/1.wav")
+        set_seed(555)
         output_audio_path = self.tts.text2speech(text, output_audio_path, voice="default")
         self.assertTrue(os.path.exists(output_audio_path))
         # verify accuracy
@@ -62,12 +64,14 @@ class TestTTS(unittest.TestCase):
     def test_tts_customized_voice(self):
         text = "Welcome to Neural Chat"
         output_audio_path = os.path.join(os.getcwd(), "tmp_audio/3.wav")
+        set_seed(555)
         output_audio_path = self.tts.text2speech(text, output_audio_path, voice="male")
         self.assertTrue(os.path.exists(output_audio_path))
         # verify accuracy
         result = self.asr.audio2text(output_audio_path)
         self.assertEqual(text.lower(), result.lower())
         output_audio_path = os.path.join(os.getcwd(), "tmp_audio/4.wav")
+        set_seed(555)
         output_audio_path = self.tts.text2speech(text, output_audio_path, voice="female")
         self.assertTrue(os.path.exists(output_audio_path))
         # verify accuracy
@@ -89,6 +93,7 @@ class TestTTS(unittest.TestCase):
         "Intel platforms, in particular effective on 4th Intel Xeon Scalable processor Sapphire Rapids " + \
         "(codenamed Sapphire Rapids)"
         output_audio_path = os.path.join(os.getcwd(), "tmp_audio/2.wav")
+        set_seed(555)
         output_audio_path = self.tts.text2speech(text, output_audio_path, voice="default", do_batch_tts=True, batch_length=120)
         self.assertTrue(os.path.exists(output_audio_path))
 
@@ -103,11 +108,14 @@ class TestTTS(unittest.TestCase):
         self.assertEqual(spk_embed.shape[1], 512)
 
     def test_tts_remove_noise(self):
-        text = "hello there."
+        text = "hello there"
         output_audio_path = os.path.join(os.getcwd(), "tmp_audio/5.wav")
+        set_seed(555)
         output_audio_path = self.tts_noise_reducer.text2speech(text, output_audio_path, voice="default")
         self.assertTrue(os.path.exists(output_audio_path))
-
+        # verify accuracy
+        result = self.asr.audio2text(output_audio_path)
+        self.assertEqual(text.lower(), result.lower())
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Type of Change

bug fix

## Description

Sometimes text to speech output is slightly different and causes UT error, and this is because a dropout is also applied in inference (https://github.com/huggingface/transformers/blob/main/src/transformers/models/speecht5/modeling_speecht5.py#L687), so we keep the seed to be the same before each inference, to keep the same bernoulli sequence. Meanwhile, the `reduce_noise` flag is disabled by default.

## Expected Behavior & Potential Risk

Same as above.

## How has this PR been tested?

UT

## Dependency Change?

None