### PR TITLE
[NeuralChat] add neural-chat-7b textchat example using Triton Inference Server

### DIFF
--- a/intel_extension_for_transformers/neural_chat/examples/serving/README.md
+++ b/intel_extension_for_transformers/neural_chat/examples/serving/README.md
@@ -1,0 +1,62 @@
+# Serving NeuralChat Text Generation with Triton Inference Server
+
+Nvidia Triton Inference Server is a widely adopted inference serving software. We also support serving and deploying NeuralChat models with Triton Inference Server.
+
+## Prepare serving scripts
+
+```
+cd <path to intel_extension_for_transformers>/neural_chat/examples/serving
+mkdir -p models/text_generation/1/
+cp text_generation/model.py models/text_generation/1/model.py
+cp text_generation/config.pbtxt models/text_generation/config.pbtxt
+```
+
+Then your folder structure under the current `serving` folder shoud be like:
+
+```
+serving/
+├── models
+│   └── text_generation
+│       ├── 1
+│       │   ├── model.py
+│       └── config.pbtxt
+├── README.md
+└── text_generation
+    ├── client.py
+    ├── config.pbtxt
+    └── model.py
+```
+
+## Start Triton Inference Server
+
+```
+cd <path to intel_extension_for_transformers>/neural_chat/examples/serving
+docker run -d -e PYTHONPATH=/opt/tritonserver/intel-extension-for-transformers --net=host -v ${PWD}/models:/models spycsh/triton_neuralchat:v1 tritonserver --model-repository=/models --http-port 8021
+```
+
+NeuralChat by default uses `Intel/neural-chat-7b-v3-1` as the LLM, so if you already have this Huggingface model in cache, you can add a `-v` flag to avoid downloading the model every time you start the server, like follows:
+
+```
+docker run -d -e PYTHONPATH=/opt/tritonserver/intel-extension-for-transformers --net=host -v ${PWD}/models:/models -v /root/.cache/huggingface/hub/models--Intel--neural-chat-7b-v3-1:/root/.cache/huggingface/hub/models--Intel--neural-chat-7b-v3-1  spycsh/triton_neuralchat:v1  tritonserver --model-repository=/models --http-port=8021
+```
+
+To check whether the server is on:
+
+```
+curl -v localhost:8021/v2/health/ready
+```
+
+## Use Triton client to send inference request
+
+Start the Triton client and enter into the container
+
+```
+cd <path to intel_extension_for_transformers>/neural_chat/examples/serving
+docker run --net=host -it --rm -v ${PWD}/text_generation/client.py:/workspace/text_generation/client.py nvcr.io/nvidia/tritonserver:23.11-py3-sdk
+```
+
+Send a request
+
+```
+python /workspace/text_generation/client.py --prompt="Tell me about Intel Xeon Scalable Processors." --url=localhost:8021
+```

--- a/intel_extension_for_transformers/neural_chat/examples/serving/text_generation/client.py
+++ b/intel_extension_for_transformers/neural_chat/examples/serving/text_generation/client.py
@@ -1,0 +1,87 @@
+
+# !/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import sys
+import warnings
+
+import numpy as np
+import tritonclient.http as httpclient
+from tritonclient.utils import *
+
+
+warnings.filterwarnings("ignore")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--model_name",
+        type=str,
+        required=False,
+        default="text_generation",
+        help="Model name",
+    )
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        required=False,
+        default="Tell me about Intel Xeon Scalable Processors.",
+        help="Prompt string",
+    )
+    parser.add_argument(
+        "--url",
+        type=str,
+        required=False,
+        default="localhost:8000",
+        help="Inference server URL. Default is localhost:8000.",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        required=False,
+        default=False,
+        help="Enable verbose output",
+    )
+    args = parser.parse_args()
+
+    try:
+        triton_client = httpclient.InferenceServerClient(args.url)
+    except Exception as e:
+        print("channel creation failed: " + str(e))
+        sys.exit(1)
+
+    if args.verbose:
+        print(json.dumps(triton_client.get_model_config(args.model_name), indent=4))
+
+    inputs = []
+    inputs.append(httpclient.InferInput('INPUT0', [1], "BYTES"))
+    input_data0 = args.prompt
+    input_data0 = np.array([input_data0.encode("utf-8")],dtype=np.object_)
+    inputs[0].set_data_from_numpy(input_data0)
+    outputs = []
+    outputs.append(httpclient.InferRequestedOutput('OUTPUT0', binary_data=False))
+
+    results = triton_client.infer(model_name=args.model_name, inputs=inputs, outputs=outputs)
+    output_data0 = results.as_numpy('OUTPUT0')
+
+    print("input:",input_data0)
+    print("output:",output_data0)

--- a/intel_extension_for_transformers/neural_chat/examples/serving/text_generation/config.pbtxt
+++ b/intel_extension_for_transformers/neural_chat/examples/serving/text_generation/config.pbtxt
@@ -1,0 +1,33 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "text_generation"
+backend: "python"
+
+input [
+  {
+    name: "INPUT0"
+    data_type: TYPE_STRING
+    dims: [ 1 ]
+  }
+]
+output [
+  {
+    name: "OUTPUT0"
+    data_type: TYPE_STRING
+    dims: [ 1 ]
+  }
+]
+
+instance_group [{ kind: KIND_CPU }]

--- a/intel_extension_for_transformers/neural_chat/examples/serving/text_generation/model.py
+++ b/intel_extension_for_transformers/neural_chat/examples/serving/text_generation/model.py
@@ -1,0 +1,129 @@
+# !/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import numpy as np
+
+# triton_python_backend_utils is available in every Triton Python model. You
+# need to use this module to create inference requests and responses. It also
+# contains some utility functions for extracting information from model_config
+# and converting Triton input/output types to numpy types.
+import triton_python_backend_utils as pb_utils
+
+from intel_extension_for_transformers.neural_chat import build_chatbot, PipelineConfig
+
+class TritonPythonModel:
+    """Your Python model must use the same class name. Every Python model
+    that is created must have "TritonPythonModel" as the class name.
+    """
+
+    def initialize(self, args):
+        """`initialize` is called only once when the model is being loaded.
+        Implementing `initialize` function is optional. This function allows
+        the model to initialize any state associated with this model.
+
+        Parameters
+        ----------
+        args : dict
+          Both keys and values are strings. The dictionary keys and values are:
+          * model_config: A JSON string containing the model configuration
+          * model_instance_kind: A string containing model instance kind
+          * model_instance_device_id: A string containing model instance device ID
+          * model_repository: Model repository path
+          * model_version: Model version
+          * model_name: Model name
+        """
+
+        # You must parse model_config. JSON string is not parsed here
+        self.model_config = model_config = json.loads(args["model_config"])
+
+        # Get OUTPUT0 configuration
+        output0_config = pb_utils.get_output_config_by_name(model_config, "OUTPUT0")
+
+        # Convert Triton types to numpy types
+        self.output0_dtype = pb_utils.triton_string_to_numpy(
+            output0_config["data_type"]
+        )
+        self.config = PipelineConfig()
+        self.chatbot = build_chatbot(self.config)
+
+    def execute(self, requests):
+        """`execute` MUST be implemented in every Python model. `execute`
+        function receives a list of pb_utils.InferenceRequest as the only
+        argument. This function is called when an inference request is made
+        for this model. Depending on the batching configuration (e.g. Dynamic
+        Batching) used, `requests` may contain multiple requests. Every
+        Python model, must create one pb_utils.InferenceResponse for every
+        pb_utils.InferenceRequest in `requests`. If there is an error, you can
+        set the error argument when creating a pb_utils.InferenceResponse
+
+        Parameters
+        ----------
+        requests : list
+          A list of pb_utils.InferenceRequest
+
+        Returns
+        -------
+        list
+          A list of pb_utils.InferenceResponse. The length of this list must
+          be the same as `requests`
+        """
+
+        output0_dtype = self.output0_dtype
+        chatbot = self.chatbot
+
+        responses = []
+
+        # Every Python backend must iterate over everyone of the requests
+        # and create a pb_utils.InferenceResponse for each of them.
+        for request in requests:
+            # Get INPUT0
+            in_0 = pb_utils.get_input_tensor_by_name(request, "INPUT0")
+            in_0 = in_0.as_numpy()
+            text = in_0[0].decode("utf-8")
+            print(f"input prompt: {text}")
+
+            out_0 = chatbot.predict(query=text)
+
+            # Create output tensors. You need pb_utils.Tensor
+            # objects to create pb_utils.InferenceResponse.
+            out_0 = np.array(out_0)
+
+            out_tensor_0 = pb_utils.Tensor("OUTPUT0", out_0.astype(output0_dtype))
+
+            # Create InferenceResponse. You can set an error here in case
+            # there was a problem with handling this inference request.
+            # Below is an example of how you can set errors in inference
+            # response:
+            #
+            # pb_utils.InferenceResponse(
+            #    output_tensors=..., TritonError("An error occurred"))
+            inference_response = pb_utils.InferenceResponse(
+                output_tensors=[out_tensor_0]
+            )
+            responses.append(inference_response)
+
+        # You should return a list of pb_utils.InferenceResponse. Length
+        # of this list must match the length of `requests` list.
+        return responses
+
+    def finalize(self):
+        """`finalize` is called only once when the model is being unloaded.
+        Implementing `finalize` function is OPTIONAL. This function allows
+        the model to perform any necessary clean ups before exit.
+        """
+        print("Cleaning up...")


### PR DESCRIPTION
## Type of Change

feature

## Description

add neural-chat-7b-v3-1 out-of-box textchat serving example using Triton Inference Server
JIRA ticket: [NLPTOOLKIU-906](https://jira.devtools.intel.com/browse/NLPTOOLKIU-906)

## Expected Behavior & Potential Risk

users can now serve NeuralChat models using the Nvidia Triton Inference Server

## How has this PR been tested?

example

## Dependency Change?

I add the docker image (including all the environment needed) for quickstart on my own docker hub as follows:
https://hub.docker.com/repository/docker/spycsh/triton_neuralchat