### PR TITLE
[NeuralChat] Fix langchain version issue since langchain upgrade to v0.1.0

### DIFF
--- a/intel_extension_for_transformers/neural_chat/requirements.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements.txt
@@ -15,7 +15,7 @@ evaluate
 pydub
 python-multipart
 PyPDF2
-langchain
+langchain==0.0.354
 langchain_core
 python-docx
 scikit-learn

--- a/intel_extension_for_transformers/neural_chat/requirements_cpu.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements_cpu.txt
@@ -12,7 +12,7 @@ evaluate
 pydub
 python-multipart
 PyPDF2
-langchain
+langchain==0.0.354
 langchain_core
 python-docx
 scikit-learn

--- a/intel_extension_for_transformers/neural_chat/requirements_hpu.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements_hpu.txt
@@ -12,7 +12,7 @@ evaluate
 pydub
 python-multipart
 PyPDF2
-langchain
+langchain==0.0.354
 langchain_core
 python-docx
 librosa

--- a/intel_extension_for_transformers/neural_chat/requirements_pc.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements_pc.txt
@@ -11,7 +11,7 @@ evaluate
 pydub
 python-multipart
 PyPDF2
-langchain
+langchain==0.0.354
 langchain_core
 python-docx
 scikit-learn

--- a/intel_extension_for_transformers/neural_chat/requirements_xpu.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements_xpu.txt
@@ -9,7 +9,7 @@ evaluate
 pydub
 python-multipart
 PyPDF2
-langchain
+langchain==0.0.354
 langchain_core
 python-docx
 scikit-learn

--- a/intel_extension_for_transformers/neural_chat/tests/requirements.txt
+++ b/intel_extension_for_transformers/neural_chat/tests/requirements.txt
@@ -15,7 +15,7 @@ evaluate
 pydub
 python-multipart
 PyPDF2
-langchain
+langchain==0.0.354
 langchain_core
 python-docx
 scikit-learn


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

Fix langchain version issue since langchain upgrade to v0.1.0

## Expected Behavior & Potential Risk

NeuralChat can run without error raised.

## How has this PR been tested?

Pre-CI test.

## Dependency Change?

None.