### PR TITLE
[NeuralChat] Fix backprop error for text only examples

### DIFF
--- a/intel_extension_for_transformers/transformers/modeling/llava_models/llava_arch.py
+++ b/intel_extension_for_transformers/transformers/modeling/llava_models/llava_arch.py
@@ -161,10 +161,9 @@ class LlavaMetaForCausalLM(PreTrainedModel):
         for batch_idx, cur_input_ids in enumerate(input_ids):
             num_images = (cur_input_ids == IMAGE_TOKEN_INDEX).sum()
             if num_images == 0:
-                cur_image_features = image_features[cur_image_idx]
-                cur_input_embeds_1 = self.get_model().embed_tokens(cur_input_ids)
-                cur_input_embeds = torch.cat([cur_input_embeds_1, cur_image_features[0:0]], dim=0)
-                new_input_embeds.append(cur_input_embeds)
+                # Concatenating the cur_image_features[0:0], like in the original implementation, 
+                # is removed as it causes the backpropogation to crash on the hpu.
+                new_input_embeds.append(self.get_model().embed_tokens(cur_input_ids))
                 new_labels.append(labels[batch_idx])
                 cur_image_idx += 1
                 continue


### PR DESCRIPTION
## Type of Change
Bug fix

## Description
This PR fixes the problem reported in [#1181](https://github.com/intel/intel-extension-for-transformers/issues/1181). The problem only happens on HPU devices and can be recreated with this simple script:

```python
import torch
import habana_frameworks.torch.core as htcore
import habana_frameworks.torch as htorch


a = torch.ones([10], requires_grad=True).to("hpu")
b = torch.ones([10], requires_grad=True).to("hpu")
c = torch.cat([a, b[0:0]], dim=0)
c.sum().backward()
```

which outputs:

```
Traceback (most recent call last):
  File "/intel-extension-for-transformers/intel_extension_for_transformers/neural_chat/examples/finetuning/multi_modal/test.py", line 9, in <module>
    c.sum().backward()
  File "/usr/local/lib/python3.10/dist-packages/torch/_tensor.py", line 502, in backward
    torch.autograd.backward(
  File "/usr/local/lib/python3.10/dist-packages/torch/autograd/__init__.py", line 251, in backward
    Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass
RuntimeError: Function SliceBackward0 returned an invalid gradient at index 0 - expected device hpu:0 but got cpu
```

which is the same error seen in the issue. Running this code on a CUDA device does not cause the issue which is why it's in the original LLaVA implementation. I removed creating the image embeddings and concatenating the empty array as it seems to no be doing anything. It was introduced in [this PR](https://github.com/haotian-liu/LLaVA/commit/44e0562f9497fb79f042427307472a87d266d90a#diff-4477387d506ccb1897a13972cba26c9da3fad4d3e1c32ec4b8bd8ff7acd3f292) but it's not clear to me why they needed to concatenate the `cur_image_features[0:0]` as it'd just be an empty list.

I've confirmed this works by running the finetuning script with DeepSpeed zero3 on only examples without images (to try and reproduce the error) and with images as well for a few iterations.

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed