### PR TITLE
fix potential thread conflict in makedirs

### DIFF
--- a/intel_extension_for_transformers/neural_chat/pipeline/plugins/video/face_animation/src/facerender/modules/make_animation.py
+++ b/intel_extension_for_transformers/neural_chat/pipeline/plugins/video/face_animation/src/facerender/modules/make_animation.py
@@ -221,8 +221,7 @@ def make_animation(
                 predictions.append(out["prediction"])
         folder_name = "logs"
         file_name = f"{p_num}_{rank}.npz"
-        if not os.path.exists(folder_name):
-            os.makedirs(folder_name)
+        os.makedirs(folder_name, exist_ok=True)
         file_path = os.path.join(folder_name, file_name)
         f = open(file_path, "w")
         np.savez(file_path, *predictions)


### PR DESCRIPTION
## Type of Change

bug fix

## Description

`os.path.exists...` is not a thread-safe check to execute `os.makedir`

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

UT

## Dependency Change?

None