### PR TITLE
[NeuralChat] Add neural-speed dependency

### DIFF
--- a/intel_extension_for_transformers/neural_chat/tests/requirements.txt
+++ b/intel_extension_for_transformers/neural_chat/tests/requirements.txt
@@ -72,3 +72,4 @@ zhconv
 diffusers
 transformers_stream_generator
 qdrant-client
+git+https://github.com/intel/neural-speed


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

Add neural-speed dependency

## Expected Behavior & Potential Risk

NeuralChat can use neural-speed for WOQ llm runtime optimization.

## How has this PR been tested?

Local test and pre-CI test.

## Dependency Change?

None.