### PR TITLE
[NeuralChat]  Add optimization pipeline for LLaMa model familly

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ https://github.com/intel/intel-extension-for-transformers/assets/109187816/1698d
 https://github.com/intel/intel-extension-for-transformers/assets/88082706/9d9bdb7e-65db-47bb-bbed-d23b151e8b31
 
 ## 📃Selected Publications/Events
+* Blog published on Huggingface: [Intel Neural-Chat 7b: Fine-Tuning on Gaudi2 for Top LLM Performance](https://huggingface.co/blog/Andyrasika/neural-chat-intel) (Nov 2023)
 * Video on YouTube: [Neural Chat 7B v3-1 Installation on Windows - Step by Step](https://www.youtube.com/watch?v=7_urstS-noU) (Nov 2023)
 * Video on YouTube: [Intel's Neural-Chat 7b: Most Powerful 7B Model! Beats GPT-4!?](https://www.youtube.com/watch?v=bWhZ1u_1rlc) (Nov 2023)
 * Blog published on marktechpost: [Intel Researchers Propose a New Artificial Intelligence Approach to Deploy LLMs on CPUs More Efficiently](https://www.marktechpost.com/2023/11/09/intel-researchers-propose-a-new-artificial-intelligence-approach-to-deploy-llms-on-cpus-more-efficiently) (Nov 2023)

--- a/docs/publication.md
+++ b/docs/publication.md
@@ -1,6 +1,7 @@
-Full Publications/Events (23)
+Full Publications/Events (29)
 ==========
-## 2023 (22)
+## 2023 (23)
+* Blog published on Huggingface: [Intel Neural-Chat 7b: Fine-Tuning on Gaudi2 for Top LLM Performance](https://huggingface.co/blog/Andyrasika/neural-chat-intel) (Nov 2023)
 * Video on YouTube: [Neural Chat 7B v3-1 Installation on Windows - Step by Step](https://www.youtube.com/watch?v=7_urstS-noU) (Nov 2023)
 * Video on YouTube: [Intel's Neural-Chat 7b: Most Powerful 7B Model! Beats GPT-4!?](https://www.youtube.com/watch?v=bWhZ1u_1rlc) (Nov 2023)
 * Blog published on marktechpost: [Intel Researchers Propose a New Artificial Intelligence Approach to Deploy LLMs on CPUs More Efficiently](https://www.marktechpost.com/2023/11/09/intel-researchers-propose-a-new-artificial-intelligence-approach-to-deploy-llms-on-cpus-more-efficiently) (Nov 2023)

--- a/intel_extension_for_transformers/neural_chat/models/model_utils.py
+++ b/intel_extension_for_transformers/neural_chat/models/model_utils.py
@@ -322,7 +322,6 @@ def load_model(
         torch_dtype = torch.float32
 
     MODELS[model_name] = {}
-    
     tokenizer = AutoTokenizer.from_pretrained(
         tokenizer_name,
         use_fast=False if (re.search("llama", model_name, re.IGNORECASE)
@@ -331,11 +330,9 @@ def load_model(
         trust_remote_code=True if (re.search("qwen", model_name, re.IGNORECASE) or \
             re.search("chatglm", model_name, re.IGNORECASE)) else False,
     )
-
     config = AutoConfig.from_pretrained(model_name, use_auth_token=hf_access_token, trust_remote_code=True \
                                         if re.search("chatglm", model_name, re.IGNORECASE) else False)
     load_to_meta = model_on_meta(config)
-    
     if isinstance(optimization_config, WeightOnlyQuantConfig) and not re.search("llama", model_name, re.IGNORECASE):
         from intel_extension_for_transformers.neural_chat.chatbot import optimize_model
         model = optimize_model(model_name, optimization_config, use_llm_runtime)
@@ -488,7 +485,6 @@ def load_model(
         MODELS[model_name]["tokenizer"] = tokenizer
         print("Optimized Model loaded.")
         return
-
     if device == "hpu":
         if peft_path:
             from peft import PeftModel
@@ -871,7 +867,6 @@ def predict_stream(**params):
         if output_token_len != 1
         else 0
     )
-    
     if return_stats:
         stats = {
             "input_token_len": str(input_token_len),

--- a/intel_extension_for_transformers/neural_chat/models/model_utils.py
+++ b/intel_extension_for_transformers/neural_chat/models/model_utils.py
@@ -516,7 +516,9 @@ def load_model(
         if device == "cpu":
             import intel_extension_for_pytorch as intel_ipex
             if re.search("llama", model_name, re.IGNORECASE):
-                qconfig = None if ipex_int8==False else intel_ipex.quantization.get_weight_only_quant_qconfig_mapping(weight_dtype=torch.quint4x2, lowp_mode=intel_ipex.quantization.WoqLowpMode.BF16)
+                qconfig = None if ipex_int8 == False else intel_ipex.quantization.get_weight_only_quant_qconfig_mapping(
+                    weight_dtype=torch.quint4x2, lowp_mode=intel_ipex.quantization.WoqLowpMode.BF16
+                )
                 model = intel_ipex.optimize_transformers(model.eval(),
                                                          dtype=torch_dtype,
                                                          inplace=True,

--- a/intel_extension_for_transformers/neural_chat/models/model_utils.py
+++ b/intel_extension_for_transformers/neural_chat/models/model_utils.py
@@ -322,6 +322,7 @@ def load_model(
         torch_dtype = torch.float32
 
     MODELS[model_name] = {}
+    
     tokenizer = AutoTokenizer.from_pretrained(
         tokenizer_name,
         use_fast=False if (re.search("llama", model_name, re.IGNORECASE)
@@ -330,11 +331,12 @@ def load_model(
         trust_remote_code=True if (re.search("qwen", model_name, re.IGNORECASE) or \
             re.search("chatglm", model_name, re.IGNORECASE)) else False,
     )
+
     config = AutoConfig.from_pretrained(model_name, use_auth_token=hf_access_token, trust_remote_code=True \
                                         if re.search("chatglm", model_name, re.IGNORECASE) else False)
     load_to_meta = model_on_meta(config)
-
-    if isinstance(optimization_config, WeightOnlyQuantConfig):
+    
+    if isinstance(optimization_config, WeightOnlyQuantConfig) and not re.search("llama", model_name, re.IGNORECASE):
         from intel_extension_for_transformers.neural_chat.chatbot import optimize_model
         model = optimize_model(model_name, optimization_config, use_llm_runtime)
         if not model.config.is_encoder_decoder:
@@ -345,10 +347,11 @@ def load_model(
         MODELS[model_name]["tokenizer"] = tokenizer
         print("Optimized Model loaded.")
         return
-
+    
     if peft_path and device == "hpu" and use_deepspeed and load_to_meta:
         print("PEFT could not work in deepspeed sharded checkpt loading mode, set load_to_meta to False")
         load_to_meta = False
+
     if device == "hpu" and use_deepspeed and load_to_meta:
         with deepspeed.OnDevice(dtype=torch.bfloat16, device="meta"):
             model = AutoModelForCausalLM.from_config(config, torch_dtype=torch.bfloat16)
@@ -477,6 +480,15 @@ def load_model(
     if model.generation_config.eos_token_id is None:
         model.generation_config.eos_token_id = tokenizer.eos_token_id
 
+    if isinstance(optimization_config, WeightOnlyQuantConfig) and not re.search("llama", model_name, re.IGNORECASE):
+        from intel_extension_for_transformers.neural_chat.chatbot import optimize_model
+        model = optimize_model(model, optimization_config, use_llm_runtime)
+
+        MODELS[model_name]["model"] = model
+        MODELS[model_name]["tokenizer"] = tokenizer
+        print("Optimized Model loaded.")
+        return
+
     if device == "hpu":
         if peft_path:
             from peft import PeftModel
@@ -506,9 +518,16 @@ def load_model(
             model = model.to(dtype=torch_dtype)
 
         if device == "cpu":
-            if torch_dtype == torch.bfloat16 and not ipex_int8:
-                import intel_extension_for_pytorch as intel_ipex
-
+            import intel_extension_for_pytorch as intel_ipex
+            if re.search("llama", model_name, re.IGNORECASE):
+                qconfig = None if ipex_int8==False else intel_ipex.quantization.get_weight_only_quant_qconfig_mapping(weight_dtype=torch.quint4x2, lowp_mode=intel_ipex.quantization.WoqLowpMode.BF16)
+                model = intel_ipex.optimize_transformers(model.eval(),
+                                                         dtype=torch_dtype,
+                                                         inplace=True,
+                                                         quantization_config=qconfig,
+                                                         deployment_mode=cpu_jit
+                                                        )
+            elif torch_dtype == torch.bfloat16 and not ipex_int8:
                 model = intel_ipex.optimize(
                     model.eval(),
                     dtype=torch_dtype,
@@ -768,7 +787,7 @@ def predict_stream(**params):
                                     generation_config=generation_config,
                                     return_dict_in_generate=True,
                                 )
-                    output_token_len= len(output_token[0]) if is_llm_runtime_model(model) else \
+                    output_token_len = len(output_token[0]) if is_llm_runtime_model(model) else \
                                       output_token.sequences[0].shape[-1]
                     return output_token
             except Exception as e:
@@ -852,6 +871,7 @@ def predict_stream(**params):
         if output_token_len != 1
         else 0
     )
+    
     if return_stats:
         stats = {
             "input_token_len": str(input_token_len),

--- a/intel_extension_for_transformers/transformers/trainer.py
+++ b/intel_extension_for_transformers/transformers/trainer.py
@@ -25,7 +25,9 @@ import sys
 import time
 import json
 import warnings
+from itertools import chain
 from functools import partial
+from optimum.exporters.tasks import TasksManager
 from neural_compressor import __version__ as nc_version
 from neural_compressor.experimental import Component
 from neural_compressor.utils import logger
@@ -2054,7 +2056,7 @@ class BaseTrainer():
         self._remove_label(input)
 
         # convert to a dict
-        input = dict(input.items())       
+        input = dict(input.items())   
 
         if model.__class__.__name__ == 'XLNetForSequenceClassification': # pragma: no cover
             input.pop('token_type_ids')
@@ -2062,12 +2064,33 @@ class BaseTrainer():
         symbolic_names = {0: 'batch_size', 1: 'max_seq_len'}
         axes_dict = {k: symbolic_names for k in input.keys()}
 
+        # set input and output names
+        input_names=list(input.keys())
+        output_names=None
+
+        model_name_or_path = model.config._name_or_path
+        task = TasksManager.infer_task_from_model(model_name_or_path)
+        try:
+            # try to get export config
+            onnx_config_constructor = TasksManager.get_exporter_config_constructor(
+                model=model, exporter="onnx", task=task
+            )
+            onnx_config = onnx_config_constructor(model.config)
+            inputs = onnx_config.ordered_inputs(model)
+            input_names = list(inputs.keys())
+            output_names = list(onnx_config.outputs.keys())
+            axes_dict = dict(chain(inputs.items(), onnx_config.outputs.items()))
+        except:
+            # skip and use settings collected from dataloader
+            pass
+
         torch.onnx.export(
             model,
             (input, ),
             onnx_save_path,
             opset_version=opset_version,
-            input_names=list(input.keys()),
+            input_names=input_names,
+            output_names=output_names,
             dynamic_axes=axes_dict,
             do_constant_folding=do_constant_folding,
         )


### PR DESCRIPTION
## Type of Change

Enhanced the LLaMa model family by incorporating an optimization pipeline using ipex.optimize_transformers(). The API remains unchanged.

## Description

This change adds support for ipex.optimize_transformers, which is causing significant perfromance boost for LLaMa model familly.

## Expected Behavior & Potential Risk

Implemented modifications to enable quantization for the LLaMa model family, with the added option to optionally trace the model for FP32/BF16 precision.

## How has this PR been tested?

Neuralchat localhost deployment was tested on c7i.24xlarge AWS instance. 
Confirmed compatibility with frontend.

## Dependency Change?

This PR is not changing any dependencies.

## Additional Comments

As ipex.optimize_transformers() brings a notable performance boost to models, it is advisable to contemplate a gradual transition to using this library once it is supported by ipex