### PR TITLE
Fix Qdrant bug caused by langchain_core upgrade

### DIFF
--- a/intel_extension_for_transformers/langchain/vectorstores/qdrant.py
+++ b/intel_extension_for_transformers/langchain/vectorstores/qdrant.py
@@ -288,3 +288,21 @@ class Qdrant(Qdrant_origin):
             return True
         else:
             return False
+
+
+    @classmethod
+    def _document_from_scored_point(
+        cls,
+        scored_point: Any,
+        content_payload_key: str,
+        metadata_payload_key: str,
+    ) -> Document:
+        metadata = scored_point.payload.get(metadata_payload_key) or {}
+        metadata["_id"] = scored_point.id
+        # TODO: re-check the bug
+        # Comment out the following line because of bug "'ScoredPoint' object has no attribute 'collection_name'"
+        # metadata["_collection_name"] = scored_point.collection_name
+        return Document(
+            page_content=scored_point.payload.get(content_payload_key),
+            metadata=metadata,
+        )


### PR DESCRIPTION
## Type of Change

bug fix 
API changed or not: no

## Description

Fix qdrant bug caused by langchain_core upgrade: `'ScoredPoint' object has no attribute 'collection_name'`

TODO: `langchain` is limited to 0.0.354, while `langchain_core` is latest version now. Will check and limit `langchain_core`  version in a new PR

## How has this PR been tested?

CI

## Dependency Change?

No
