### PR TITLE
[NeuralChat] Align inference generation configuration behaviour with HF

### DIFF
--- a/intel_extension_for_transformers/neural_chat/config.py
+++ b/intel_extension_for_transformers/neural_chat/config.py
@@ -380,7 +380,7 @@ class TTSFinetuningConfig:
 class GenerationConfig:
     device: str = "cpu"
     temperature: float = 0.1
-    top_k: int = 1
+    top_k: int = 40
     top_p: float = 0.75
     repetition_penalty: float = 1.1
     num_beams: int = 0


### PR DESCRIPTION
## Type of Change

bug fix
API not changed 

## Description

Fix the issue that itrex has different result compared with huggingface interfaces.
Modify the parameter top_k to 40 as hugging face.
https://wiki.ith.intel.com/pages/viewpage.action?pageId=3042423855#LLMInferenceParameters-ComparisontoHuggingFace

## Expected Behavior & Potential Risk

The LLM inference result will be `sampling`, as same as huggingface.

## How has this PR been tested?

Local tested on SDP server.

## Dependency Change?

no