### PR TITLE
fix imageio path issue

### DIFF
--- a/intel_extension_for_transformers/neural_chat/pipeline/plugins/video/face_animation/src/test_audio2coeff.py
+++ b/intel_extension_for_transformers/neural_chat/pipeline/plugins/video/face_animation/src/test_audio2coeff.py
@@ -109,11 +109,11 @@ class Audio2Coeff:
             coeffs_pred_numpy = coeffs_pred[0].clone().detach().cpu().numpy()
 
             savemat(
-                os.path.join(coeff_save_dir, "%s##%s.mat" % (batch["pic_name"], batch["audio_name"])),
+                os.path.join(coeff_save_dir, "%s-%s.mat" % (batch["pic_name"], batch["audio_name"])),
                 {"coeff_3dmm": coeffs_pred_numpy},
             )
 
-            return os.path.join(coeff_save_dir, "%s##%s.mat" % (batch["pic_name"], batch["audio_name"]))
+            return os.path.join(coeff_save_dir, "%s-%s.mat" % (batch["pic_name"], batch["audio_name"]))
 
     def using_refpose(self, coeffs_pred_numpy, ref_pose_coeff_path):
         num_frames = coeffs_pred_numpy.shape[0]


### PR DESCRIPTION
## Type of Change

bug fix

## Description

ut fix
'##' in path will be double quoted with `shlex.quote()`, which will lead to a wrong path. `shlex.quote()` is needed for security check, so we replace '##' with '-' to resolve that.

JIRA ticket: [NLPTOOLKIU-1083](https://jira.devtools.intel.com/browse/NLPTOOLKIU-1083)

## Expected Behavior & Potential Risk

ut pass

## How has this PR been tested?

run nightly CI

## Dependency Change?

None