### PR TITLE
[LLM WOQ] add QuantizedLinearQbits activation contiguous check

### DIFF
--- a/intel_extension_for_transformers/llm/quantization/nn/modules.py
+++ b/intel_extension_for_transformers/llm/quantization/nn/modules.py
@@ -120,6 +120,8 @@ class QuantizedLinearQBits(torch.nn.Linear):
         m = reduce(mul, shape[0:-1])
         out = torch.zeros(m, self.out_features, dtype=x.dtype)
         bias = None if self.bias is None else self.bias.data
+        if not x.is_contiguous():
+            x = x.contiguous()
         out = matmul_kbit(
             x.view(m, shape[-1]), self.weight, bias, out,
             self.compute_dtype, self.weight_dtype, self.scale_dtype, do_dequant=self.training


### PR DESCRIPTION
## Type of Change

bug fix
API  not changed

## Description
issue description as following, the root cause is tensor.view requests the tensor is contiguous, so add the check, we will correct it if it is not contiguous.
```
  File "/dataset/huggingface/modules/transformers_modules/THUDM/chatglm2-6b/7fabe56db91e085c9c027f56f1c654d137bdba40/modeling_chatglm.py", line 640, in forward
    layer_ret = layer(
  File "/home/changwa1/anaconda3/envs/starcoder/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/changwa1/anaconda3/envs/starcoder/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "/dataset/huggingface/modules/transformers_modules/THUDM/chatglm2-6b/7fabe56db91e085c9c027f56f1c654d137bdba40/modeling_chatglm.py", line 544, in forward
    attention_output, kv_cache = self.self_attention(
  File "/home/changwa1/anaconda3/envs/starcoder/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/changwa1/anaconda3/envs/starcoder/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "/dataset/huggingface/modules/transformers_modules/THUDM/chatglm2-6b/7fabe56db91e085c9c027f56f1c654d137bdba40/modeling_chatglm.py", line 447, in forward
    output = self.dense(context_layer)
  File "/home/changwa1/anaconda3/envs/starcoder/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/changwa1/anaconda3/envs/starcoder/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/changwa1/itrex/intel_extension_for_transformers/llm/quantization/nn/modules.py", line 126, in forward
    x.view(m, shape[-1]), self.weight, bias, out,
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.


```
chatglm2 local test 
```
2023-12-24 16:50:46 [INFO] WeightOnlyQuant done.
---- Prompt size: 34
> /home/changwa1/itrex/examples/huggingface/pytorch/text-generation/quantization/run_generation.py(359)<module>()
-> gen_ids = user_model.generate(
(Pdb) c
/home/changwa1/anaconda3/envs/starcoder/lib/python3.10/site-packages/transformers/generation/configuration_utils.py:362: UserWarning: `do_sample` is set to `False`. However, `temperature` is set to `0.- this flag is only used in sample-based generation modes. You should set `do_sample=True` or unset `temperature`.
  warnings.warn(
['[Round 1]\n\n问：Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun.\n\n答： One day, the little girl decided thhe wanted to go on a big adventure. She packed a bag with some food, water, and supplies, and set']
> /home/changwa1/itrex/examples/huggingface/pytorch/text-generation/quantization/run_generation.py(359)<module>()
-> gen_ids = user_model.generate(
(Pdb) c
['[Round 1]\n\n问：Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun.\n\n答： One day, the little girl decided thhe wanted to go on a big adventure. She packed a bag with some food, water, and supplies, and set']

```
detail description 
JIRA ticket: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed