### PR TITLE
improve prepare_generation_for_inputs for chatglm

### DIFF
--- a/intel_extension_for_transformers/llm/evaluation/models.py
+++ b/intel_extension_for_transformers/llm/evaluation/models.py
@@ -49,8 +49,7 @@ class TSModelCausalLMForITREX(TSModelForCausalLM):
                 for layer_past in past_key_values
             )
 
-    # Adapted from 
-    # transformers.models.gpt2.modeling_gpt2.GPT2LMHeadModel.prepare_inputs_for_generation
+    # Adapted from transformers.models.gpt2.modeling_gpt2.GPT2LMHeadModel.prepare_inputs_for_generation
     def prepare_inputs_for_generation(self, input_ids, past_key_values=None, **kwargs):
         past_key_values = past_key_values or kwargs.get("past", None)
 
@@ -58,7 +57,8 @@ class TSModelCausalLMForITREX(TSModelForCausalLM):
             if not re.search("THUDM/chatglm-6b", self.config.auto_map["AutoConfig"]):
                 input_ids = input_ids[:, -1:]
 
-        # `past_key_values` may be in the stardard format (e.g. in contrastive search), converts to bloom's format if needed
+        # `past_key_values` may be in the stardard format (e.g. in contrastive search),
+        # converts to bloom's format if needed
         if past_key_values is not None and self.config.model_type == "bloom":
             if past_key_values[0][0].shape[0] == input_ids.shape[0]:
                 past_key_values = self._convert_to_bloom_cache(past_key_values)

--- a/intel_extension_for_transformers/llm/evaluation/models.py
+++ b/intel_extension_for_transformers/llm/evaluation/models.py
@@ -49,6 +49,90 @@ class TSModelCausalLMForITREX(TSModelForCausalLM):
                 for layer_past in past_key_values
             )
 
+    # Adapted from transformers.models.gpt2.modeling_gpt2.GPT2LMHeadModel.prepare_inputs_for_generation
+    def prepare_inputs_for_generation(self, input_ids, past_key_values=None, **kwargs):
+        past_key_values = past_key_values or kwargs.get("past", None)
+
+        if self.use_cache and past_key_values is not None:
+            if not re.search("THUDM/chatglm-6b", self.config.auto_map["AutoConfig"]):
+                input_ids = input_ids[:, -1:]
+
+        # `past_key_values` may be in the stardard format (e.g. in contrastive search), converts to bloom's format if needed
+        if past_key_values is not None and self.config.model_type == "bloom":
+            if past_key_values[0][0].shape[0] == input_ids.shape[0]:
+                past_key_values = self._convert_to_bloom_cache(past_key_values)
+        position_ids = kwargs.get("position_ids", None)
+
+        attention_mask = kwargs.get("attention_mask", None)
+
+        if attention_mask is not None and position_ids is None:
+            # create position_ids on the fly for batch generation
+            position_ids = attention_mask.long().cumsum(-1) - 1
+            position_ids.masked_fill_(attention_mask == 0, 1)
+            if past_key_values:
+                position_ids = position_ids[:, -1].unsqueeze(-1)
+
+        if re.search("THUDM/chatglm-6b", self.config.auto_map["AutoConfig"]):
+            MASK, gMASK = self.config.mask_token_id, self.config.gmask_token_id
+            seqs = input_ids.tolist()
+            mask_positions, use_gmasks = [], []
+            for seq in seqs:
+                mask_token = gMASK if gMASK in seq else MASK
+                use_gmask = mask_token == gMASK
+                mask_positions.append(seq.index(mask_token))
+                use_gmasks.append(use_gmask)
+            batch_size, seq_length = input_ids.shape
+            device = input_ids.device
+            if past_key_values is None:
+                context_lengths = [
+                    seq.tolist().index(self.config.bos_token_id) for seq in input_ids
+                ]
+                position_ids = (
+                    torch.arange(seq_length, dtype=torch.long, device=device)
+                    .unsqueeze(0)
+                    .repeat(batch_size, 1)
+                )
+                for i, context_length in enumerate(context_lengths):
+                    position_ids[i, context_length:] = mask_positions[i]
+                block_position_ids = [
+                    torch.cat(
+                        (
+                            torch.zeros(
+                                context_length, dtype=torch.long, device=device
+                            ),
+                            torch.arange(
+                                seq_length - context_length,
+                                dtype=torch.long,
+                                device=device,
+                            )
+                            + 1,
+                        )
+                    )
+                    for context_length in context_lengths
+                ]
+                block_position_ids = torch.stack(block_position_ids, dim=0)
+                position_ids = torch.stack((position_ids, block_position_ids), dim=1)
+            else:
+                context_lengths = [seq.index(self.config.bos_token_id) for seq in seqs]
+                position_ids = torch.tensor(
+                    [
+                        [mask_position, seq_length - context_length]
+                        for mask_position, context_length in zip(
+                            mask_positions, context_lengths
+                        )
+                    ],
+                    dtype=torch.long,
+                    device=input_ids.device,
+                ).unsqueeze(-1)
+        return {
+            "input_ids": input_ids,
+            "past_key_values": past_key_values,
+            "use_cache": self.use_cache,
+            "position_ids": position_ids,
+            "attention_mask": attention_mask,
+            "token_type_ids": None,
+        }
+
     def forward(
         self,
         input_ids: torch.LongTensor = None,
@@ -72,35 +156,15 @@ class TSModelCausalLMForITREX(TSModelForCausalLM):
                 past_key_values = generate_dummy_past_key_values(
                     config=self.config, input_bs=input_bs
                 )
-            if model_type == "chatglm":
-                if re.search("THUDM/chatglm-6b", self.config.auto_map["AutoConfig"]):
-                    MASK, gMASK = self.config.mask_token_id, self.config.gmask_token_id
-                    seqs = input_ids.tolist()
-                    mask_positions, use_gmasks = [], []
-                    for seq in seqs:
-                        mask_token = gMASK if gMASK in seq else MASK
-                        use_gmask = mask_token == gMASK
-                        mask_positions.append(seq.index(mask_token))
-                        use_gmasks.append(use_gmask)
-                    context_lengths = [
-                        seq.index(self.config.bos_token_id) for seq in seqs
-                    ]
-                    position_ids = torch.tensor(
-                        [
-                            [mask_position, input_len - context_length]
-                            for mask_position, context_length in zip(
-                                mask_positions, context_lengths
-                            )
-                        ],
-                        dtype=torch.long,
-                        device=input_ids.device,
-                    ).unsqueeze(-1)
         inputs["past_key_values"] = past_key_values
         if attention_mask is None:
             inputs["attention_mask"] = torch.ones_like(input_ids)
-        if model_type == "chatglm":
-            if re.search("THUDM/chatglm-6b", self.config.auto_map["AutoConfig"]):
-                inputs.pop("attention_mask")
+        if re.search("THUDM/chatglm-6b", self.config.auto_map["AutoConfig"]):
+            if position_ids is None:
+                position_ids = self.prepare_inputs_for_generation(input_ids)[
+                    "position_ids"
+                ]
+            inputs.pop("attention_mask")
         if model_type in MODEL_TYPES_REQUIRING_POSITION_IDS:
             if position_ids is not None:
                 inputs["position_ids"] = position_ids

--- a/intel_extension_for_transformers/llm/evaluation/models.py
+++ b/intel_extension_for_transformers/llm/evaluation/models.py
@@ -49,7 +49,8 @@ class TSModelCausalLMForITREX(TSModelForCausalLM):
                 for layer_past in past_key_values
             )
 
-    # Adapted from transformers.models.gpt2.modeling_gpt2.GPT2LMHeadModel.prepare_inputs_for_generation
+    # Adapted from 
+    # transformers.models.gpt2.modeling_gpt2.GPT2LMHeadModel.prepare_inputs_for_generation
     def prepare_inputs_for_generation(self, input_ids, past_key_values=None, **kwargs):
         past_key_values = past_key_values or kwargs.get("past", None)
 

--- a/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
+++ b/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
@@ -221,6 +221,7 @@ class _BaseQBitsAutoModelClass:
                 low_cpu_mem_usage=True,
                 torch_dtype=torch.float,
                 torchscript=True,
+                use_cache=True,
                 *model_args,
                 **kwargs,
             )


### PR DESCRIPTION
## Type of Change
code improve
1. move  how to get position_ids for THUDM/chatglm-6b from forward to prepare_generation_for_inputs.
2. add use_cache=True for fp32 model when sq.

## Description

detail description 
JIRA ticket: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed