### PR TITLE
[LLM] Adapt models didn't need position ids do sq auto tune

### DIFF
--- a/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
+++ b/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
@@ -328,15 +328,25 @@ class _BaseQBitsAutoModelClass:
                         input_ids_padded.append(input_ids)
                         attention_mask_padded.append(attention_mask)
                         position_ids_padded.append(position_ids)
-                    return (
-                        {
-                            "input_ids": torch.vstack(input_ids_padded),
-                            "attention_mask": torch.vstack(attention_mask_padded),
-                            "position_ids": torch.vstack(position_ids_padded),
-                            "past_key_values": past_key_values,
-                        },
-                        torch.tensor(last_ind),
-                    )
+                    if model_type in MODEL_TYPES_REQUIRING_POSITION_IDS:
+                        return (
+                            {
+                                "input_ids": torch.vstack(input_ids_padded),
+                                "attention_mask": torch.vstack(attention_mask_padded),
+                                "position_ids": torch.vstack(position_ids_padded),
+                                "past_key_values": past_key_values,
+                            },
+                            torch.tensor(last_ind),
+                        )
+                    else:
+                        return (
+                            {
+                                "input_ids": torch.vstack(input_ids_padded),
+                                "attention_mask": torch.vstack(attention_mask_padded),
+                                "past_key_values": past_key_values,
+                            },
+                            torch.tensor(last_ind),
+                        )
 
                 def collate_batch_for_chatglm(batch):
                     last_ind = []

--- a/tests/CI/test_quantization.py
+++ b/tests/CI/test_quantization.py
@@ -325,7 +325,7 @@ class TestQuantization(unittest.TestCase):
         self.assertTrue(isinstance(q_model.model, torch.jit.ScriptModule))
         sq_config = SmoothQuantConfig(
                                     tokenizer=tokenizer,  # either two of one, tokenizer or calib_func
-                                    calib_iters=5,
+                                    calib_iters=2,
                                     ipex_opt_llm=False
                                     )
         q_model = AutoModelForCausalLM.from_pretrained(model_name_or_path,
@@ -333,7 +333,23 @@ class TestQuantization(unittest.TestCase):
                                                     use_llm_runtime=False
                                                 )
         self.assertTrue(isinstance(q_model.model, torch.jit.ScriptModule))
-
+        # SQ auto
+        recipes = {
+            "smooth_quant": True,
+            "smooth_quant_args": { "alpha": "auto", "auto_alpha_args":{"alpha_max": 0.6,
+                "alpha_min":0.5, "alpha_step":0.1, "shared_criterion": "mean", "do_blockwise": False}},
+            }
+        sq_config = SmoothQuantConfig(
+                            tokenizer=tokenizer,  # either two of one, tokenizer or calib_func
+                            calib_iters=2,
+                            recipes=recipes,
+                            ipex_opt_llm=False
+                            )
+        q_model = AutoModelForCausalLM.from_pretrained(model_name_or_path,
+                                                    quantization_config=sq_config,
+                                                    use_llm_runtime=False
+                                                )
+        self.assertTrue(isinstance(q_model.model, torch.jit.ScriptModule))
         # weight-only
         #RTN
         woq_config = WeightOnlyQuantConfig(weight_dtype="int4_fullrange")


### PR DESCRIPTION
## Type of Change
sq alpha auto tuning need use calib_dataloader, but position_ids is not used by all models.
add ut opt-125m for models which didn't have position_ids parameters.
raised by @yintong-lu  please review.

## Description

detail description 
JIRA ticket: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed