### PR TITLE
[NeuralChat] Support deepseek-coder models in NeuralChat

### DIFF
--- a/intel_extension_for_transformers/neural_chat/chatbot.py
+++ b/intel_extension_for_transformers/neural_chat/chatbot.py
@@ -134,6 +134,9 @@ def build_chatbot(config: PipelineConfig=None):
     elif "solar" in config.model_name_or_path.lower():
         from .models.solar_model import SolarModel
         adapter = SolarModel(config.model_name_or_path, config.task)
+    elif "deepseek-coder" in config.model_name_or_path.lower():
+        from .models.deepseek_coder_model import DeepseekCoderModel
+        adapter = DeepseekCoderModel(config.model_name_or_path, config.task)
     elif "opt" in config.model_name_or_path.lower() or \
          "gpt" in config.model_name_or_path.lower() or \
          "flan-t5" in config.model_name_or_path.lower() or \

--- a/intel_extension_for_transformers/neural_chat/models/deepseek_coder_model.py
+++ b/intel_extension_for_transformers/neural_chat/models/deepseek_coder_model.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .base_model import BaseModel
+import logging
+from fastchat.conversation import get_conv_template, Conversation
+
+logging.basicConfig(
+    format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+    datefmt="%m/%d/%Y %H:%M:%S",
+    level=logging.INFO,
+)
+logger = logging.getLogger(__name__)
+
+class DeepseekCoderModel(BaseModel):
+    def match(self):
+        """
+        Check if the provided model_path matches the current model.
+
+        Returns:
+            bool: True if the model_path matches, False otherwise.
+        """
+        return "deepseek-coder" in self.model_name.lower()
+
+    def get_default_conv_template(self) -> Conversation:
+        """
+        Get the default conversation template for the given model path.
+
+        Returns:
+            Conversation: A default conversation template.
+        """
+        return get_conv_template("deepseek-coder")

--- a/intel_extension_for_transformers/neural_chat/models/model_utils.py
+++ b/intel_extension_for_transformers/neural_chat/models/model_utils.py
@@ -668,7 +668,8 @@ def load_model(
         return
 
     if re.search("llama", model.config.architectures[0], re.IGNORECASE) and \
-       not re.search("magicoder", model_name, re.IGNORECASE):
+       (not re.search("magicoder", model_name, re.IGNORECASE) and
+       not re.search("deepseek-coder", model_name, re.IGNORECASE)):
         # unwind broken decapoda-research config
         model.generation_config.pad_token_id = 0
         model.generation_config.bos_token_id = 1

--- a/intel_extension_for_transformers/neural_chat/requirements.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements.txt
@@ -3,7 +3,7 @@ cchardet
 einops
 evaluate
 fastapi==0.103.2
-fschat==0.2.32
+fschat==0.2.35
 git+https://github.com/EleutherAI/lm-evaluation-harness.git@cc9778fbe4fa1a709be2abed9deb6180fd40e7e2
 huggingface_hub
 intel_extension_for_pytorch

--- a/intel_extension_for_transformers/neural_chat/requirements_hpu.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements_hpu.txt
@@ -2,7 +2,7 @@ cchardet
 einops
 evaluate
 fastapi==0.103.2
-fschat==0.2.32
+fschat==0.2.35
 git+https://github.com/EleutherAI/lm-evaluation-harness.git@cc9778fbe4fa1a709be2abed9deb6180fd40e7e2
 intel_extension_for_pytorch
 neural-compressor

--- a/intel_extension_for_transformers/neural_chat/requirements_pc.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements_pc.txt
@@ -3,7 +3,7 @@ cchardet
 einops
 evaluate
 fastapi==0.103.2
-fschat==0.2.32
+fschat==0.2.35
 git+https://github.com/EleutherAI/lm-evaluation-harness.git@cc9778fbe4fa1a709be2abed9deb6180fd40e7e2
 neural-compressor
 numpy==1.23.5

--- a/intel_extension_for_transformers/neural_chat/requirements_xpu.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements_xpu.txt
@@ -2,7 +2,7 @@ cchardet
 einops
 evaluate
 fastapi==0.103.2
-fschat==0.2.32
+fschat==0.2.35
 neural-compressor
 numpy==1.23.5
 pydantic==1.10.13

--- a/intel_extension_for_transformers/neural_chat/tests/nightly/models/test_deepseekcoder.py
+++ b/intel_extension_for_transformers/neural_chat/tests/nightly/models/test_deepseekcoder.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from intel_extension_for_transformers.neural_chat import build_chatbot, PipelineConfig
+from intel_extension_for_transformers.neural_chat.utils.common import get_device_type
+import unittest
+
+class TestStarCoderModel(unittest.TestCase):
+    def setUp(self):
+        return super().setUp()
+
+    def tearDown(self) -> None:
+        return super().tearDown()
+
+    def test_code_gen(self):
+        config = PipelineConfig(
+            model_name_or_path="/tf_dataset2/models/nlp_toolkit/deepseek-coder-6.7b-instruct")
+        chatbot = build_chatbot(config=config)
+        result = chatbot.predict("def print_hello_world():")
+        print(result)
+        self.assertIn("Hello World", str(result))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/intel_extension_for_transformers/neural_chat/tests/requirements.txt
+++ b/intel_extension_for_transformers/neural_chat/tests/requirements.txt
@@ -12,7 +12,7 @@ face_alignment==1.3.5
 facexlib @ git+https://github.com/Spycsh/facexlib@master
 fastapi==0.103.2
 ffmpeg-python==0.2.0
-fschat==0.2.32
+fschat==0.2.35
 gfpgan
 git+https://github.com/EleutherAI/lm-evaluation-harness.git@cc9778fbe4fa1a709be2abed9deb6180fd40e7e2
 git+https://github.com/UKPLab/sentence-transformers.git@5c838a705c24c2dfd151a71674c99d09d014c1a9


### PR DESCRIPTION
## Type of Change

feature
API not changed

## Description

Support deepseek-coder models in NeuralChat

## Expected Behavior & Potential Risk

Users can use the deepseek-ai/deepseek-coder models in NeuralChat.

## How has this PR been tested?

Local test and pre-CI test.

## Dependency Change?

None.
