### PR TITLE
[NeuralChat] Fixed broken links, model name typo

### DIFF
--- a/intel_extension_for_transformers/neural_chat/examples/finetuning/instruction/README.md
+++ b/intel_extension_for_transformers/neural_chat/examples/finetuning/instruction/README.md
@@ -39,7 +39,7 @@ Once you have the docker image ready, please follow [run docker image](../../../
 ## 2. Prepare the Model
 
 #### meta-llama/Llama-2-7b-hf
-To acquire the checkpoints and tokenizer, the user can get those files from [meta-llama/Llama-2-7b-hf]([https://huggingface.co/mosaicml/mpt-7b](https://huggingface.co/meta-llama/Llama-2-7b-hf)).
+To acquire the checkpoints and tokenizer, the user can get those files from [meta-llama/Llama-2-7b-hf](https://huggingface.co/meta-llama/Llama-2-7b-hf).
 Users could follow below commands to get the checkpoints from github repository after the access request to the files is approved.
 ```bash
 git lfs install

--- a/intel_extension_for_transformers/neural_chat/examples/finetuning/instruction/README.md
+++ b/intel_extension_for_transformers/neural_chat/examples/finetuning/instruction/README.md
@@ -38,12 +38,12 @@ Once you have the docker image ready, please follow [run docker image](../../../
 
 ## 2. Prepare the Model
 
-#### meta-llama/Llama-2-7b
-To acquire the checkpoints and tokenizer, the user can get those files from [meta-llama/Llama-2-7b]([https://huggingface.co/mosaicml/mpt-7b](https://huggingface.co/meta-llama/Llama-2-7b)).
+#### meta-llama/Llama-2-7b-hf
+To acquire the checkpoints and tokenizer, the user can get those files from [meta-llama/Llama-2-7b-hf]([https://huggingface.co/mosaicml/mpt-7b](https://huggingface.co/meta-llama/Llama-2-7b-hf)).
 Users could follow below commands to get the checkpoints from github repository after the access request to the files is approved.
 ```bash
 git lfs install
-git clone https://huggingface.co/meta-llama/Llama-2-7b
+git clone https://huggingface.co/meta-llama/Llama-2-7b-hf
 ```
 ### MPT
 To acquire the checkpoints and tokenizer, the user can get those files from [mosaicml/mpt-7b](https://huggingface.co/mosaicml/mpt-7b).
@@ -143,11 +143,11 @@ python finetune_seq2seq.py \
 
 #### For LLaMA2
 
-- use the below command line for code tuning with `meta-llama/Llama-2-7b` on [theblackcat102/evol-codealpaca-v1](https://huggingface.co/datasets/theblackcat102/evol-codealpaca-v1).
+- use the below command line for code tuning with `meta-llama/Llama-2-7b-hf` on [theblackcat102/evol-codealpaca-v1](https://huggingface.co/datasets/theblackcat102/evol-codealpaca-v1).
 
 ```bash
 python finetune_clm.py \
-        --model_name_or_path "meta-llama/Llama-2-7b" \
+        --model_name_or_path "meta-llama/Llama-2-7b-hf" \
         --bf16 True \
         --dataset_name "theblackcat102/evol-codealpaca-v1" \
         --per_device_train_batch_size 8 \

--- a/intel_extension_for_transformers/neural_chat/ui/customized/talking_photo/README.md
+++ b/intel_extension_for_transformers/neural_chat/ui/customized/talking_photo/README.md
@@ -1,8 +1,8 @@
-<h1 align="center" id="title"><img align="center" src="./src/lib/assets/favicon.png" alt="project-image">Neural Chat</h1>
+<h1 align="center" id="title"><img align="center" src="./static/favicon.png" alt="project-image">Neural Chat</h1>
 
 <h2>🚀 Demo</h2>
 
-[http://neuralstudio.intel.com/NeuralChat](http://neuralstudio.intel.com/NeuralChat)
+[https://talkingphoto.eglb.intel.com/](https://talkingphoto.eglb.intel.com/)
 
 <h2>📸 Project Screenshots:</h2>
 

--- a/intel_extension_for_transformers/neural_chat/ui/customized/talkingbot/README.md
+++ b/intel_extension_for_transformers/neural_chat/ui/customized/talkingbot/README.md
@@ -1,4 +1,4 @@
-<h1 align="center" id="title"><img align="center" src="./src/lib/assets/favicon.png" alt="project-image">Talking Bot</h1>
+<h1 align="center" id="title"><img align="center" src="./static/favicon.png" alt="project-image">Talking Bot</h1>
 
 ### 📸 Project Screenshots
 


### PR DESCRIPTION
## Type of Change

Documentation cleanup

## Description

Neural Chat UI documentation had 3 broken links, finetuning example README uses the wrong Llama-2 model, should have hf in its name in order to access its config.json

## Expected Behavior & Potential Risk

N/A

## How has this PR been tested?

N/A

## Dependency Change?

None
