### PR TITLE
[NeuralChat] fix wrong output of multi-round prediction

### DIFF
--- a/intel_extension_for_transformers/neural_chat/models/base_model.py
+++ b/intel_extension_for_transformers/neural_chat/models/base_model.py
@@ -389,7 +389,7 @@ class BaseModel(ABC):
         if self.conv_template:
             return
         if not task:
-            self.conv_template = PromptTemplate(self.get_default_conv_template(model_path).name)
+            self.conv_template = PromptTemplate(self.get_default_conv_template(model_path).name, clear_after_gen=True)
         else:
             clear_after_gen = True
             if task == "completion":

--- a/intel_extension_for_transformers/neural_chat/models/base_model.py
+++ b/intel_extension_for_transformers/neural_chat/models/base_model.py
@@ -389,19 +389,19 @@ class BaseModel(ABC):
         if self.conv_template:
             return
         if not task:
-            self.conv_template = PromptTemplate(self.get_default_conv_template(model_path).name, clear_after_gen=True)
+            self.conv_template = PromptTemplate(self.get_default_conv_template(model_path).name, clear_history=True)
         else:
-            clear_after_gen = True
+            clear_history = True
             if task == "completion":
                 name = "alpaca_without_input"
             elif task == "chat":
                 name = "neural-chat-7b-v2"
-                clear_after_gen = False
+                clear_history = False
             elif task == "summarization":
                 name = "summarization"
             else:
                 raise NotImplementedError(f"Unsupported task {task}.")
-            self.conv_template = PromptTemplate(name, clear_after_gen=clear_after_gen)
+            self.conv_template = PromptTemplate(name, clear_history=clear_history)
 
     def prepare_prompt(self, prompt: str, model_path: str, task: str = ""):
         self.get_conv_template(model_path, task)

--- a/intel_extension_for_transformers/neural_chat/prompts/prompt.py
+++ b/intel_extension_for_transformers/neural_chat/prompts/prompt.py
@@ -202,9 +202,9 @@ register_conv_template(
 )
 
 class PromptTemplate:
-    def __init__(self, name="one_shot", clear_after_gen=False):
+    def __init__(self, name="one_shot", clear_history=False):
         self.conv = get_conv_template(name)
-        self.clear_after_gen = clear_after_gen
+        self.clear_history = clear_history
 
     @property
     def roles(self):
@@ -215,7 +215,7 @@ class PromptTemplate:
 
     def get_prompt(self) -> str:
         res = self.conv.get_prompt()
-        if self.clear_after_gen:
+        if self.clear_history:
             self.clear_messages()
         return res
 


### PR DESCRIPTION
## Type of Change

bug fix

## Description

A simple example will reproduce this issue, when the second output contains template information and no correct output. I think we should by default clear the previous prompt template unless we know exactly our model can work on multi-round speech.

```
from intel_extension_for_transformers.neural_chat import build_chatbot, PipelineConfig
config = PipelineConfig()
chatbot = build_chatbot(config)
out = chatbot.predict("Tell me about Intel Xeon Scalable Processors.")
print(out)
out = chatbot.predict("Tell me about Intel")
print(out)
```

This is because the new query is simply appended to the previous template and the default model cannot deal with it.

## Expected Behavior & Potential Risk

bug fix

## How has this PR been tested?

example

## Dependency Change?

None