### PR TITLE
[NeuralChat] Fix response issue of model.predict

### DIFF
--- a/intel_extension_for_transformers/neural_chat/models/model_utils.py
+++ b/intel_extension_for_transformers/neural_chat/models/model_utils.py
@@ -1437,15 +1437,15 @@ def predict(**params):
     else:
         output = tokenizer.decode(generation_output.sequences[0], skip_special_tokens=True)
     if "### Response:" in output:
-        return output.split("### Response:")[1].strip()
+        return output.split("### Response:")[-1].strip()
     if "@@ Response" in output:
-        return output.split("@@ Response")[1].strip()
+        return output.split("@@ Response")[-1].strip()
     if "### Assistant" in output:
-        return output.split("### Assistant:")[1].strip()
+        return output.split("### Assistant:")[-1].strip()
     if "\nassistant\n" in output:
-        return output.split("\nassistant\n")[1].strip()
+        return output.split("\nassistant\n")[-1].strip()
     if "[/INST]" in output:
-        return output.split("[/INST]")[1].strip()
+        return output.split("[/INST]")[-1].strip()
     if "答：" in output:
-        return output.split("答：")[1].strip()
+        return output.split("答：")[-1].strip()
     return output


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

Fix response issue of model.predict

## Expected Behavior & Potential Risk

The response of chatbot.predict will be cropped by the last endding identifier.
Chatbot will return the correct response when chatting with history.

## How has this PR been tested?

Local test.

## Dependency Change?

None.