### PR TITLE
[LLM Runtime] make rms_norm_eps and freq_base as parameter

### DIFF
--- a/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.c
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.c
@@ -864,6 +864,12 @@ void ne_scratch_load(struct ne_context* ctx) { ctx->scratch = ctx->scratch_save;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+static void ne_set_op_params(struct ne_tensor* tensor, const void* params, size_t params_size) {
+  NE_ASSERT(tensor != NULL);  // silence -Warray-bounds warnings
+  // assert(params_size <= NE_MAX_OP_PARAMS);
+  memcpy(tensor->op_params, params, params_size);
+}
+
 struct ne_tensor* ne_new_tensor_impl(struct ne_context* ctx, enum ne_type type, int n_dims, const int64_t* ne,
                                      void* data, size_t size) {
   // always insert objects at the end of the context's memory pool
@@ -3200,12 +3206,6 @@ struct ne_tensor* ne_conv_1d_2s(struct ne_context* ctx, struct ne_tensor* a, str
   result->src1 = b;
 
   return result;
-}
-
-static void ne_set_op_params(struct ne_tensor* tensor, const void* params, size_t params_size) {
-  NE_ASSERT(tensor != NULL);  // silence -Warray-bounds warnings
-  // assert(params_size <= NE_MAX_OP_PARAMS);
-  memcpy(tensor->op_params, params, params_size);
 }
 
 // for ne_conv_1d
@@ -6072,7 +6072,7 @@ static void ne_compute_forward_norm(const struct ne_compute_params* params, cons
 }
 
 static void ne_compute_forward_rms_norm_f32(const struct ne_compute_params* params, const struct ne_tensor* src0,
-                                            struct ne_tensor* dst, float eps) {
+                                            struct ne_tensor* dst) {
   NE_ASSERT(ne_are_same_shape(src0, dst));
 
   if (params->type == NE_TASK_INIT || params->type == NE_TASK_FINALIZE) {

--- a/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.c
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.c
@@ -10015,8 +10015,8 @@ static void ne_compute_backward(struct ne_context* ctx, struct ne_tensor* tensor
         const int n_past = ((int32_t*)src1->data)[0];
         const int n_dims = ((int32_t*)src1->data)[1];
         const int mode = ((int32_t*)src1->data)[2];
-        src0->grad = 
-          ne_add_impl(ctx, src0->grad, ne_rope(ctx, tensor->grad, n_past, n_dims, mode, 0, 10000.0), inplace);
+        src0->grad =
+            ne_add_impl(ctx, src0->grad, ne_rope(ctx, tensor->grad, n_past, n_dims, mode, 0, 10000.0), inplace);
       }
       if (src1->grad) {
         // noop

--- a/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.c
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.c
@@ -10015,7 +10015,8 @@ static void ne_compute_backward(struct ne_context* ctx, struct ne_tensor* tensor
         const int n_past = ((int32_t*)src1->data)[0];
         const int n_dims = ((int32_t*)src1->data)[1];
         const int mode = ((int32_t*)src1->data)[2];
-        src0->grad = ne_add_impl(ctx, src0->grad, ne_rope(ctx, tensor->grad, n_past, n_dims, mode, 0, 10000.0), inplace);
+        src0->grad = 
+          ne_add_impl(ctx, src0->grad, ne_rope(ctx, tensor->grad, n_past, n_dims, mode, 0, 10000.0), inplace);
       }
       if (src1->grad) {
         // noop

--- a/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.h
@@ -412,7 +412,8 @@ NE_API struct ne_tensor* ne_rope_inplace(struct ne_context* ctx, struct ne_tenso
 // shift all tokens by a give p (n_shift)
 // Optionally give a 1d tensor of precomputed interleaved cos/sin value of n_shift*scale^k for k \in [0, n_dims)
 NE_API struct ne_tensor* ne_rope_shift_inplace(struct ne_context* ctx, struct ne_tensor* a, int n_shift, int n_dims,
-                                               int mode, int prompt_size, int n_keep, struct ne_tensor* cossin, float freq_base);
+                                               int mode, int prompt_size, int n_keep, struct ne_tensor* cossin,
+                                               float freq_base);
 
 // rotary position embedding backward, i.e compute dx from dy
 // a - dy
@@ -423,7 +424,8 @@ NE_API struct ne_tensor* ne_rope_with_padding(struct ne_context* ctx, struct ne_
 
 // in-place, returns view(a)
 NE_API struct ne_tensor* ne_rope_with_padding_inplace(struct ne_context* ctx, struct ne_tensor* a, int n_past,
-                                                      int n_dims, int mode, int prompt_size, int* n_padding, float freq_base);
+                                                      int n_dims, int mode, int prompt_size, int* n_padding,
+                                                      float freq_base);
 
 // alibi position embedding
 // in-place, returns view(a)

--- a/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.h
@@ -403,27 +403,27 @@ NE_API struct ne_tensor* ne_soft_max_inplace(struct ne_context* ctx, struct ne_t
 // if mode & 4 == 1, especially for glm
 // TODO: avoid creating a new tensor every time
 NE_API struct ne_tensor* ne_rope(struct ne_context* ctx, struct ne_tensor* a, int n_past, int n_dims, int mode,
-                                 int prompt_size);
+                                 int prompt_size, float freq_base);
 
 // in-place, returns view(a)
 NE_API struct ne_tensor* ne_rope_inplace(struct ne_context* ctx, struct ne_tensor* a, int n_past, int n_dims, int mode,
-                                         int prompt_size);
+                                         int prompt_size, float freq_base);
 
 // shift all tokens by a give p (n_shift)
 // Optionally give a 1d tensor of precomputed interleaved cos/sin value of n_shift*scale^k for k \in [0, n_dims)
 NE_API struct ne_tensor* ne_rope_shift_inplace(struct ne_context* ctx, struct ne_tensor* a, int n_shift, int n_dims,
-                                               int mode, int prompt_size, int n_keep, struct ne_tensor* cossin);
+                                               int mode, int prompt_size, int n_keep, struct ne_tensor* cossin, float freq_base);
 
 // rotary position embedding backward, i.e compute dx from dy
 // a - dy
 NE_API struct ne_tensor* ne_rope_back(struct ne_context* ctx, struct ne_tensor* a, int n_past, int n_dims, int mode);
 
 NE_API struct ne_tensor* ne_rope_with_padding(struct ne_context* ctx, struct ne_tensor* a, int n_past, int n_dims,
-                                              int mode, int prompt_size, int* n_padding);
+                                              int mode, int prompt_size, int* n_padding, float freq_base);
 
 // in-place, returns view(a)
 NE_API struct ne_tensor* ne_rope_with_padding_inplace(struct ne_context* ctx, struct ne_tensor* a, int n_past,
-                                                      int n_dims, int mode, int prompt_size, int* n_padding);
+                                                      int n_dims, int mode, int prompt_size, int* n_padding, float freq_base);
 
 // alibi position embedding
 // in-place, returns view(a)

--- a/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/core/ne_layers.h
@@ -251,9 +251,9 @@ NE_API struct ne_tensor* ne_silu_back(struct ne_context* ctx, struct ne_tensor* 
 // TODO: eps is hardcoded to 1e-5 for now
 NE_API struct ne_tensor* ne_norm(struct ne_context* ctx, struct ne_tensor* a);
 
-NE_API struct ne_tensor* ne_rms_norm(struct ne_context* ctx, struct ne_tensor* a);
+NE_API struct ne_tensor* ne_rms_norm(struct ne_context* ctx, struct ne_tensor* a, float eps);
 
-NE_API struct ne_tensor* ne_rms_norm_inplace(struct ne_context* ctx, struct ne_tensor* a);
+NE_API struct ne_tensor* ne_rms_norm_inplace(struct ne_context* ctx, struct ne_tensor* a, float eps);
 // a - x
 // b - dy
 NE_API struct ne_tensor* ne_rms_norm_back(struct ne_context* ctx, struct ne_tensor* a, struct ne_tensor* b);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/baichuan/baichuan.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/baichuan/baichuan.cpp
@@ -133,7 +133,7 @@ static bool baichuan_model_eval_internal(model_context* ctx, const model_input* 
     struct ne_tensor* residual = inpL;
 
     // LayerNorm
-    cur = ne_rms_norm(ctx0, inpL);
+    cur = ne_rms_norm(ctx0, inpL, hparams.rms_norm_eps);
     cur = ne_mul(ctx0, cur, model.layers[il].norm[0]);
     // SelfAttention
     {
@@ -241,7 +241,7 @@ static bool baichuan_model_eval_internal(model_context* ctx, const model_input* 
     residual = cur;
 
     // post_attention_layernorm
-    struct ne_tensor* hidden_states = ne_rms_norm(ctx0, cur);
+    struct ne_tensor* hidden_states = ne_rms_norm(ctx0, cur, hparams.rms_norm_eps);
     hidden_states = ne_mul(ctx0, hidden_states, model.layers[il].norm[1]);
 
     // mlp.forward
@@ -267,7 +267,7 @@ static bool baichuan_model_eval_internal(model_context* ctx, const model_input* 
   struct ne_tensor* embeddings = NULL;
   // norm
   {
-    inpL = ne_rms_norm(ctx0, inpL);
+    inpL = ne_rms_norm(ctx0, inpL, hparams.rms_norm_eps);
     inpL = ne_mul(ctx0, inpL, model.others[1]);
   }
 

--- a/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm.cpp
@@ -137,14 +137,14 @@ static bool chatglm_model_eval_internal(model_context* ctx, const model_input* i
 
       ne_set_name(query_layer, "query_layer");
       query_layer =
-          ne_rope_with_padding_inplace(ctx0, query_layer, n_past, rope_dim, 4, first_tokens_size, n_padding.data());
+          ne_rope_with_padding_inplace(ctx0, query_layer, n_past, rope_dim, 4, first_tokens_size, n_padding.data(), hparams.freq_base);
       query_layer = ne_permute(ctx0, query_layer, 0, 2, 1, 3);  // [bs, heads, qlen, head_size]
 
       ne_tensor* key_layer =
           ne_view_4d(ctx0, cur, head_size, num_attention_heads, qlen, batch_size, 3 * head_size * ne_element_size(cur),
                      cur->nb[1], cur->nb[1] * qlen, head_size * ne_element_size(cur));  // [bs, qlen, heads, head_size]
       key_layer =
-          ne_rope_with_padding_inplace(ctx0, key_layer, n_past, rope_dim, 4, first_tokens_size, n_padding.data());
+          ne_rope_with_padding_inplace(ctx0, key_layer, n_past, rope_dim, 4, first_tokens_size, n_padding.data(), hparams.freq_base);
 
       ne_tensor* value_layer = ne_view_4d(ctx0, cur, head_size, num_attention_heads, qlen, batch_size,
                                           3 * head_size * ne_element_size(cur), cur->nb[1], cur->nb[1] * qlen,

--- a/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm.cpp
@@ -136,15 +136,15 @@ static bool chatglm_model_eval_internal(model_context* ctx, const model_input* i
                      cur->nb[1] * N, 0);  // [qlen * bs, 3 * hidden]
 
       ne_set_name(query_layer, "query_layer");
-      query_layer =
-          ne_rope_with_padding_inplace(ctx0, query_layer, n_past, rope_dim, 4, first_tokens_size, n_padding.data(), hparams.freq_base);
+      query_layer = ne_rope_with_padding_inplace(ctx0, query_layer, n_past, rope_dim, 4, first_tokens_size,
+                                                 n_padding.data(), hparams.freq_base);
       query_layer = ne_permute(ctx0, query_layer, 0, 2, 1, 3);  // [bs, heads, qlen, head_size]
 
       ne_tensor* key_layer =
           ne_view_4d(ctx0, cur, head_size, num_attention_heads, qlen, batch_size, 3 * head_size * ne_element_size(cur),
                      cur->nb[1], cur->nb[1] * qlen, head_size * ne_element_size(cur));  // [bs, qlen, heads, head_size]
-      key_layer =
-          ne_rope_with_padding_inplace(ctx0, key_layer, n_past, rope_dim, 4, first_tokens_size, n_padding.data(), hparams.freq_base);
+      key_layer = ne_rope_with_padding_inplace(ctx0, key_layer, n_past, rope_dim, 4, first_tokens_size,
+                                               n_padding.data(), hparams.freq_base);
 
       ne_tensor* value_layer = ne_view_4d(ctx0, cur, head_size, num_attention_heads, qlen, batch_size,
                                           3 * head_size * ne_element_size(cur), cur->nb[1], cur->nb[1] * qlen,

--- a/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm2.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/chatglm/chatglm2.cpp
@@ -135,7 +135,7 @@ static bool chatglm_model_eval_internal(model_context* ctx, const model_input* i
     lctx.use_buf(ctx0, 0);
 
     // self-attention
-    cur = ne_rms_norm(ctx0, inpL);
+    cur = ne_rms_norm(ctx0, inpL, hparams.rms_norm_eps);
     cur = ne_mul(ctx0, ne_repeat(ctx0, model.layers[il].norm[0], cur), cur);
     {
       // compute QKV
@@ -275,7 +275,7 @@ static bool chatglm_model_eval_internal(model_context* ctx, const model_input* i
     struct ne_tensor* hidden_states = ne_add(ctx0, inpL, cur);
 
     // mlp.forward
-    struct ne_tensor* mlp_output = ne_rms_norm(ctx0, hidden_states);
+    struct ne_tensor* mlp_output = ne_rms_norm(ctx0, hidden_states, hparams.rms_norm_eps);
     ne_set_name(mlp_output, "mlp_output");
     // mlp_output = ne_mul(ctx0, mlp_output, model.layers[il].norm[1]);
     mlp_output = ne_mul(ctx0, ne_repeat(ctx0, model.layers[il].norm[1], mlp_output), mlp_output);
@@ -298,7 +298,7 @@ static bool chatglm_model_eval_internal(model_context* ctx, const model_input* i
   struct ne_tensor* embeddings = NULL;
   // norm
   {
-    inpL = ne_rms_norm(ctx0, inpL);
+    inpL = ne_rms_norm(ctx0, inpL, hparams.rms_norm_eps);
     ne_set_name(inpL, "inpL");
     // inpL = ne_mul(ctx0, inpL, model.others[1]);
     inpL = ne_mul(ctx0, ne_repeat(ctx0, model.others[1], inpL), inpL);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/falcon/falcon.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/falcon/falcon.cpp
@@ -162,8 +162,8 @@ static bool falcon_model_eval_internal(model_context* ctx, const model_input* in
                                           fused_qkv_row_nb, (n_embd + n_head_kv * head_dim) * ne_element_size(cur));
 
       // using mode = 2 for neox mode
-      Qcur = ne_rope_inplace(ctx0, Qcur, n_past, head_dim, 2, 0);
-      Kcur = ne_rope_inplace(ctx0, Kcur, n_past, head_dim, 2, 0);
+      Qcur = ne_rope_inplace(ctx0, Qcur, n_past, head_dim, 2, 0, hparams.freq_base);
+      Kcur = ne_rope_inplace(ctx0, Kcur, n_past, head_dim, 2, 0, hparams.freq_base);
 
       // self-attention
       const float attn_scale = 1.0f / sqrtf(static_cast<float>(head_dim));

--- a/intel_extension_for_transformers/llm/runtime/graph/models/gptj/gptj.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/gptj/gptj.cpp
@@ -186,9 +186,9 @@ static bool gptj_model_eval_internal(model_context* ctx, const model_input* inpu
       Kcur = ne_reshape_4d(ctx0, ne_mul_mat(ctx0, model.layers[il].attn[1], cur), head_size, n_head, N, batch_size);
       Vcur = ne_mul_mat(ctx0, model.layers[il].attn[2], cur);
     }
-    Qcur = ne_rope_inplace(ctx0, Qcur, std::max(n_cached - N, n_past), n_rot, 0, 0);
+    Qcur = ne_rope_inplace(ctx0, Qcur, std::max(n_cached - N, n_past), n_rot, 0, 0, hparams.freq_base);
     Kcur = ne_rope_inplace(  // n_ctx exceeds but it will be shift-roped back with cached K
-        ctx0, Kcur, (is_ring_full ? n_ctx : n_past), n_rot, 0, 0);
+        ctx0, Kcur, (is_ring_full ? n_ctx : n_past), n_rot, 0, 0, hparams.freq_base);
     ne_set_name(Qcur, "Qcur");
     ne_set_name(Kcur, "Kcur");
     ne_set_name(Vcur, "Vcur");
@@ -293,7 +293,7 @@ static bool gptj_model_eval_internal(model_context* ctx, const model_input* inpu
         // Currently we only cache cossin for N == 1 in model-wide; It may be worthwhile to cache cossin for other N
         // in a single eval execution
         if (N == 1) cossin_cache = kv_self.cossin;
-        K = ne_rope_shift_inplace(ctx0, K, -N, n_rot, 0, 0, n_keep, cossin_cache);
+        K = ne_rope_shift_inplace(ctx0, K, -N, n_rot, 0, 0, n_keep, cossin_cache, hparams.freq_base);
       }
       const auto v_size = kv_cache_info.v_bytes;
       V = ne_view_4d(ctx0, kv_self.v,                                                            // tensor
@@ -321,7 +321,7 @@ static bool gptj_model_eval_internal(model_context* ctx, const model_input* inpu
         // Currently we only cache cossin for N == 1 in model-wide; It may be worthwhile to cache cossin for other N in
         // a single eval execution
         if (N == 1) cossin_cache = kv_self.cossin;
-        K = ne_rope_shift_inplace(ctx0, K, -N, n_rot, 0, 0, n_keep, cossin_cache);
+        K = ne_rope_shift_inplace(ctx0, K, -N, n_rot, 0, 0, n_keep, cossin_cache, hparams.freq_base);
         K = ne_permute(ctx0, K, 0, 2, 1, 3);
       }
     } else {
@@ -332,7 +332,7 @@ static bool gptj_model_eval_internal(model_context* ctx, const model_input* inpu
         // Currently we only cache cossin for N == 1 in model-wide; It may be worthwhile to cache cossin for other N in
         // a single eval execution
         if (N == 1) cossin_cache = kv_self.cossin;
-        K = ne_rope_shift_inplace(ctx0, K, -N, n_rot, 0, 0, n_keep, cossin_cache);
+        K = ne_rope_shift_inplace(ctx0, K, -N, n_rot, 0, 0, n_keep, cossin_cache, hparams.freq_base);
         K = ne_permute(ctx0, K, 0, 2, 1, 3);
       }
 

--- a/intel_extension_for_transformers/llm/runtime/graph/models/gptneox/gptneox.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/gptneox/gptneox.cpp
@@ -187,8 +187,8 @@ static bool gptneox_model_eval_internal(model_context* ctx, const model_input* i
                                                         cur->nb[1] / n_head, cur->nb[1], 2 * sizeof(float) * head_dim));
 
       // using mode = 2 for GPT-NeoX mode
-      Qcur = ne_rope_inplace(ctx0, ne_reshape_4d(ctx0, Qcur, head_dim, n_head, N, batch_size), n_past, n_rot, 2, 0);
-      Kcur = ne_rope_inplace(ctx0, ne_reshape_4d(ctx0, Kcur, head_dim, n_head, N, batch_size), n_past, n_rot, 2, 0);
+      Qcur = ne_rope_inplace(ctx0, ne_reshape_4d(ctx0, Qcur, head_dim, n_head, N, batch_size), n_past, n_rot, 2, 0, hparams.freq_base);
+      Kcur = ne_rope_inplace(ctx0, ne_reshape_4d(ctx0, Kcur, head_dim, n_head, N, batch_size), n_past, n_rot, 2, 0, hparams.freq_base);
       const float attn_scale = 1.0f / sqrtf(static_cast<float>(head_dim));
       // store key and value to memory
       if (!run_mha_reordered) {

--- a/intel_extension_for_transformers/llm/runtime/graph/models/gptneox/gptneox.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/gptneox/gptneox.cpp
@@ -187,8 +187,10 @@ static bool gptneox_model_eval_internal(model_context* ctx, const model_input* i
                                                         cur->nb[1] / n_head, cur->nb[1], 2 * sizeof(float) * head_dim));
 
       // using mode = 2 for GPT-NeoX mode
-      Qcur = ne_rope_inplace(ctx0, ne_reshape_4d(ctx0, Qcur, head_dim, n_head, N, batch_size), n_past, n_rot, 2, 0, hparams.freq_base);
-      Kcur = ne_rope_inplace(ctx0, ne_reshape_4d(ctx0, Kcur, head_dim, n_head, N, batch_size), n_past, n_rot, 2, 0, hparams.freq_base);
+      Qcur = ne_rope_inplace(ctx0, ne_reshape_4d(ctx0, Qcur, head_dim, n_head, N, batch_size), n_past, n_rot, 2, 0,
+                             hparams.freq_base);
+      Kcur = ne_rope_inplace(ctx0, ne_reshape_4d(ctx0, Kcur, head_dim, n_head, N, batch_size), n_past, n_rot, 2, 0,
+                             hparams.freq_base);
       const float attn_scale = 1.0f / sqrtf(static_cast<float>(head_dim));
       // store key and value to memory
       if (!run_mha_reordered) {

--- a/intel_extension_for_transformers/llm/runtime/graph/models/llama/llama.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/llama/llama.cpp
@@ -187,10 +187,10 @@ static bool llama_model_eval_internal(model_context* ctx, const model_input* inp
       Kcur = ne_reshape_3d(ctx0, ne_mul_mat(ctx0, model.layers[il].attn[1], cur), head_size, n_head_kv, N);
       Vcur = ne_mul_mat(ctx0, model.layers[il].attn[2], cur);
     }
-    Qcur = ne_rope_inplace(ctx0, Qcur, std::max(n_cached - N, n_past), n_rot, 0, 0);
+    Qcur = ne_rope_inplace(ctx0, Qcur, std::max(n_cached - N, n_past), n_rot, 0, 0, hparams.freq_base);
     ne_set_name(Qcur, "Qcur");
     Kcur = ne_rope_inplace(  // n_ctx exceeds but it will be shift-roped back with cached K
-        ctx0, Kcur, (is_ring_full ? n_ctx : n_past), n_rot, 0, 0);
+        ctx0, Kcur, (is_ring_full ? n_ctx : n_past), n_rot, 0, 0, hparams.freq_base);
     ne_set_name(Kcur, "Kcur");
     Vcur = ne_transpose(ctx0, ne_reshape_2d(ctx0, Vcur, head_size * n_head_kv, N));
     ne_set_name(Vcur, "Vcur");
@@ -221,7 +221,7 @@ static bool llama_model_eval_internal(model_context* ctx, const model_input* inp
         // Currently we only cache cossin for N == 1 in model-wide; It may be worthwhile to cache cossin for other N in
         // a single eval execution
         if (N == 1) cossin_cache = kv_self.cossin;
-        K = ne_rope_shift_inplace(ctx0, K, -N, n_rot, 0, 0, n_keep, cossin_cache);
+        K = ne_rope_shift_inplace(ctx0, K, -N, n_rot, 0, 0, n_keep, cossin_cache, hparams.freq_base);
       }
       K = ne_permute(ctx0, K, 0, 2, 1, 3);
       ne_set_name(K, "K");
@@ -301,7 +301,7 @@ static bool llama_model_eval_internal(model_context* ctx, const model_input* inp
         // Currently we only cache cossin for N == 1 in model-wide; It may be worthwhile to cache cossin for other N in
         // a single eval execution
         if (N == 1) cossin_cache = kv_self.cossin;
-        K = ne_rope_shift_inplace(ctx0, K, -N, n_rot, 0, 0, n_keep, cossin_cache);
+        K = ne_rope_shift_inplace(ctx0, K, -N, n_rot, 0, 0, n_keep, cossin_cache, hparams.freq_base);
       }
       ne_set_name(K, "K");
 

--- a/intel_extension_for_transformers/llm/runtime/graph/models/llama/llama.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/llama/llama.cpp
@@ -165,7 +165,7 @@ static bool llama_model_eval_internal(model_context* ctx, const model_input* inp
 
     // norm
     {
-      cur = ne_rms_norm(ctx0, inpL);
+      cur = ne_rms_norm(ctx0, inpL, hparams.rms_norm_eps);
 
       // cur = cur*attention_norm(broadcasted)
       cur = ne_mul(ctx0, cur, model.layers[il].norm[0]);
@@ -337,7 +337,7 @@ static bool llama_model_eval_internal(model_context* ctx, const model_input* inp
     {
       // norm
       {
-        cur = ne_rms_norm(ctx0, inpFF);
+        cur = ne_rms_norm(ctx0, inpFF, hparams.rms_norm_eps);
 
         // cur = cur*ffn_norm(broadcasted)
         cur = ne_mul(ctx0, cur, model.layers[il].norm[1]);
@@ -374,7 +374,7 @@ static bool llama_model_eval_internal(model_context* ctx, const model_input* inp
   struct ne_tensor* embeddings = NULL;
   // norm
   {
-    inpL = ne_rms_norm(ctx0, inpL);
+    inpL = ne_rms_norm(ctx0, inpL, hparams.rms_norm_eps);
 
     // inpL = inpL*norm(broadcasted)
     inpL = ne_mul(ctx0, inpL, model.others[1]);

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_files.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_files.h
@@ -281,6 +281,8 @@ struct model_file_loader {
 
     // For ChatGLM-2
     hparams.inner_hidden_size = file.read_u32();
+
+    file.read_raw(&hparams.rms_norm_eps, sizeof(float));
   }
 
   void read_vocab() {
@@ -397,6 +399,8 @@ struct model_file_saver {
     file.write_u32(hparams.multi_query_group_num);
     file.write_u32(hparams.ffn_hidden_size);
     file.write_u32(hparams.inner_hidden_size);
+
+    file.write_raw(&hparams.rms_norm_eps, sizeof(float));
   }
   void write_vocab() {
     if (any_file_loader->file_version == MODEL_FILE_VERSION_NE) {

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_files.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_files.h
@@ -283,6 +283,7 @@ struct model_file_loader {
     hparams.inner_hidden_size = file.read_u32();
 
     file.read_raw(&hparams.rms_norm_eps, sizeof(float));
+    file.read_raw(&hparams.freq_base, sizeof(float));
   }
 
   void read_vocab() {
@@ -401,6 +402,7 @@ struct model_file_saver {
     file.write_u32(hparams.inner_hidden_size);
 
     file.write_raw(&hparams.rms_norm_eps, sizeof(float));
+    file.write_raw(&hparams.freq_base, sizeof(float));
   }
   void write_vocab() {
     if (any_file_loader->file_version == MODEL_FILE_VERSION_NE) {

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_types.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_types.h
@@ -125,6 +125,8 @@ struct model_hparams {
   int32_t par_res = 1;                // for neox 1 = true, 0 = false
   uint32_t word_embed_proj_dim = 0;   // for opt
   bool do_layer_norm_before = false;  // for opt
+  float rms_norm_eps = 1e-6f;  // rms norm epsilon
+  float freq_base = 10000.0f;
 
   // ChatGLM-2
   int32_t multi_query_group_num = 0;
@@ -132,7 +134,6 @@ struct model_hparams {
 
   // ChatGLM-1
   int32_t inner_hidden_size = 0;
-  float rms_norm_eps = 1e-6f;  // rms norm epsilon
 
   bool operator!=(const model_hparams& other) const {
     return static_cast<bool>(memcmp(this, &other, sizeof(model_hparams)));

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_types.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_types.h
@@ -132,6 +132,7 @@ struct model_hparams {
 
   // ChatGLM-1
   int32_t inner_hidden_size = 0;
+  float rms_norm_eps = 1e-6f;  // rms norm epsilon
 
   bool operator!=(const model_hparams& other) const {
     return static_cast<bool>(memcmp(this, &other, sizeof(model_hparams)));

--- a/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_types.h
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/model_utils/model_types.h
@@ -125,7 +125,7 @@ struct model_hparams {
   int32_t par_res = 1;                // for neox 1 = true, 0 = false
   uint32_t word_embed_proj_dim = 0;   // for opt
   bool do_layer_norm_before = false;  // for opt
-  float rms_norm_eps = 1e-6f;  // rms norm epsilon
+  float rms_norm_eps = 1e-6f;         // rms norm epsilon
   float freq_base = 10000.0f;
 
   // ChatGLM-2

--- a/intel_extension_for_transformers/llm/runtime/graph/models/qwen/qwen.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/qwen/qwen.cpp
@@ -180,9 +180,9 @@ static bool qwen_model_eval_internal(model_context* ctx, const model_input* inpu
                                                         fused_qkv_row_nb, 2 * sizeof(float) * n_embd));
 
       // using mode = 2 for GPT-NeoX mode
-      Qcur = ne_rope_inplace(ctx0, Qcur, n_past, n_rot, 2, 0);
+      Qcur = ne_rope_inplace(ctx0, Qcur, n_past, n_rot, 2, 0, hparams.freq_base);
       ne_set_name(Qcur, "Qcur");
-      Kcur = ne_rope_inplace(ctx0, Kcur, n_past, n_rot, 2, 0);
+      Kcur = ne_rope_inplace(ctx0, Kcur, n_past, n_rot, 2, 0, hparams.freq_base);
       ne_set_name(Kcur, "kcur");
       const float attn_scale = 1.0f / sqrtf(static_cast<float>(head_dim));
       // store key and value to memory

--- a/intel_extension_for_transformers/llm/runtime/graph/models/qwen/qwen.cpp
+++ b/intel_extension_for_transformers/llm/runtime/graph/models/qwen/qwen.cpp
@@ -157,7 +157,7 @@ static bool qwen_model_eval_internal(model_context* ctx, const model_input* inpu
     {
       // RMS
       {
-        cur = ne_rms_norm(ctx0, inpL);
+        cur = ne_rms_norm(ctx0, inpL, hparams.rms_norm_eps);
 
         // cur = cur*attention_norm(broadcasted)
         cur = ne_mul(ctx0, cur, model.layers[il].norm[0]);
@@ -310,7 +310,7 @@ static bool qwen_model_eval_internal(model_context* ctx, const model_input* inpu
     // this is independent of the self-attention result, so it could be done in parallel to the self-attention
     // note here we pass inpL instead of cur
     {
-      cur = ne_rms_norm(ctx0, cur);
+      cur = ne_rms_norm(ctx0, cur, hparams.rms_norm_eps);
 
       cur = ne_mul(ctx0, cur, model.layers[il].norm[1]);
     }
@@ -325,7 +325,7 @@ static bool qwen_model_eval_internal(model_context* ctx, const model_input* inpu
   struct ne_tensor* embeddings = NULL;
   // norm
   {
-    inpL = ne_rms_norm(ctx0, inpL);
+    inpL = ne_rms_norm(ctx0, inpL, hparams.rms_norm_eps);
     inpL = ne_mul(ctx0, inpL, model.others[1]);
   }
   lctx.use_buf(ctx0, -1);

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_baichuan.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_baichuan.py
@@ -156,6 +156,7 @@ def baichuan13B_convert(model, tokenizer, dir_model, fname_out, ftype, hparams):
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", hparams["intermediate_size"]))
+    fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
 
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_baichuan.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_baichuan.py
@@ -157,6 +157,7 @@ def baichuan13B_convert(model, tokenizer, dir_model, fname_out, ftype, hparams):
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", hparams["intermediate_size"]))
     fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
+    fout.write(struct.pack("f", 10000.0))  # freq_base
 
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_bloom.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_bloom.py
@@ -99,6 +99,7 @@ def main(args_in: Optional[List[str]] = None) -> None:
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
+    fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
 
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_bloom.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_bloom.py
@@ -100,6 +100,7 @@ def main(args_in: Optional[List[str]] = None) -> None:
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
+    fout.write(struct.pack("f", 10000.0))  # freq_base
 
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_chatglm.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_chatglm.py
@@ -178,6 +178,7 @@ def chatglm2_convert(model, tokenizer, dir_model, fname_out, ftype, hparams):
     fout.write(struct.pack("i", hparams["multi_query_group_num"]))
     fout.write(struct.pack("i", hparams["ffn_hidden_size"]))
     fout.write(struct.pack("i", 0))
+    fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
 
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))
@@ -271,6 +272,7 @@ def chatglm1_convert(model, tokenizer, dir_model, fname_out, ftype, hparams):
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", hparams["inner_hidden_size"]))
+    fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
 
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else -1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else -1))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_chatglm.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_chatglm.py
@@ -179,6 +179,7 @@ def chatglm2_convert(model, tokenizer, dir_model, fname_out, ftype, hparams):
     fout.write(struct.pack("i", hparams["ffn_hidden_size"]))
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("f", hparams.get("layernorm_epsilon", 1e-6)))  # rms norm eps
+    fout.write(struct.pack("f", 10000.0))  # freq_base
 
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))
@@ -273,6 +274,7 @@ def chatglm1_convert(model, tokenizer, dir_model, fname_out, ftype, hparams):
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", hparams["inner_hidden_size"]))
     fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
+    fout.write(struct.pack("f", 10000.0))  # freq_base
 
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else -1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else -1))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_chatglm.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_chatglm.py
@@ -178,7 +178,7 @@ def chatglm2_convert(model, tokenizer, dir_model, fname_out, ftype, hparams):
     fout.write(struct.pack("i", hparams["multi_query_group_num"]))
     fout.write(struct.pack("i", hparams["ffn_hidden_size"]))
     fout.write(struct.pack("i", 0))
-    fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
+    fout.write(struct.pack("f", hparams.get("layernorm_epsilon", 1e-6)))  # rms norm eps
 
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_dolly.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_dolly.py
@@ -114,7 +114,8 @@ def main(args_in: Optional[List[str]] = None) -> None:
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
-
+    fout.write(struct.pack("f", 10000.0))  # freq_base
+    
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))
     fout.write(struct.pack("i", tokenizer.pad_token_id if tokenizer.pad_token_id is not None else -1))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_dolly.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_dolly.py
@@ -113,6 +113,7 @@ def main(args_in: Optional[List[str]] = None) -> None:
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
+    fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
 
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_falcon.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_falcon.py
@@ -108,7 +108,8 @@ def main(args_in: Optional[List[str]] = None) -> None:
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
-
+    fout.write(struct.pack("f", 10000.0))  # freq_base
+    
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))
     fout.write(struct.pack("i", tokenizer.pad_token_id if tokenizer.pad_token_id is not None else -1))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_falcon.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_falcon.py
@@ -107,6 +107,7 @@ def main(args_in: Optional[List[str]] = None) -> None:
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
+    fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
 
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_gptj.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_gptj.py
@@ -99,6 +99,7 @@ def main(args_in: Optional[List[str]] = None) -> None:
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
+    fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
 
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_gptj.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_gptj.py
@@ -100,7 +100,8 @@ def main(args_in: Optional[List[str]] = None) -> None:
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
-
+    fout.write(struct.pack("f", 10000.0))  # freq_base
+    
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))
     fout.write(struct.pack("i", tokenizer.pad_token_id if tokenizer.pad_token_id is not None else -1))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_gptneox.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_gptneox.py
@@ -114,7 +114,8 @@ def main(args_in: Optional[List[str]] = None) -> None:
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
-
+    fout.write(struct.pack("f", 10000.0))  # freq_base
+    
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))
     fout.write(struct.pack("i", tokenizer.pad_token_id if tokenizer.pad_token_id is not None else -1))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_gptneox.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_gptneox.py
@@ -113,6 +113,7 @@ def main(args_in: Optional[List[str]] = None) -> None:
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
+    fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
 
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_gptq_bloom.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_gptq_bloom.py
@@ -170,6 +170,7 @@ f.write(struct.pack("i", 0))  # do_layer_norm_before (for opt)
 f.write(struct.pack("i", 0))
 f.write(struct.pack("i", 0))
 f.write(struct.pack("i", 0))
+fout.write(struct.pack("f", 1e-6))  # rms norm eps
 
 f.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
 f.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_llama.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_llama.py
@@ -149,6 +149,7 @@ class Params:
     n_head_kv: int
     ffn_hidden_size: int
     rms_norm_eps: float
+    rope_theta: float
 
     @staticmethod
     def guessed(model: 'LazyModel') -> 'Params':
@@ -176,6 +177,7 @@ class Params:
         n_head_kv = config["num_key_value_heads"] if "num_key_value_heads" in config else n_head
         ffn_hidden_size = config["intermediate_size"]
         rms_norm_eps = config["rms_norm_eps"]
+        rope_theta = config["rope_theta"] if "rope_theta" in config else 10000
 
         return Params(
             n_vocab=n_vocab,
@@ -186,6 +188,7 @@ class Params:
             n_head_kv=n_head_kv,
             ffn_hidden_size=ffn_hidden_size,
             rms_norm_eps=rms_norm_eps,
+            rope_theta=rope_theta,
         )
 
     # LLaMA v2 70B params.json
@@ -1059,6 +1062,7 @@ class OutputFile:
         self.fout.write(struct.pack("i", 0))
 
         self.fout.write(struct.pack("f", params.rms_norm_eps))
+        self.fout.write(struct.pack("f", params.rope_theta))
 
         # TODO, bos_token_id = 0 in https://huggingface.co/decapoda-research/llama-7b-hf/blob/main/config.json 
         # but bos_token_id = 1 in llama.cpp

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_llama.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_llama.py
@@ -33,7 +33,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import (IO, TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Literal, Optional, Sequence, Tuple, TypeVar,
                     Union)
-from transformers import AutoConfig
 import numpy as np
 from sentencepiece import SentencePieceProcessor  # type: ignore
 
@@ -176,6 +175,7 @@ class Params:
         n_head = config["num_attention_heads"]
         n_head_kv = config["num_key_value_heads"] if "num_key_value_heads" in config else n_head
         ffn_hidden_size = config["intermediate_size"]
+        rms_norm_eps = config["rms_norm_eps"]
 
         return Params(
             n_vocab=n_vocab,
@@ -185,7 +185,7 @@ class Params:
             n_head=n_head,
             n_head_kv=n_head_kv,
             ffn_hidden_size=ffn_hidden_size,
-            rms_norm_eps=1e-6,
+            rms_norm_eps=rms_norm_eps,
         )
 
     # LLaMA v2 70B params.json
@@ -1313,8 +1313,6 @@ def main(args_in: Optional[List[str]] = None) -> None:
         output_type = pick_output_type(model, args.outtype)
         model = convert_to_output_type(model, output_type)
         outfile = args.outfile or default_outfile(model_plus.paths, params)
-        config = AutoConfig.from_pretrained(args.model, trust_remote_code=True)
-        params.rms_norm_eps = config.rms_norm_eps
         OutputFile.write_all(outfile, params, model, vocab, output_type)
         print(f"Wrote {outfile}")
 

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_mistral.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_mistral.py
@@ -1049,6 +1049,7 @@ class OutputFile:
         self.fout.write(struct.pack("i", 0))
         self.fout.write(struct.pack("i", params.ffn_hidden_size))
         self.fout.write(struct.pack("i", 0))
+        fout.write(struct.pack("f", 1e-6))  # rms norm eps
 
         self.fout.write(
             struct.pack("i", 1)

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_mistral.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_mistral.py
@@ -150,6 +150,7 @@ class Params:
     n_head_kv: int
     ffn_hidden_size: int
     rms_norm_eps: float
+    rope_theta: float
 
     @staticmethod
     def guessed(model: 'LazyModel') -> 'Params':
@@ -177,6 +178,7 @@ class Params:
         n_head_kv = config["num_key_value_heads"] if "num_key_value_heads" in config else n_head
         ffn_hidden_size = config["intermediate_size"]
         rms_norm_eps = config["rms_norm_eps"]
+        rope_theta = config["rope_theta"] if "rope_theta" in config else 10000
 
         return Params(
             n_vocab=n_vocab,
@@ -187,6 +189,7 @@ class Params:
             n_head_kv=n_head_kv,
             ffn_hidden_size=ffn_hidden_size,
             rms_norm_eps=rms_norm_eps,
+            rope_theta=rope_theta,
         )
 
     # LLaMA v2 70B params.json
@@ -1053,6 +1056,7 @@ class OutputFile:
         self.fout.write(struct.pack("i", params.ffn_hidden_size))
         self.fout.write(struct.pack("i", 0))
         self.fout.write(struct.pack("f", params.rms_norm_eps))
+        self.fout.write(struct.pack("f", params.rope_theta))
 
         self.fout.write(
             struct.pack("i", 1)

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_mistral.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_mistral.py
@@ -149,6 +149,7 @@ class Params:
     n_layer: int
     n_head_kv: int
     ffn_hidden_size: int
+    rms_norm_eps: float
 
     @staticmethod
     def guessed(model: 'LazyModel') -> 'Params':
@@ -175,6 +176,7 @@ class Params:
         n_head = config["num_attention_heads"]
         n_head_kv = config["num_key_value_heads"] if "num_key_value_heads" in config else n_head
         ffn_hidden_size = config["intermediate_size"]
+        rms_norm_eps = config["rms_norm_eps"]
 
         return Params(
             n_vocab=n_vocab,
@@ -184,6 +186,7 @@ class Params:
             n_head=n_head,
             n_head_kv=n_head_kv,
             ffn_hidden_size=ffn_hidden_size,
+            rms_norm_eps=rms_norm_eps,
         )
 
     # LLaMA v2 70B params.json
@@ -1049,7 +1052,7 @@ class OutputFile:
         self.fout.write(struct.pack("i", 0))
         self.fout.write(struct.pack("i", params.ffn_hidden_size))
         self.fout.write(struct.pack("i", 0))
-        fout.write(struct.pack("f", 1e-6))  # rms norm eps
+        self.fout.write(struct.pack("f", params.rms_norm_eps))
 
         self.fout.write(
             struct.pack("i", 1)

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_mpt.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_mpt.py
@@ -95,6 +95,7 @@ def main(args_in: Optional[List[str]] = None) -> None:
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
+    fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
 
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_mpt.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_mpt.py
@@ -96,7 +96,8 @@ def main(args_in: Optional[List[str]] = None) -> None:
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
-
+    fout.write(struct.pack("f", 10000.0))  # freq_base
+    
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))
     fout.write(struct.pack("i", tokenizer.pad_token_id if tokenizer.pad_token_id is not None else -1))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_opt.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_opt.py
@@ -106,6 +106,7 @@ def main(args_in: Optional[List[str]] = None) -> None:
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
+    fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
 
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_opt.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_opt.py
@@ -107,7 +107,8 @@ def main(args_in: Optional[List[str]] = None) -> None:
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
-
+    fout.write(struct.pack("f", 10000.0))  # freq_base
+    
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))
     fout.write(struct.pack("i", tokenizer.pad_token_id if tokenizer.pad_token_id is not None else -1))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_qwen.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_qwen.py
@@ -112,6 +112,8 @@ def main(args_in: Optional[List[str]] = None) -> None:
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
+    fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
+    
     fout.write(struct.pack("i", tokenizer.special_tokens['<|endoftext|>']))
     fout.write(struct.pack("i", tokenizer.special_tokens['<|endoftext|>']))
     fout.write(struct.pack("i", tokenizer.pad_token_id if tokenizer.pad_token_id is not None else -1))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_qwen.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_qwen.py
@@ -113,7 +113,8 @@ def main(args_in: Optional[List[str]] = None) -> None:
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
-    
+    fout.write(struct.pack("f", 10000.0))  # freq_base
+
     fout.write(struct.pack("i", tokenizer.special_tokens['<|endoftext|>']))
     fout.write(struct.pack("i", tokenizer.special_tokens['<|endoftext|>']))
     fout.write(struct.pack("i", tokenizer.pad_token_id if tokenizer.pad_token_id is not None else -1))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_starcoder.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_starcoder.py
@@ -110,6 +110,7 @@ def main(args_in: Optional[List[str]] = None) -> None:
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
+    fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
 
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_starcoder.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/convert_starcoder.py
@@ -111,6 +111,7 @@ def main(args_in: Optional[List[str]] = None) -> None:
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("i", 0))
     fout.write(struct.pack("f", hparams.get("rms_norm_eps", 1e-6)))  # rms norm eps
+    fout.write(struct.pack("f", 10000.0))  # freq_base
 
     fout.write(struct.pack("i", tokenizer.bos_token_id if tokenizer.bos_token_id is not None else 1))
     fout.write(struct.pack("i", tokenizer.eos_token_id if tokenizer.eos_token_id is not None else 2))

--- a/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
+++ b/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
@@ -137,7 +137,7 @@ class _BaseQBitsAutoModelClass:
                 if quantization_config is None:
                     if use_llm_runtime:
                         quantization_config = WeightOnlyQuantConfig(
-                            compute_dtype="bf16", weight_dtype="int8"
+                            compute_dtype="int8", weight_dtype="int8"
                         )
                     else:
                         quantization_config = WeightOnlyQuantConfig(


### PR DESCRIPTION
## Type of Change

bug fix

## Description

neural_chat_v3.1:
- before fix:  fp32 {'diff2': 0.15223888, 'cos': 0.9888011}
- after fix: fp32 {'diff2': 8.285937e-05, 'cos': 1.0}

chatglm2:
- before fix: fp32 {'diff2': 0.01901678, 'cos': 0.99988997}
- after fix: fp32 {'diff2': 0.009832479, 'cos': 0.99995184}

codellama
- before fix: fp32 {'diff2': 0.07989038, 'cos': 0.99698734}
- after fix rms_norm_eps: fp32 {'diff2': 0.0529107, 'cos': 0.99863917}
- after fix freq_bas: fp32 {'diff2': 0.00017308403, 'cos': 0.9999999}

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed