### PR TITLE
[NeuralChat] fix latest transformers whisper forced_decoder_ids error

### DIFF
--- a/intel_extension_for_transformers/neural_chat/pipeline/plugins/audio/asr.py
+++ b/intel_extension_for_transformers/neural_chat/pipeline/plugins/audio/asr.py
@@ -94,7 +94,8 @@ class AudioSpeechRecognition():
             else:
                 self.forced_decoder_ids = self.processor.get_decoder_prompt_ids(language=self.language,
                                                                                 task="transcribe")
-                predicted_ids = self.model.generate(inputs, forced_decoder_ids=self.forced_decoder_ids)
+                self.model.config.forced_decoder_ids = self.forced_decoder_ids
+                predicted_ids = self.model.generate(inputs)
         # pylint: disable=E1101
         result = self.processor.tokenizer.batch_decode(
             predicted_ids, skip_special_tokens=True, normalize=True)[0]


### PR DESCRIPTION
## Type of Change

bug fix

## Description

latest transformers >=4.37.0 cause error when passing forced_decoder_ids in model.generate

## Expected Behavior & Potential Risk

I fix the problem and test that it is compatible with transformers == 4.37.0 as well as 4.36.2

## How has this PR been tested?

ut

## Dependency Change?

None