### PR TITLE
Limit sentence-transformers version

### DIFF
--- a/intel_extension_for_transformers/langchain/embeddings/requirements.txt
+++ b/intel_extension_for_transformers/langchain/embeddings/requirements.txt
@@ -1,3 +1,3 @@
 langchain_core
 InstructorEmbedding
-git+https://github.com/UKPLab/sentence-transformers.git
+git+https://github.com/UKPLab/sentence-transformers.git@5c838a705c24c2dfd151a71674c99d09d014c1a9

--- a/intel_extension_for_transformers/neural_chat/pipeline/plugins/caching/requirements.txt
+++ b/intel_extension_for_transformers/neural_chat/pipeline/plugins/caching/requirements.txt
@@ -1,2 +1,2 @@
 gptcache
-git+https://github.com/UKPLab/sentence-transformers.git
+git+https://github.com/UKPLab/sentence-transformers.git@5c838a705c24c2dfd151a71674c99d09d014c1a9

--- a/intel_extension_for_transformers/neural_chat/pipeline/plugins/retrieval/retrieval_agent.py
+++ b/intel_extension_for_transformers/neural_chat/pipeline/plugins/retrieval/retrieval_agent.py
@@ -128,6 +128,7 @@ class Agent_QA():
                 )
         except Exception as e:
             logging.error("Please selet a proper embedding model.")
+            logging.error(e)
         
         self.document_parser = DocumentParser(max_chuck_size=max_chuck_size, min_chuck_size = min_chuck_size, \
                                               process=self.process)

--- a/intel_extension_for_transformers/neural_chat/requirements.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements.txt
@@ -30,7 +30,7 @@ yacs
 uvicorn
 optimum
 optimum-intel
-git+https://github.com/UKPLab/sentence-transformers.git
+git+https://github.com/UKPLab/sentence-transformers.git@5c838a705c24c2dfd151a71674c99d09d014c1a9
 unstructured
 markdown
 rouge_score

--- a/intel_extension_for_transformers/neural_chat/requirements_cpu.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements_cpu.txt
@@ -27,7 +27,7 @@ yacs
 uvicorn
 optimum
 optimum-intel
-git+https://github.com/UKPLab/sentence-transformers.git
+git+https://github.com/UKPLab/sentence-transformers.git@5c838a705c24c2dfd151a71674c99d09d014c1a9
 unstructured
 markdown
 rouge_score

--- a/intel_extension_for_transformers/neural_chat/requirements_hpu.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements_hpu.txt
@@ -25,7 +25,7 @@ starlette
 yacs
 uvicorn
 optimum
-git+https://github.com/UKPLab/sentence-transformers.git
+git+https://github.com/UKPLab/sentence-transformers.git@5c838a705c24c2dfd151a71674c99d09d014c1a9
 unstructured
 markdown
 rouge_score

--- a/intel_extension_for_transformers/neural_chat/requirements_pc.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements_pc.txt
@@ -26,7 +26,7 @@ yacs
 uvicorn
 optimum
 optimum-intel
-git+https://github.com/UKPLab/sentence-transformers.git
+git+https://github.com/UKPLab/sentence-transformers.git@5c838a705c24c2dfd151a71674c99d09d014c1a9
 unstructured
 markdown
 rouge_score

--- a/intel_extension_for_transformers/neural_chat/tests/requirements.txt
+++ b/intel_extension_for_transformers/neural_chat/tests/requirements.txt
@@ -32,7 +32,7 @@ yacs
 uvicorn
 optimum
 optimum[habana]
-git+https://github.com/UKPLab/sentence-transformers.git
+git+https://github.com/UKPLab/sentence-transformers.git@5c838a705c24c2dfd151a71674c99d09d014c1a9
 unstructured
 markdown
 rouge_score

--- a/workflows/chatbot/demo/docker/Dockerfile
+++ b/workflows/chatbot/demo/docker/Dockerfile
@@ -97,7 +97,7 @@ RUN source activate && conda activate chatbot-demo && \
     pip install schema python-multipart speechbrain soundfile gptcache pydub && \
     pip install -i https://test.pypi.org/simple/ intel-extension-for-transformers==1.0.0.dev20230602 && \
     pip uninstall sentence_transformers -y && \
-    pip install git+https://github.com/UKPLab/sentence-transformers.git
+    pip install git+https://github.com/UKPLab/sentence-transformers.git@5c838a705c24c2dfd151a71674c99d09d014c1a9
 
 
 # Add user


### PR DESCRIPTION
## Type of Change

others
API changed or not: no

## Description

Limit sentence-transformers version to 5c838a705c24c2dfd151a71674c99d09d014c1a9. 
Sentence-transformers will release a new version (v2.2.3) soon. We will update the version limit once a new version is released.

## How has this PR been tested?
CI

## Dependency Change?

NO