### PR TITLE
[NeuralChat] pip install neural_speed from wheel

### DIFF
--- a/.github/workflows/script/unitTest/run_unit_test_neuralchat.sh
+++ b/.github/workflows/script/unitTest/run_unit_test_neuralchat.sh
@@ -86,10 +86,6 @@ function main() {
     apt-get install libsm6 libxext6 -y
     wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.19_amd64.deb
     dpkg -i libssl1.1_1.1.1f-1ubuntu2.19_amd64.deb
-    git clone https://github.com/intel/neural-speed.git
-    cd neural-speed && pip install -r requirements.txt && pip install .
-    cd ..
-    pip list | grep neural-speed
     python -m pip install --upgrade --force-reinstall torch
     pip install paddlepaddle==2.4.2 paddlenlp==2.5.2 paddlespeech==1.4.1 paddle2onnx==1.0.6
     cd ${WORKING_DIR} || exit 1

--- a/intel_extension_for_transformers/neural_chat/requirements.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements.txt
@@ -74,3 +74,4 @@ transformers_stream_generator
 qdrant-client
 huggingface_hub
 vllm
+neural_speed

--- a/intel_extension_for_transformers/neural_chat/requirements_hpu.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements_hpu.txt
@@ -44,3 +44,4 @@ zhconv
 urllib3
 langid
 qdrant-client
+neural_speed

--- a/intel_extension_for_transformers/neural_chat/requirements_pc.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements_pc.txt
@@ -47,3 +47,4 @@ pymysql
 deepface
 exifread
 qdrant-client
+neural_speed

--- a/intel_extension_for_transformers/neural_chat/requirements_xpu.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements_xpu.txt
@@ -40,3 +40,4 @@ zhconv
 urllib3
 langid
 qdrant-client
+neural_speed

--- a/intel_extension_for_transformers/neural_chat/tests/requirements.txt
+++ b/intel_extension_for_transformers/neural_chat/tests/requirements.txt
@@ -74,3 +74,4 @@ transformers_stream_generator
 qdrant-client
 huggingface_hub
 vllm
+neural_speed


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

pip install neural_speed from wheel

## Expected Behavior & Potential Risk

Now neural_speed can be pip install from wheel.

## How has this PR been tested?

pre-CI test

## Dependency Change?

None.