### PR TITLE
Fix missing documentation in LLM runtime, and a broken link + some typos

### DIFF
--- a/intel_extension_for_transformers/llm/runtime/graph/README.md
+++ b/intel_extension_for_transformers/llm/runtime/graph/README.md
@@ -408,7 +408,7 @@ while True:
     outputs = model.generate(inputs, streamer=streamer, interactive=True, ignore_prompt=True, do_sample=True)
 ```
 
-## How to use: Python script
+## How to use: Straightforward Python script
 Install from binary
 ```shell
 pip install intel-extension-for-transformers

--- a/intel_extension_for_transformers/llm/runtime/graph/README.md
+++ b/intel_extension_for_transformers/llm/runtime/graph/README.md
@@ -412,6 +412,7 @@ while True:
 Install from binary
 ```shell
 pip install intel-extension-for-transformers
+pip install -r requirements.txt  # under graph folder
 ```
 
 Build from source

--- a/intel_extension_for_transformers/llm/runtime/graph/scripts/run.py
+++ b/intel_extension_for_transformers/llm/runtime/graph/scripts/run.py
@@ -167,7 +167,7 @@ def main(args_in: Optional[List[str]] = None) -> None:
     convert_cmd.extend(["--outfile", Path(work_path, "ne_{}_f32.bin".format(model_type))])
     convert_cmd.extend(["--outtype", "f32"])
     convert_cmd.append(args.model)
-    print("convert model ...")
+    print("Convert model ...")
     subprocess.run(convert_cmd)
 
     # 2. quantize
@@ -185,7 +185,7 @@ def main(args_in: Optional[List[str]] = None) -> None:
     if args.use_ggml:
         quant_cmd.extend(["--use_ggml"])
     quant_cmd.extend(["--build_dir", args.build_dir])
-    print("quantize model ...")
+    print("Quantize model ...")
     subprocess.run(quant_cmd)
 
     # 3. inference
@@ -204,7 +204,7 @@ def main(args_in: Optional[List[str]] = None) -> None:
     infer_cmd.extend(["--build_dir", args.build_dir])
     if args.shift_roped_k:
         infer_cmd.extend(["--shift-roped-k"])
-    print("inferce model ...")
+    print("Inference model ...")
     subprocess.run(infer_cmd)
 
 


### PR DESCRIPTION
## Type of Change

- Fix missing documentation in LLM runtime, and a broken link + some typos

## Description

- User needs to install the dependencies in requirements.txt, not only in Transformer-based API option but also when running the Straightforward Python script option, otherwise the convert.py throws an error of many missing packages.
- Fix a broken link of Python script option: When clicking on it doesn't take you to the right part in the README.
- Fix typos in run.py script.

## Expected Behavior & Potential Risk

N/A

## How has this PR been tested?

Any HW

## Dependency Change?

N/A