### PR TITLE
[LLM Runtime] add shared memory support ccl to parallel context

### DIFF
--- a/intel_extension_for_transformers/llm/runtime/graph/application/main_run.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/application/main_run.cpp
@@ -405,6 +405,15 @@ int main(int argc, char** argv) {  // NOLINT
   const bool penalize_nl = params.penalize_nl;
   model_token id = 0;
 
+#ifdef NE_TP_MODEL
+  // sync here to make multi node run into inference at the same time
+  parallel_context* p_ctx = init_parallel_context();
+  if (get_tp_size(p_ctx) > 1) {
+    barrier(p_ctx);
+  }
+
+#endif
+
   while ((n_remain != 0 && !is_antiprompt) || params.interactive) {
     // predict
     if (embd.size() > 0) {

--- a/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.c
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.c
@@ -1324,13 +1324,9 @@ struct ne_tensor* ne_debug_op(struct ne_context* ctx, struct ne_tensor* a, ne_de
   return result;
 }
 
-struct ne_tensor* ne_dup(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_dup_impl(ctx, a, false);
-}
+struct ne_tensor* ne_dup(struct ne_context* ctx, struct ne_tensor* a) { return ne_dup_impl(ctx, a, false); }
 
-struct ne_tensor* ne_dup_inplace(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_dup_impl(ctx, a, true);
-}
+struct ne_tensor* ne_dup_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_dup_impl(ctx, a, true); }
 
 // ne_add
 
@@ -1683,13 +1679,9 @@ struct ne_tensor* ne_sqr_impl(struct ne_context* ctx, struct ne_tensor* a, bool 
   return result;
 }
 
-struct ne_tensor* ne_sqr(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_sqr_impl(ctx, a, false);
-}
+struct ne_tensor* ne_sqr(struct ne_context* ctx, struct ne_tensor* a) { return ne_sqr_impl(ctx, a, false); }
 
-struct ne_tensor* ne_sqr_inplace(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_sqr_impl(ctx, a, true);
-}
+struct ne_tensor* ne_sqr_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_sqr_impl(ctx, a, true); }
 
 // ne_sqrt
 
@@ -1710,13 +1702,9 @@ struct ne_tensor* ne_sqrt_impl(struct ne_context* ctx, struct ne_tensor* a, bool
   return result;
 }
 
-struct ne_tensor* ne_sqrt(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_sqrt_impl(ctx, a, false);
-}
+struct ne_tensor* ne_sqrt(struct ne_context* ctx, struct ne_tensor* a) { return ne_sqrt_impl(ctx, a, false); }
 
-struct ne_tensor* ne_sqrt_inplace(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_sqrt_impl(ctx, a, true);
-}
+struct ne_tensor* ne_sqrt_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_sqrt_impl(ctx, a, true); }
 
 // ne_log
 
@@ -1737,13 +1725,9 @@ struct ne_tensor* ne_log_impl(struct ne_context* ctx, struct ne_tensor* a, bool 
   return result;
 }
 
-struct ne_tensor* ne_log(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_log_impl(ctx, a, false);
-}
+struct ne_tensor* ne_log(struct ne_context* ctx, struct ne_tensor* a) { return ne_log_impl(ctx, a, false); }
 
-struct ne_tensor* ne_log_inplace(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_log_impl(ctx, a, true);
-}
+struct ne_tensor* ne_log_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_log_impl(ctx, a, true); }
 
 // ne_sum
 
@@ -1853,13 +1837,9 @@ struct ne_tensor* ne_abs_impl(struct ne_context* ctx, struct ne_tensor* a, bool 
   return result;
 }
 
-struct ne_tensor* ne_abs(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_abs_impl(ctx, a, false);
-}
+struct ne_tensor* ne_abs(struct ne_context* ctx, struct ne_tensor* a) { return ne_abs_impl(ctx, a, false); }
 
-struct ne_tensor* ne_abs_inplace(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_abs_impl(ctx, a, true);
-}
+struct ne_tensor* ne_abs_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_abs_impl(ctx, a, true); }
 
 // ne_sgn
 
@@ -1880,13 +1860,9 @@ struct ne_tensor* ne_sgn_impl(struct ne_context* ctx, struct ne_tensor* a, bool 
   return result;
 }
 
-struct ne_tensor* ne_sgn(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_sgn_impl(ctx, a, false);
-}
+struct ne_tensor* ne_sgn(struct ne_context* ctx, struct ne_tensor* a) { return ne_sgn_impl(ctx, a, false); }
 
-struct ne_tensor* ne_sgn_inplace(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_sgn_impl(ctx, a, true);
-}
+struct ne_tensor* ne_sgn_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_sgn_impl(ctx, a, true); }
 
 // ne_neg
 
@@ -1907,13 +1883,9 @@ struct ne_tensor* ne_neg_impl(struct ne_context* ctx, struct ne_tensor* a, bool 
   return result;
 }
 
-struct ne_tensor* ne_neg(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_neg_impl(ctx, a, false);
-}
+struct ne_tensor* ne_neg(struct ne_context* ctx, struct ne_tensor* a) { return ne_neg_impl(ctx, a, false); }
 
-struct ne_tensor* ne_neg_inplace(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_neg_impl(ctx, a, true);
-}
+struct ne_tensor* ne_neg_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_neg_impl(ctx, a, true); }
 
 // ne_step
 
@@ -1934,13 +1906,9 @@ struct ne_tensor* ne_step_impl(struct ne_context* ctx, struct ne_tensor* a, bool
   return result;
 }
 
-struct ne_tensor* ne_step(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_step_impl(ctx, a, false);
-}
+struct ne_tensor* ne_step(struct ne_context* ctx, struct ne_tensor* a) { return ne_step_impl(ctx, a, false); }
 
-struct ne_tensor* ne_step_inplace(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_step_impl(ctx, a, true);
-}
+struct ne_tensor* ne_step_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_step_impl(ctx, a, true); }
 
 // ne_relu
 
@@ -1961,13 +1929,9 @@ struct ne_tensor* ne_relu_impl(struct ne_context* ctx, struct ne_tensor* a, bool
   return result;
 }
 
-struct ne_tensor* ne_relu(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_relu_impl(ctx, a, false);
-}
+struct ne_tensor* ne_relu(struct ne_context* ctx, struct ne_tensor* a) { return ne_relu_impl(ctx, a, false); }
 
-struct ne_tensor* ne_relu_inplace(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_relu_impl(ctx, a, true);
-}
+struct ne_tensor* ne_relu_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_relu_impl(ctx, a, true); }
 
 // ne_gelu
 
@@ -1988,13 +1952,9 @@ struct ne_tensor* ne_gelu_impl(struct ne_context* ctx, struct ne_tensor* a, bool
   return result;
 }
 
-struct ne_tensor* ne_gelu(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_gelu_impl(ctx, a, false);
-}
+struct ne_tensor* ne_gelu(struct ne_context* ctx, struct ne_tensor* a) { return ne_gelu_impl(ctx, a, false); }
 
-struct ne_tensor* ne_gelu_inplace(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_gelu_impl(ctx, a, true);
-}
+struct ne_tensor* ne_gelu_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_gelu_impl(ctx, a, true); }
 
 // ne_silu
 
@@ -2015,13 +1975,9 @@ struct ne_tensor* ne_silu_impl(struct ne_context* ctx, struct ne_tensor* a, bool
   return result;
 }
 
-struct ne_tensor* ne_silu(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_silu_impl(ctx, a, false);
-}
+struct ne_tensor* ne_silu(struct ne_context* ctx, struct ne_tensor* a) { return ne_silu_impl(ctx, a, false); }
 
-struct ne_tensor* ne_silu_inplace(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_silu_impl(ctx, a, true);
-}
+struct ne_tensor* ne_silu_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_silu_impl(ctx, a, true); }
 
 // ne_silu_back
 
@@ -2063,13 +2019,9 @@ struct ne_tensor* ne_norm_impl(struct ne_context* ctx, struct ne_tensor* a, bool
   return result;
 }
 
-struct ne_tensor* ne_norm(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_norm_impl(ctx, a, false);
-}
+struct ne_tensor* ne_norm(struct ne_context* ctx, struct ne_tensor* a) { return ne_norm_impl(ctx, a, false); }
 
-struct ne_tensor* ne_norm_inplace(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_norm_impl(ctx, a, true);
-}
+struct ne_tensor* ne_norm_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_norm_impl(ctx, a, true); }
 
 struct ne_tensor* ne_rms_norm_impl(struct ne_context* ctx, struct ne_tensor* a, bool inplace, float eps) {
   bool is_node = false;
@@ -2415,13 +2367,9 @@ struct ne_tensor* ne_cont_impl(struct ne_context* ctx, struct ne_tensor* a, bool
   return result;
 }
 
-struct ne_tensor* ne_cont(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_cont_impl(ctx, a, false);
-}
+struct ne_tensor* ne_cont(struct ne_context* ctx, struct ne_tensor* a) { return ne_cont_impl(ctx, a, false); }
 
-struct ne_tensor* ne_cont_inplace(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_cont_impl(ctx, a, true);
-}
+struct ne_tensor* ne_cont_inplace(struct ne_context* ctx, struct ne_tensor* a) { return ne_cont_impl(ctx, a, true); }
 
 // ne_reshape
 
@@ -2968,9 +2916,7 @@ struct ne_tensor* ne_soft_max_impl(struct ne_context* ctx, struct ne_tensor* a, 
   return result;
 }
 
-struct ne_tensor* ne_soft_max(struct ne_context* ctx, struct ne_tensor* a) {
-  return ne_soft_max_impl(ctx, a, false);
-}
+struct ne_tensor* ne_soft_max(struct ne_context* ctx, struct ne_tensor* a) { return ne_soft_max_impl(ctx, a, false); }
 
 struct ne_tensor* ne_soft_max_inplace(struct ne_context* ctx, struct ne_tensor* a) {
   return ne_soft_max_impl(ctx, a, true);
@@ -7652,7 +7598,7 @@ static void ne_compute_forward_alibi_f32(const struct ne_compute_params* params,
   }
 
   const int n_past = ((int32_t*)src1->data)[0];
-  const int n_head = ((int32_t*)src1->data)[1];
+  int n_head = ((int32_t*)src1->data)[1];
   const float max_bias = ((float*)src1->data)[2];
 
   assert(n_past >= 0);
@@ -7673,6 +7619,15 @@ static void ne_compute_forward_alibi_f32(const struct ne_compute_params* params,
   assert(nb0 == sizeof(float));
   assert(ne1 + n_past == ne0);
   (void)n_past;
+  // TP will need the real rank oder of k
+  int32_t k_offset = 0;
+#ifdef NE_TP_MODEL
+  parallel_context* p_ctx = init_parallel_context();
+  int32_t world_size = get_tp_size(p_ctx);
+  int32_t rank = get_tp_rank(p_ctx);
+  if (world_size > 1) k_offset += rank * n_head;
+  n_head *= world_size;
+#endif
 
   // add alibi to src0 (KQ_scaled)
   const int n_heads_log2_floor = 1 << (int)floor(log2(n_head));
@@ -7690,10 +7645,10 @@ static void ne_compute_forward_alibi_f32(const struct ne_compute_params* params,
 
         float m_k;
 
-        if (k < n_heads_log2_floor) {
-          m_k = powf(m0, k + 1);
+        if (k + k_offset < n_heads_log2_floor) {
+          m_k = powf(m0, k + k_offset + 1);
         } else {
-          m_k = powf(m1, 2 * (k - n_heads_log2_floor) + 1);
+          m_k = powf(m1, 2 * (k + k_offset - n_heads_log2_floor) + 1);
         }
 
         pdst[0] = (i - ne0 + 1) * m_k + src[0];
@@ -7713,7 +7668,7 @@ static void ne_compute_forward_alibi_f16(const struct ne_compute_params* params,
   }
 
   const int n_past = ((int32_t*)src1->data)[0];
-  const int n_head = ((int32_t*)src1->data)[1];
+  int n_head = ((int32_t*)src1->data)[1];
   const float max_bias = ((float*)src1->data)[2];
 
   assert(n_past >= 0);
@@ -7734,7 +7689,15 @@ static void ne_compute_forward_alibi_f16(const struct ne_compute_params* params,
   assert(nb0 == sizeof(ne_fp16_t));
   assert(ne1 + n_past == ne0);
   (void)n_past;
-
+  // TP will need the real rank oder of k
+  int32_t k_offset = 0;
+#ifdef NE_TP_MODEL
+  parallel_context* p_ctx = init_parallel_context();
+  int32_t world_size = get_tp_size(p_ctx);
+  int32_t rank = get_tp_rank(p_ctx);
+  if (world_size > 1) k_offset += rank * n_head;
+  n_head *= world_size;
+#endif
   // add alibi to src0 (KQ_scaled)
   const int n_heads_log2_floor = 1 << (int)floor(log2(n_head));
 
@@ -7752,10 +7715,10 @@ static void ne_compute_forward_alibi_f16(const struct ne_compute_params* params,
 
         float m_k;
 
-        if (k < n_heads_log2_floor) {
-          m_k = powf(m0, k + 1);
+        if (k + k_offset < n_heads_log2_floor) {
+          m_k = powf(m0, k + k_offset + 1);
         } else {
-          m_k = powf(m1, 2 * (k - n_heads_log2_floor) + 1);
+          m_k = powf(m1, 2 * (k + k_offset - n_heads_log2_floor) + 1);
         }
 
         // we return F32

--- a/intel_extension_for_transformers/llm/runtime/graph/core/parallel_context.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/parallel_context.cpp
@@ -14,6 +14,7 @@
 #include <mpi.h>
 #include "oneapi/ccl.hpp"
 #include "parallel_context.h"
+#include "shared_memory_ccl.hpp"
 
 class parallel_class {
  public:
@@ -26,7 +27,12 @@ class parallel_class {
       return instance_p;
     }
   }
-  ~parallel_class() { delete pcomm; }
+  ~parallel_class() {
+    delete pcomm;
+    if (use_shm) {
+      shared_close(&shared_buffer);
+    }
+  }
 
   bool is_master() { return rank == 0; }
 
@@ -37,8 +43,13 @@ class parallel_class {
 
   // From some example code of oneCCL, inplace reducing is supported
   void reduce_add(float* sendBuf, float* recvBuf, size_t count) {
-    ccl::allreduce(sendBuf, recvBuf, count, ccl::reduction::sum, *pcomm).wait();
+    if (use_shm) {
+      shm_all_reduce(sendBuf, recvBuf, count, rank, world_size);
+    } else {
+      ccl::allreduce(sendBuf, recvBuf, count, ccl::reduction::sum, *pcomm).wait();
+    }
   }
+
   void broadcast(float* buf, size_t count) {
     int root = 0;  // assume always broadcast from master
     ccl::broadcast(buf, count, root, *pcomm).wait();
@@ -71,6 +82,30 @@ class parallel_class {
 
     rank = pcomm->rank();
     world_size = pcomm->size();
+
+    // Check whether all ranks is on the same physical machine.
+    // If true use SHM allreduce
+    auto local_size = std::getenv("TP_LOCAL_SIZE");
+    if (local_size != NULL) {
+      use_shm = std::stoi(local_size) == world_size;
+    }
+    if (use_shm) {
+      char shm_name[100];
+      snprintf(shm_name, 100, "%s_%d", "shared_memory_tp", getuid());
+      if (rank == 0) {
+        cbuffer = (struct ccl_buffer*)malloc(world_size * sizeof(struct ccl_buffer));
+        shared_create(&shared_buffer, shm_name, cbuffer, world_size * sizeof(struct ccl_buffer));
+        cbuffer = (struct ccl_buffer*)shared_buffer.bytes;
+        for (int i = 0; i < world_size; i++) {
+          cbuffer[i].state = ccl_begin;
+        }
+      }
+      ccl::barrier(*pcomm).wait();
+      if (rank != 0) {
+        shared_open(&shared_buffer, shm_name, world_size * sizeof(struct ccl_buffer));
+      }
+      cbuffer = (struct ccl_buffer*)shared_buffer.bytes;
+    }
   }
   static void mpi_finalize() {
     int is_finalized = 0;
@@ -81,6 +116,8 @@ class parallel_class {
     }
   }
 
+  bool use_shm = false;
+  SharedData shared_buffer;
   int world_size;
   int rank;
 

--- a/intel_extension_for_transformers/llm/runtime/graph/core/shared_memory_ccl.hpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/shared_memory_ccl.hpp
@@ -184,7 +184,7 @@ void shm_all_reduce(float* sendBuf, float* recvBuf, size_t count, size_t rank, s
   for (int offset = 0; offset < count * sizeof(float); offset += MAX_BUF_SIZE) {
     auto send_ptr = (char*)sendBuf + offset;
     auto recv_ptr = (char*)recvBuf + offset;
-    size_t chunk_size = count * sizeof(float) - offset > MAX_BUF_SIZE ? MAX_BUF_SIZE : count * sizeof(float) - offset;
+    size_t chunk_size = std::min(count * sizeof(float) - offset, MAX_BUF_SIZE)
     size_t chunk_count = chunk_size / sizeof(float);
 
     parallel_memcpy(cbuffer[rank].data, send_ptr, chunk_size);

--- a/intel_extension_for_transformers/llm/runtime/graph/core/shared_memory_ccl.hpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/shared_memory_ccl.hpp
@@ -214,7 +214,7 @@ void shm_all_reduce(float* sendBuf, float* recvBuf, size_t count, size_t rank, s
     }
     if (rank == 0) {
       for (int i = 1; i < world_size; i++) {
-        wait_state_change(i, copy_out_done);
+        wait_state_equal(i, copy_out_done);
       }
       std::atomic_thread_fence(std::memory_order_release);
       cbuffer[rank].state = ccl_begin;

--- a/intel_extension_for_transformers/llm/runtime/graph/core/shared_memory_ccl.hpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/shared_memory_ccl.hpp
@@ -1,0 +1,241 @@
+//  Copyright (c) 2023 Intel Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+#include <assert.h>
+#include <fcntl.h>
+#include <immintrin.h>
+#include <math.h>
+#include <omp.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <atomic>
+#include <cstdlib>
+#include <iostream>
+#include "oneapi/ccl.hpp"
+
+// states for collectives
+enum ccl_state {
+  ccl_begin = 0,
+  copy_in_done,
+  reduce_done,
+  copy_out_done,
+};
+
+// SHM building blocks
+struct SharedData {
+  const char* name;
+  int descriptor;
+  void* bytes;
+  size_t nbytes;
+};
+
+void shared_open(SharedData* data, const char* name, size_t nbytes) {
+  int d = shm_open(name, O_RDWR, S_IRUSR | S_IWUSR);
+  if (d != -1) {
+    void* bytes = mmap(NULL, nbytes, PROT_READ | PROT_WRITE, MAP_SHARED, d, 0);
+    data->name = name;
+    data->descriptor = d;
+    data->bytes = bytes;
+    data->nbytes = nbytes;
+  } else {
+    printf("shared_open %s failed\n", name);
+    data->descriptor = -1;
+  }
+}
+
+void shared_create(SharedData* data, const char* name, void* bytes, size_t nbytes) {
+  int d = shm_open(name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
+  if (d != -1) {
+    if (nbytes = write(d, bytes, nbytes)) {
+      shared_open(data, name, nbytes);
+    }
+  } else {
+    printf("shared_create %s failed\n", name);
+  }
+}
+
+void shared_close(SharedData* data) {
+  if (data->descriptor != -1) {
+    munmap(data->bytes, data->nbytes);
+    shm_unlink(data->name);
+  }
+}
+
+#define MAX_BUF_SIZE 1048576
+struct ccl_buffer {
+  enum ccl_state state;
+  char data[MAX_BUF_SIZE];
+};
+struct ccl_buffer* cbuffer;
+
+void wait_state_equal(int index, enum ccl_state state) {
+  volatile enum ccl_state* state_ptr = &(cbuffer[index].state);
+  while (*state_ptr != state)
+    ;
+}
+
+void wait_state_change(int index, enum ccl_state state) {
+  volatile enum ccl_state* state_ptr = &(cbuffer[index].state);
+  while (*state_ptr == state)
+    ;
+}
+
+void reduce_2_fp32_buffers(int num_elements, void* rank_0, void* rank_1) __attribute__((target("avx512bw")));
+
+void reduce_fp32_buffers(int num_elements, int num_buffers, struct ccl_buffer* cbuffer)
+    __attribute__((target("avx512bw")));
+
+// N_REDUCE_LIMIT is the number of buffers that can be reduced together in one shot.
+// Compared with do N-1 2-reduces which needs 2*(N-1) read and N-1 write,
+// N-reduce only needs N read and 1 write, this saves 2/3 memory bandwidth.
+// When increase N_REDUCE_LIMIT to a bigger number, do the following steps
+// 1. Extend REPEAT_<X> macros list down below
+// 2. Extend switch cases which call "REPEAT(X, ...)" down below
+#define N_REDUCE_LIMIT 8
+
+void reduce_buffers(struct ccl_buffer* cbuffer, int num_elements, int num_buffers) {
+  if(num_buffers == 2) {
+    reduce_2_fp32_buffers(num_elements, cbuffer[0].data, cbuffer[1].data);
+  } else if (num_buffers > 2 && num_buffers <= N_REDUCE_LIMIT) {
+    reduce_fp32_buffers(num_elements, num_buffers, cbuffer);
+  } else {
+    assert(!"Not supported buffer number.");
+  }
+}
+
+#define REPEAT(N, x) REPEAT_##N(x)
+#define REPEAT_1(x) x(1)
+#define REPEAT_2(x) \
+  REPEAT_1(x);      \
+  x(2)
+#define REPEAT_3(x) \
+  REPEAT_2(x);      \
+  x(3)
+#define REPEAT_4(x) \
+  REPEAT_3(x);      \
+  x(4)
+#define REPEAT_5(x) \
+  REPEAT_4(x);      \
+  x(5)
+#define REPEAT_6(x) \
+  REPEAT_5(x);      \
+  x(6)
+#define REPEAT_7(x) \
+  REPEAT_6(x);      \
+  x(7)
+
+// Reduce functions down below use vectorized algorithm, the number of bytes processed each
+// iteration depends on vector length.  256bit vector ==> 32 bytes, 512bit vector ==> 64 bytes
+#define VECTOR_LENGTH_IN_BYTES 32
+
+#define REDUCE_ADD_F32(x)                                                     \
+  do {                                                                     \
+    auto in##x##_val = _mm256_loadu_ps((float*)(cbuffer[x].data + i)); \
+    inout_val = _mm256_add_ps(inout_val, in##x##_val);                     \
+  } while (0)
+
+void reduce_fp32_buffers(int num_elements, int num_buffers, struct ccl_buffer* cbuffer) {
+// TODO num_elements must be divisible by 16 (caller check)
+#pragma omp parallel for
+  for (int i = 0; i < num_elements * 4; i += VECTOR_LENGTH_IN_BYTES) {
+    auto inout_val = _mm256_loadu_ps((float*)(cbuffer[0].data + i));
+    switch (num_buffers) {
+      case 8:
+        REPEAT(7, REDUCE_ADD_F32);
+        break;
+      case 7:
+        REPEAT(6, REDUCE_ADD_F32);
+        break;
+      case 6:
+        REPEAT(5, REDUCE_ADD_F32);
+        break;
+      case 5:
+        REPEAT(4, REDUCE_ADD_F32);
+        break;
+      case 4:
+        REPEAT(3, REDUCE_ADD_F32);
+        break;
+      case 3:
+        REPEAT(2, REDUCE_ADD_F32);
+        break;
+      default:
+        assert(!"Should not get here.");
+    }
+    _mm256_storeu_ps((float*)(cbuffer[0].data + i), inout_val);
+  }
+}
+
+void reduce_2_fp32_buffers(int num_elements, void* rank_0, void* rank_1) {
+#pragma omp parallel for
+  for (int i = 0; i < num_elements * sizeof(float); i += VECTOR_LENGTH_IN_BYTES) {
+    auto rank_0_val = _mm256_loadu_ps((float*)((char*)rank_0 + i));
+    auto rank_1_val = _mm256_loadu_ps((float*)((char*)rank_1 + i));
+    rank_0_val = _mm256_add_ps(rank_0_val, rank_1_val);
+    _mm256_storeu_ps((float*)((char*)rank_0 + i), rank_0_val);
+  }
+}
+
+static void parallel_memcpy(void* to, void* from, size_t n_bytes) __attribute__((target("avx512bw")));
+static void parallel_memcpy(void* to, void* from, size_t n_bytes) {
+#pragma omp parallel for
+  for (int i = 0; i < n_bytes; i += VECTOR_LENGTH_IN_BYTES) {
+    auto val = _mm256_loadu_si256((__m256i*)((char*)from + i));
+    _mm256_storeu_si256((__m256i*)((char*)to + i), val);
+  }
+}
+
+void shm_all_reduce(float* sendBuf, float* recvBuf, size_t count, size_t rank, size_t world_size) {
+  for (int offset = 0; offset < count * sizeof(float); offset += MAX_BUF_SIZE) {
+    auto send_ptr = (char*)sendBuf + offset;
+    auto recv_ptr = (char*)recvBuf + offset;
+    size_t chunk_size = count * sizeof(float) - offset > MAX_BUF_SIZE ? MAX_BUF_SIZE : count * sizeof(float) - offset;
+    size_t chunk_count = chunk_size / sizeof(float);
+
+    parallel_memcpy(cbuffer[rank].data, send_ptr, chunk_size);
+    std::atomic_thread_fence(std::memory_order_release);
+    cbuffer[rank].state = copy_in_done;
+
+    if (rank == 0) {
+      // compute allreduce result on rank 0
+      for (int i = 1; i < world_size; i++) {
+        // wait until the other rank copy the buffer
+        wait_state_equal(i, copy_in_done);
+      }
+      reduce_buffers(cbuffer, chunk_count, world_size);
+      std::atomic_thread_fence(std::memory_order_release);
+      cbuffer[rank].state = reduce_done;
+      parallel_memcpy(recv_ptr, cbuffer[0].data, chunk_size);
+    }
+    if (rank != 0) {
+      wait_state_equal(0, reduce_done);
+      parallel_memcpy(recv_ptr, cbuffer[0].data, chunk_size);
+      std::atomic_thread_fence(std::memory_order_release);
+      cbuffer[rank].state = copy_out_done;
+    }
+    if (rank == 0) {
+      for (int i = 1; i < world_size; i++) {
+        wait_state_change(i, copy_out_done);
+      }
+      std::atomic_thread_fence(std::memory_order_release);
+      cbuffer[rank].state = ccl_begin;
+    }
+    if (rank != 0) {
+      // if rank 0 spin too fast it could be in state 1 of next allreduce
+      // in this case wait_state_change(0, 0) may cause deadlock
+      // what we are certain is when rank 0 finishes the state won't be 2
+      wait_state_change(0, reduce_done);
+      cbuffer[rank].state = ccl_begin;
+    }
+  }
+}

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_files.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_files.h
@@ -138,6 +138,13 @@ struct model_load_tensor {
           name.find(".attn.k_proj.weight") != std::string::npos ||
           name.find(".attn.v_proj.weight") != std::string::npos ||
           name.find(".mlp.fc_in.weight") != std::string::npos ||
+          // for baichuan
+          name.find(".self_attn.W_pack.weight") != std::string::npos ||
+          name.find(".mlp.gate_proj.weight") != std::string::npos ||
+          name.find(".mlp.up_proj.weight") != std::string::npos ||
+          // for chatglm2
+          name.find(".self_attention.query_key_value.weight") != std::string::npos ||
+          name.find(".mlp.dense_h_to_4h.weight") != std::string::npos ||
           // for llama model
           name.find(".attention.wq.weight") != std::string::npos ||
           name.find(".attention.wk.weight") != std::string::npos ||
@@ -148,6 +155,13 @@ struct model_load_tensor {
       }
       if (name.find(".mlp.fc_in.bias") != std::string::npos || name.find(".mlp.fc_out.weight") != std::string::npos ||
           name.find(".attn.out_proj.weight") != std::string::npos ||
+          name.find(".self_attention.dense.weight") != std::string::npos ||
+          // for baichuan
+          name.find(".self_attn.o_proj.weight") != std::string::npos ||
+          name.find(".mlp.down_proj.weight") != std::string::npos ||
+          // for chatglm2
+          name.find(".mlp.dense_4h_to_h.weight") != std::string::npos ||
+          name.find(".self_attention.query_key_value.bias") != std::string::npos ||
           // TODO check if this part should be column
           name.find(".attention.wo.weight") != std::string::npos ||
           name.find(".feed_forward.w2.weight") != std::string::npos) {

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_files.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_files.h
@@ -107,8 +107,8 @@ struct model_load_tensor {
       size = shards[0].size;
 #ifdef NE_TP_MODEL
       if (split_type == TP_1D_ROW || split_type == TP_1D_COLUMN) {
-	// TODO when we can calc accurate jblas split size, remove this
-	size_t JBLAS_MISC_SIZE = 192;
+        // TODO when we can calc accurate jblas split size, remove this
+        size_t JBLAS_MISC_SIZE = 192;
         size = int(size / world_size) + JBLAS_MISC_SIZE;
       }
 #endif
@@ -634,8 +634,8 @@ struct model_model_loader {
     }
   }
 
-  size_t jblas_split_weight(void** src, void** dst, size_t src_n, size_t src_k, size_t dst_n, size_t dst_k, size_t n_rank,
-                          size_t k_rank) {
+  size_t jblas_split_weight(void** src, void** dst, size_t src_n, size_t src_k, size_t dst_n, size_t dst_k,
+                            size_t n_rank, size_t k_rank) {
     auto src_fp32 = (float*)malloc(src_n * src_k * sizeof(float));
     if (src_fp32 == nullptr) {
       assert(0);
@@ -700,8 +700,8 @@ struct model_model_loader {
         file.read_raw(tmp_buf.addr, shard.size);
         void* dst_data = (void*)lt.data;
         void* src_data = (void*)(tmp_buf.addr);
-        lt.size = jblas_split_weight(&src_data, &dst_data, lt.world_size * num_rows, lt.ne.at(0), num_rows, lt.ne.at(0), lt.rank,
-                           0);
+        lt.size = jblas_split_weight(&src_data, &dst_data, lt.world_size * num_rows, lt.ne.at(0), num_rows, lt.ne.at(0),
+                                     lt.rank, 0);
       } else {
         // only copy part of weight form the tmp_buf of origin file
         tmp_buf.resize(lt.size * lt.world_size);
@@ -722,8 +722,8 @@ struct model_model_loader {
         file.read_raw(tmp_buf.addr, shard.size);
         void* dst_data = (void*)lt.data;
         void* src_data = (void*)(tmp_buf.addr);
-        lt.size = jblas_split_weight(&src_data, &dst_data, num_rows, lt.world_size * lt.ne.at(0), num_rows, lt.ne.at(0), 0,
-                           lt.rank);
+        lt.size = jblas_split_weight(&src_data, &dst_data, num_rows, lt.world_size * lt.ne.at(0), num_rows, lt.ne.at(0),
+                                     0, lt.rank);
       } else {
         tmp_buf.resize(lt.size * lt.world_size);
         file.read_raw(tmp_buf.addr, lt.size * lt.world_size);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_files.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_files.h
@@ -105,6 +105,13 @@ struct model_load_tensor {
     calc_ne();
     if (type == NE_TYPE_JBLAS) {
       size = shards[0].size;
+#ifdef NE_TP_MODEL
+      if (split_type == TP_1D_ROW || split_type == TP_1D_COLUMN) {
+	// TODO when we can calc accurate jblas split size, remove this
+	size_t JBLAS_MISC_SIZE = 192;
+        size = int(size / world_size) + JBLAS_MISC_SIZE;
+      }
+#endif
     } else {
       calc_size();
     }
@@ -627,7 +634,7 @@ struct model_model_loader {
     }
   }
 
-  void jblas_split_weight(void** src, void** dst, size_t src_n, size_t src_k, size_t dst_n, size_t dst_k, size_t n_rank,
+  size_t jblas_split_weight(void** src, void** dst, size_t src_n, size_t src_k, size_t dst_n, size_t dst_k, size_t n_rank,
                           size_t k_rank) {
     auto src_fp32 = (float*)malloc(src_n * src_k * sizeof(float));
     if (src_fp32 == nullptr) {
@@ -638,6 +645,9 @@ struct model_model_loader {
     auto dst_fp32 = src_fp32 + k_rank * dst_k * src_n + n_rank * dst_n;
     jblas_packweight_copyattr(dst_fp32, *dst, dst_n, dst_k, src_n, *src);
     free(src_fp32);
+    auto dst_tmp = jblas::prologue::weight_comp::gemm_kblcok::PackedWeightParser::deserialBuffer(*dst);
+    MODEL_ASSERT(dst_tmp != nullptr);
+    return dst_tmp->mSize;
   }
   void load_data_for(model_load_tensor& lt) {
     if (use_mmap) {
@@ -690,7 +700,7 @@ struct model_model_loader {
         file.read_raw(tmp_buf.addr, shard.size);
         void* dst_data = (void*)lt.data;
         void* src_data = (void*)(tmp_buf.addr);
-        jblas_split_weight(&src_data, &dst_data, lt.world_size * num_rows, lt.ne.at(0), num_rows, lt.ne.at(0), lt.rank,
+        lt.size = jblas_split_weight(&src_data, &dst_data, lt.world_size * num_rows, lt.ne.at(0), num_rows, lt.ne.at(0), lt.rank,
                            0);
       } else {
         // only copy part of weight form the tmp_buf of origin file
@@ -712,7 +722,7 @@ struct model_model_loader {
         file.read_raw(tmp_buf.addr, shard.size);
         void* dst_data = (void*)lt.data;
         void* src_data = (void*)(tmp_buf.addr);
-        jblas_split_weight(&src_data, &dst_data, num_rows, lt.world_size * lt.ne.at(0), num_rows, lt.ne.at(0), 0,
+        lt.size = jblas_split_weight(&src_data, &dst_data, num_rows, lt.world_size * lt.ne.at(0), num_rows, lt.ne.at(0), 0,
                            lt.rank);
       } else {
         tmp_buf.resize(lt.size * lt.world_size);


### PR DESCRIPTION
## Type of Change

use shared memory ccl when TP in only one physical machine, other case use oneCCL.

This feature will make the TP run fast when model only run on single physical machine.