### PR TITLE
Fix text-generation example accuracy test

### DIFF
--- a/examples/huggingface/pytorch/text-generation/quantization/requirements.txt
+++ b/examples/huggingface/pytorch/text-generation/quantization/requirements.txt
@@ -1,5 +1,7 @@
 accelerate
 datasets >= 2.0
+peft
+protobuf
 sentencepiece != 0.1.92
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.1.1+cpu
@@ -9,6 +11,7 @@ bitsandbytes  #baichuan
 transformers_stream_generator
 tiktoken  #qwen
 einops  #qwen
-optimum-intel
 git+https://github.com/intel/neural-compressor.git
+git+https://github.com/huggingface/optimum-intel.git@f95dea1ae8966dee4d75d622e7b2468c514ba02d
+git+https://github.com/huggingface/optimum.git@927e94739447b13f7eefe085c8d3662654b6a11c
 git+https://github.com/EleutherAI/lm-evaluation-harness.git@cc9778fbe4fa1a709be2abed9deb6180fd40e7e2

--- a/examples/huggingface/pytorch/text-generation/quantization/requirements.txt
+++ b/examples/huggingface/pytorch/text-generation/quantization/requirements.txt
@@ -1,6 +1,5 @@
 accelerate
 datasets >= 2.0
-protobuf
 sentencepiece != 0.1.92
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.1.1+cpu

--- a/examples/huggingface/pytorch/text-generation/quantization/requirements.txt
+++ b/examples/huggingface/pytorch/text-generation/quantization/requirements.txt
@@ -11,7 +11,6 @@ bitsandbytes  #baichuan
 transformers_stream_generator
 tiktoken  #qwen
 einops  #qwen
+optimum-intel
 git+https://github.com/intel/neural-compressor.git
-git+https://github.com/huggingface/optimum-intel.git@f95dea1ae8966dee4d75d622e7b2468c514ba02d
-git+https://github.com/huggingface/optimum.git@927e94739447b13f7eefe085c8d3662654b6a11c
 git+https://github.com/EleutherAI/lm-evaluation-harness.git@cc9778fbe4fa1a709be2abed9deb6180fd40e7e2

--- a/examples/huggingface/pytorch/text-generation/quantization/requirements.txt
+++ b/examples/huggingface/pytorch/text-generation/quantization/requirements.txt
@@ -1,6 +1,5 @@
 accelerate
 datasets >= 2.0
-peft
 protobuf
 sentencepiece != 0.1.92
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/examples/huggingface/pytorch/text-generation/quantization/run_generation.py
+++ b/examples/huggingface/pytorch/text-generation/quantization/run_generation.py
@@ -285,7 +285,7 @@ elif args.woq:
             scale_dtype=args.woq_scale_dtype,
             weight_dtype=args.woq_weight_dtype,
             scheme=args.woq_scheme,
-            group_size=args.gptq_block_size,
+            group_size=args.woq_group_size,
             algorithm=args.woq_algo,
             tokenizer=tokenizer,
             algorithm_args=algorithm_args,
@@ -438,7 +438,7 @@ if args.accuracy:
         peft_config.base_model_name_or_path if args.peft_model_id else args.model
     )
     from intel_extension_for_transformers.llm.evaluation.lm_eval import evaluate
-
+    args._commit_hash = "main" if args._commit_hash is None else args._commit_hash 
     results = evaluate(
         model="hf-causal",
         model_args="pretrained="


### PR DESCRIPTION
## Type of Change

1. fix gptq args, args.woq_group_size is different with args.gptq_block_size
2. _commit_hash default is None, but evaluate func need pass the string.

## Description

detail description 
JIRA ticket: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
