### PR TITLE
fix finetuning instruction readme issue

### DIFF
--- a/intel_extension_for_transformers/neural_chat/examples/finetuning/instruction/README.md
+++ b/intel_extension_for_transformers/neural_chat/examples/finetuning/instruction/README.md
@@ -94,7 +94,7 @@ We select 4 kind of datasets to conduct the finetuning process for different tas
 
 2. Text Generation (Domain-specific instruction): Inspired by Alpaca, we constructed a domain-specific dataset focusing on Business and Intel-related issues. We made minor modifications to the [prompt template](https://github.com/tatsu-lab/stanford_alpaca/blob/main/prompt.txt) to proactively guide Alpaca in generating more Intel and Business related instruction data. The generated data could be find in `intel_domain.json`.
 
-3. Text Generation (ChatBot): To finetune a chatbot, we use the chat-style dataset [HuggingFaceH4/oasst1_en](https://huggingface.co/datasets/HuggingFaceH4/oasst1_en).
+3. Text Generation (ChatBot): To finetune a chatbot, we use the chat-style dataset [HuggingFaceH4/ultrachat_200k](https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k).
 
 4. Summarization: An English-language dataset [cnn_dailymail](https://huggingface.co/datasets/cnn_dailymail) containing just over 300k unique news articles as written by journalists at CNN and the Daily Mail, is used for this task.
 
@@ -187,7 +187,8 @@ python finetune_clm.py \
         --output_dir ./codellama_peft_finetuned_model \
         --peft lora \
         --use_fast_tokenizer True \
-        --no_cuda
+        --no_cuda \
+        --task code-generation
 ```
 
 **For [MPT](https://huggingface.co/mosaicml/mpt-7b)**, use the below command line for finetuning on the Alpaca dataset. Only LORA supports MPT in PEFT perspective.it uses gpt-neox-20b tokenizer, so you need to define it in command line explicitly.This model also requires that trust_remote_code=True be passed to the from_pretrained method. This is because we use a custom MPT model architecture that is not yet part of the Hugging Face transformers package.
@@ -289,6 +290,7 @@ python finetune_clm.py \
         --peft lora \
         --use_fast_tokenizer True \
         --no_cuda \
+        --task code-generation
 ```
 
 Where the `--dataset_concatenation` argument is a way to vastly accelerate the fine-tuning process through training samples concatenation. With several tokenized sentences concatenated into a longer and concentrated sentence as the training sample instead of having several training samples with different lengths, this way is more efficient due to the parallelism characteristic provided by the more concentrated training samples.


### PR DESCRIPTION
## Type of Change

documentation

## Description

1. https://huggingface.co/datasets/HuggingFaceH4/oasst1_en does not exist any more, use https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k instead
2. add **--task code-generation** in sample code for code generation finetuning