### PR TITLE
move llmruntime ut to azure for disk missing

### DIFF
--- a/.github/workflows/unit-test-llmruntime.yml
+++ b/.github/workflows/unit-test-llmruntime.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   unit-test:
-    runs-on: [self-hosted, linux, X64, llmruntime-node]
+    runs-on: [self-hosted, linux, X64, itrex-node]
     steps:
       - name: Load environment variables
         run: cat ~/actions-runner2/.env >> $GITHUB_ENV
@@ -53,7 +53,7 @@ jobs:
 
       - name: Docker Build
         run: |
-          docker build -f ${{ github.workspace }}/.github/workflows/docker/${{ env.DOCKER_FILE_NAME }}.dockerfile --build-arg http_proxy="${{ env.HTTP_PROXY }}" --build-arg https_proxy="${{ env.HTTPS_PROXY }}" -t ${{ env.REPO_NAME }}:${{ env.REPO_TAG }} .
+          docker build -f ${{ github.workspace }}/.github/workflows/docker/${{ env.DOCKER_FILE_NAME }}.dockerfile -t ${{ env.REPO_NAME }}:${{ env.REPO_TAG }} .
 
       - name: Docker Run
         run: |
@@ -62,8 +62,6 @@ jobs:
             docker rm -vf ${{ env.CONTAINER_NAME }}-${{ runner.name }} || true
           fi
           docker run -dit --disable-content-trust --privileged --name=${{ env.CONTAINER_NAME }}-${{ runner.name }} -v /dev/shm:/dev/shm \
-          -e http_proxy="${{ env.HTTP_PROXY }}" \
-          -e https_proxy="${{ env.HTTPS_PROXY }}" \
           -v ${{ github.workspace }}:/intel-extension-for-transformers \
           -v /tf_dataset2:/tf_dataset2 \
           -v ~/.cache/oneAPI:/cache \


### PR DESCRIPTION
## Type of Change

Due to shared disk missing data, move llmruntime running on Azure temperately, and disable chatbot infer for the same reason. Will check chatbot infer in nightly test temperately.