### PR TITLE
[Neural Engine] Fix kernels softmax in int8 mha

### DIFF
--- a/examples/huggingface/pytorch/text-embedding/deployment/mteb/bge/executor_utils.py
+++ b/examples/huggingface/pytorch/text-embedding/deployment/mteb/bge/executor_utils.py
@@ -38,18 +38,12 @@ def set_log_file(log, log_file):
     file_handler.setFormatter(formatter)
     log.addHandler(file_handler)
 
-bge_pattern_config = {
-    'pattern_switch': {
-        'MultiHeadAttention': False,
-    }
-}
-
 class Neural_Engine_bge():
 
     def __init__(self, model_path, log_file, cast_type="native"):
         set_log_file(log, log_file)
         with autocast(cast_type):
-            self.graph = compile(model_path, bge_pattern_config)
+            self.graph = compile(model_path)
         self.log_file = log_file
 
     def accuracy(self, batch_size, seq_len, dataset_name, task_name, data_dir, tokenizer_dir):

--- a/intel_extension_for_transformers/llm/runtime/deprecated/kernels/src/cpu/jit_domain/jit_softmax_Ab16a.cpp
+++ b/intel_extension_for_transformers/llm/runtime/deprecated/kernels/src/cpu/jit_domain/jit_softmax_Ab16a.cpp
@@ -69,7 +69,7 @@ void jit_softmax_Ab16a::generate() {
   mov(r15d, dword[reg_param + GET_OFF(QK_rescale)]);
   vpbroadcastd(zmm17, r15d);  // zmm17 is vscale
   mov(r15d, bit_cast<uint32_t>(-10000.f));
-  vpbroadcastd(zmm18, r15d);
+  vpbroadcastd(zmm18, r15d);  // zmm18 is -INF (psudo)
 
   if (param_.has_badd) mov(r11, qword[reg_param + GET_OFF(src_badd)]);
   if (param_.has_badd) mov(r12d, dword[reg_param + GET_OFF(ld_badd)]);
@@ -105,7 +105,7 @@ void jit_softmax_Ab16a::generate() {
       vmovaps(vreg_x, zmm18);
       vcvtdq2ps(vreg_x | mask, zword[r13 + i * 16 * 4]);
       if (!param_.has_badd) {
-        vmulps(vreg_x, vreg_x, zmm17);
+        vmulps(vreg_x | mask, vreg_x, zmm17);
       } else {
         if (i == 0)
           mov(r14, r11);
@@ -115,7 +115,7 @@ void jit_softmax_Ab16a::generate() {
         vfmadd213ps(vreg_x | mask, zmm17, zmm19);
       }
       vmovaps(zword[r13 + i * 16 * 4], vreg_x);
-      vmaxps(Zmm(i), Zmm(i), vreg_x);
+      vmaxps(Zmm(i) | mask, Zmm(i), vreg_x);
     }
   }
   vpxorq(zmm16, zmm16, zmm16);

--- a/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
+++ b/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
@@ -68,16 +68,9 @@ class _BaseQBitsAutoModelClass:
                 autocast,
             )
 
-            # This interface will switch the MHA fusion off.
-            pattern_config = {
-                "pattern_switch": {
-                    "MultiHeadAttention": False,
-                }
-            }
-
             cast_type = kwargs.get("cast_type", "native")
             with autocast(cast_type):
-                model = compile(pretrained_model_name_or_path, pattern_config)
+                model = compile(pretrained_model_name_or_path)
 
             return model
 


### PR DESCRIPTION
## Type of Change: bug fix

API not changed

## Description
Fixed a bug in the softmax sub-kernel of MHA of the NeuralEngine (deprecated) that may cause accuracy when seqlen (with mask) is small.

## Expected Behavior & Potential Risk
The BGE accuracy with MHA-fusion is increased. 

## How has this PR been tested?
```bash
bash run_bge.sh --model=BAAI/bge-base-en-v1.5 --precision=int8 --mode=accuracy
```

- BAAI/bge-base-en-v1.5: STS res 82.219  ===with-mha in this PR===> 81.541
- BAAI/bge-small-en-v1.5: STS res 81.430  ===with-mha in this PR===> 80.911
- --model=BAAI/bge-base-en-v1.5 --precision=fp32: STS res 82.392
- --model=BAAI/bge-small-en-v1.5 --precision=fp32: STS res 81.593


## Dependency Change?
No