### PR TITLE
[NeuralChat] Remove redundant knowledge id in audio plugin api

### DIFF
--- a/intel_extension_for_transformers/neural_chat/server/restful/plugin_audio_api.py
+++ b/intel_extension_for_transformers/neural_chat/server/restful/plugin_audio_api.py
@@ -98,10 +98,9 @@ async def talkingbot(request: Request):
     data = await request.json()
     text = data["text"]
     voice = data["voice"]
-    knowledge_id = data["knowledge_id"]
     audio_output_path = data["audio_output_path"] if "audio_output_path" in data else "output_audio.wav"
 
-    logger.info(f'Received prompt: {text}, and use voice: {voice} knowledge_id: {knowledge_id}')
+    logger.info(f'Received prompt: {text}, and use voice: {voice}')
 
     return await router.handle_voice_tts_request(text, voice, audio_output_path)
 


### PR DESCRIPTION
## Type of Change

code refine

## Description

knowledge id is not needed in TTS router

## Expected Behavior & Potential Risk

remove the knowledge id parameter

## How has this PR been tested?

ut

## Dependency Change?

None