### PR TITLE
[NeuralChat] Fix tts crash with messy retrieval input and enhance normalizer

### DIFF
--- a/intel_extension_for_transformers/neural_chat/pipeline/plugins/audio/tts.py
+++ b/intel_extension_for_transformers/neural_chat/pipeline/plugins/audio/tts.py
@@ -19,7 +19,6 @@ from transformers import SpeechT5Processor, SpeechT5ForTextToSpeech, set_seed
 from datasets import load_dataset, Audio, Dataset, Features, ClassLabel
 import os
 import torch
-from speechbrain.pretrained import EncoderClassifier
 from typing import Any, Dict, List, Union
 from transformers import SpeechT5HifiGan
 import soundfile as sf
@@ -59,6 +58,7 @@ class TextToSpeech():
         self.stream_mode = stream_mode
         self.spk_model_name = "speechbrain/spkrec-xvect-voxceleb"
         try:
+            from speechbrain.pretrained import EncoderClassifier
             self.speaker_model = EncoderClassifier.from_hparams(
                 source=self.spk_model_name,
                 run_opts={"device": "cpu"},

--- a/intel_extension_for_transformers/neural_chat/pipeline/plugins/audio/utils/english_normalizer.py
+++ b/intel_extension_for_transformers/neural_chat/pipeline/plugins/audio/utils/english_normalizer.py
@@ -26,7 +26,7 @@ logging.basicConfig(
 class EnglishNormalizer:
     def __init__(self):
         self.correct_dict = {
-            "A": "Eigh",
+            "A": "eigh",
             "B": "bee",
             "C": "cee",
             "D": "dee",
@@ -34,7 +34,7 @@ class EnglishNormalizer:
             "F": "ef",
             "G": "jee",
             "H": "aitch",
-            "I": "I",
+            "I": "eye",
             "J": "jay",
             "K": "kay",
             "L": "el",

--- a/intel_extension_for_transformers/neural_chat/pipeline/plugins/audio/utils/english_normalizer.py
+++ b/intel_extension_for_transformers/neural_chat/pipeline/plugins/audio/utils/english_normalizer.py
@@ -58,8 +58,7 @@ class EnglishNormalizer:
     def correct_abbreviation(self, text):
         # TODO mixed abbreviation or proper noun like i7, ffmpeg, BTW should be supported
 
-        # words = text.split()    # CVPR-15 will be upper but 1 and 5 will be splitted to two numbers
-        words = re.split(' |_|/', text)
+        words = re.split(r' |_|/|\*|\#', text)  # ignore the characters that not break sentence
         results = []
         for idx, word in enumerate(words):
             if word.startswith("-"):    # bypass negative number

--- a/intel_extension_for_transformers/neural_chat/tests/ci/plugins/audio/test_english_normalizer.py
+++ b/intel_extension_for_transformers/neural_chat/tests/ci/plugins/audio/test_english_normalizer.py
@@ -52,7 +52,7 @@ class TestTTS(unittest.TestCase):
         text = "CVPR-15 ICML-21 PM2.5"
         text = self.normalizer.correct_abbreviation(text)
         result = self.normalizer.correct_number(text)
-        self.assertEqual(result, "cee vee pea ar fifteen I cee em el twenty-one pea em two point five.")
+        self.assertEqual(result, "cee vee pea ar fifteen eye cee em el twenty-one pea em two point five.")
 
 if __name__ == "__main__":
     unittest.main()

--- a/intel_extension_for_transformers/neural_chat/tests/ci/plugins/audio/test_tts.py
+++ b/intel_extension_for_transformers/neural_chat/tests/ci/plugins/audio/test_tts.py
@@ -95,7 +95,11 @@ class TestTTS(unittest.TestCase):
         output_audio_path = os.path.join(os.getcwd(), "tmp_audio/2.wav")
         set_seed(555)
         output_audio_path = self.tts.text2speech(text, output_audio_path, voice="default", do_batch_tts=True, batch_length=120)
+        result = self.asr.audio2text(output_audio_path)
         self.assertTrue(os.path.exists(output_audio_path))
+        self.assertEqual("intel extension for transformers is an innovative toolkit to accelerate transformer based " + \
+                         "models on intel platforms in particular effective on 4th intel xeon scalable processor " + \
+                            "sapphire rapids codenamed sapphire rapids", result)
 
     def test_create_speaker_embedding(self):
         driven_audio_path = \
@@ -116,6 +120,16 @@ class TestTTS(unittest.TestCase):
         # verify accuracy
         result = self.asr.audio2text(output_audio_path)
         self.assertEqual(text.lower(), result.lower())
+
+    def test_tts_messy_input(self):
+        text = "Please refer to the following responses to this inquiry:\n" + 244 * "* " + "*"
+        output_audio_path = os.path.join(os.getcwd(), "tmp_audio/6.wav")
+        set_seed(555)
+        output_audio_path = self.tts_noise_reducer.text2speech(text, output_audio_path, voice="default")
+        self.assertTrue(os.path.exists(output_audio_path))
+        # verify accuracy
+        result = self.asr.audio2text(output_audio_path)
+        self.assertEqual("please refer to the following responses to this inquiry", result.lower())
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Type of Change

bug fix

## Description

there is a random issue in UT that retrieval generate some messy output that TTS cannot correctly convert to speech, I fix that and fix some other issues

## Expected Behavior & Potential Risk

UT will not encounter random issues.

## How has this PR been tested?

UT

## Dependency Change?

None