### PR TITLE
[LLM Runtime] Circumvent dependabot check for chatglm/baichuan/baichuan2

### DIFF
--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/ci/cpp_graph_inference.sh
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/ci/cpp_graph_inference.sh
@@ -209,17 +209,17 @@ function main() {
         quant_script="./build/bin/quant_chatglm"
         infer_cmd="python ./scripts/inference.py"
         extension=" --model_name chatglm --tokenizer $model_path"
-        requirements_file="scripts/requirements/chatglm-6b.txt"
+        requirements_file="scripts/requirements/chatglm-6b.sh"
     elif [[ "${model}" == "baichuan2-13b" ]]; then
         quant_script="./build/bin/quant_baichuan"
         infer_cmd="python ./scripts/inference.py"
-        requirements_file="scripts/requirements/baichuan.txt"
+        requirements_file="scripts/requirements/baichuan.sh"
         extension=" --model_name baichuan --tokenizer $model_path"
     elif [[ "${model}" == "baichuan-13b" ]]; then
         quant_script="./build/bin/quant_baichuan"
         infer_cmd="python ./scripts/inference.py"
         extension=" --model_name baichuan --tokenizer $model_path"
-        requirements_file="scripts/requirements/baichuan.txt"
+        requirements_file="scripts/requirements/baichuan.sh"
     elif [[ "${model}" == "mistral-7b" ]]; then
         quant_script="./build/bin/quant_mistral"
         infer_cmd="./build/bin/run_mistral"
@@ -273,7 +273,14 @@ function main() {
     cd ..
 
     ## prepare example requiement
-    pip install -r "$requirements_file"
+    if [[ $requirements_file == *'.txt' ]]; then
+        pip install -r "$requirements_file"
+    elif [[ $requirements_file == *'.sh' ]]; then
+        source "$requirements_file"
+    else
+        echo "Error: Unexpedted requirements_file: $requirements_file" 1>&2
+        exit 1
+    fi
 
     echo "=======  Convert Start  ======="
     ## prepare fp32 bin

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/requirements/baichuan.sh
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/requirements/baichuan.sh
@@ -1,0 +1,3 @@
+# To avoid the error: 'ChatGLMTokenizer' object has no attribute 'sp_tokenizer'
+script_dir=$(dirname "${BASH_SOURCE[0]}")
+pip install -r "$script_dir/common.txt" transformers==4.33.1

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/requirements/baichuan.sh
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/requirements/baichuan.sh
@@ -1,3 +1,20 @@
+#!/bin/bash
+#===============================================================================
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
 # To avoid the error: 'ChatGLMTokenizer' object has no attribute 'sp_tokenizer'
 script_dir=$(dirname "${BASH_SOURCE[0]}")
 pip install -r "$script_dir/common.txt" transformers==4.33.1

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/requirements/baichuan.sh
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/requirements/baichuan.sh
@@ -16,5 +16,4 @@
 #===============================================================================
 
 # To avoid the error: 'ChatGLMTokenizer' object has no attribute 'sp_tokenizer'
-script_dir=$(dirname "${BASH_SOURCE[0]}")
-pip install -r "$script_dir/common.txt" transformers==4.33.1
+pip install -r "$(dirname "${BASH_SOURCE[0]}")/common.txt" transformers==4.33.1

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/requirements/baichuan.txt
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/requirements/baichuan.txt
@@ -1,3 +1,0 @@
-# To avoid the error: 'ChatGLMTokenizer' object has no attribute 'sp_tokenizer'
--r common.txt
-transformers==4.33.1

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/requirements/chatglm-6b.sh
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/requirements/chatglm-6b.sh
@@ -1,0 +1,3 @@
+# To avoid the error: 'ChatGLMTokenizer' object has no attribute 'sp_tokenizer'
+script_dir=$(dirname "${BASH_SOURCE[0]}")
+pip install -r "$script_dir/common.txt" transformers==4.33.1

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/requirements/chatglm-6b.sh
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/requirements/chatglm-6b.sh
@@ -1,3 +1,20 @@
+#!/bin/bash
+#===============================================================================
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===============================================================================
+
 # To avoid the error: 'ChatGLMTokenizer' object has no attribute 'sp_tokenizer'
 script_dir=$(dirname "${BASH_SOURCE[0]}")
 pip install -r "$script_dir/common.txt" transformers==4.33.1

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/requirements/chatglm-6b.sh
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/requirements/chatglm-6b.sh
@@ -16,5 +16,4 @@
 #===============================================================================
 
 # To avoid the error: 'ChatGLMTokenizer' object has no attribute 'sp_tokenizer'
-script_dir=$(dirname "${BASH_SOURCE[0]}")
-pip install -r "$script_dir/common.txt" transformers==4.33.1
+pip install -r "$(dirname "${BASH_SOURCE[0]}")/common.txt" transformers==4.33.1

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/requirements/chatglm-6b.txt
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/requirements/chatglm-6b.txt
@@ -1,3 +1,0 @@
-# To avoid the error: 'ChatGLMTokenizer' object has no attribute 'sp_tokenizer'
--r common.txt
-transformers==4.33.1


### PR DESCRIPTION
## Type of Change: ?
API not changed.

## Description
This dependency is only used if a user wants to run these 3 specific models. Some users (and our tests) do want to use these models which cannot work with newer version of transformers. Users using these 3 models should be aware of this risk and should trust the publisher of these 3 models.

Due to internal regulations, we cannot dismiss [this vulnerability check](https://github.com/intel/intel-extension-for-transformers/pull/1074) and have to add the workaround here.

## Expected Behavior & Potential Risk
Ignore security check for model-specific requirements.

## Dependency Change?
No