### PR TITLE
[NeuralChat] add time tracer decorator

### DIFF
--- a/intel_extension_for_transformers/neural_chat/models/base_model.py
+++ b/intel_extension_for_transformers/neural_chat/models/base_model.py
@@ -26,6 +26,7 @@ from .model_utils import load_model, predict, predict_stream, MODELS
 from ..prompts import PromptTemplate
 from ..prompts.prompt import MAGICODER_PROMPT, generate_sqlcoder_prompt
 from ..utils.error_utils import set_latest_error
+from ..utils.tracer import tracer
 from ..errorcode import ErrorCodes
 import logging
 logging.basicConfig(
@@ -254,6 +255,7 @@ class BaseModel(ABC):
 
         return response, link
 
+    @tracer.time_tracer
     def predict(self, query, origin_query="", config=None):
         """
         Predict using a non-streaming approach.
@@ -449,6 +451,7 @@ class BaseModel(ABC):
                 raise NotImplementedError(f"Unsupported task {task}.")
             self.conv_template = PromptTemplate(name, clear_history=clear_history)
 
+    @tracer.time_tracer
     def prepare_prompt(self, prompt: str, task: str = ""):
         self.get_conv_template(task)
         self.conv_template.append_message(self.conv_template.roles[0], prompt)

--- a/intel_extension_for_transformers/neural_chat/server/restful/textchat_api.py
+++ b/intel_extension_for_transformers/neural_chat/server/restful/textchat_api.py
@@ -49,6 +49,8 @@ from ...config import GenerationConfig
 import json, types
 import tiktoken
 from ...plugins import plugins, is_plugin_enabled
+from ...utils.tracer import tracer
+
 
 def check_requests(request) -> Optional[JSONResponse]:
     # Check all params
@@ -119,6 +121,7 @@ def _add_to_set(s, new_stop):
     else:
         new_stop.update(s)
 
+@tracer.time_tracer
 async def get_generation_parameters(
     model_name: str,
     chatbot: BaseModel,
@@ -351,6 +354,7 @@ async def generate_completion_stream(payload: Dict[str, Any], chatbot: BaseModel
         plugins["cache"]["instance"].post_llm_inference_actions(prompt, buffered_texts)
 
 
+@tracer.time_tracer
 async def generate_completion(payload: Dict[str, Any], chatbot: BaseModel):
     config = GenerationConfig()
     for attr, value in payload.items():
@@ -468,11 +472,13 @@ async def show_available_models():
     return ModelList(data=model_cards)
 
 @router.get("/health")
+@tracer.time_tracer
 async def health() -> Response:
     """Health check."""
     return Response(status_code=200)
 
 @router.post("/v1/chat/completions")
+@tracer.time_tracer
 async def create_chat_completion(request: ChatCompletionRequest):
     """Creates a completion for the chat message.
     This API mimics the OpenAI ChatCompletion API.
@@ -487,6 +493,9 @@ async def create_chat_completion(request: ChatCompletionRequest):
         return error_check_ret
 
     chatbot = router.get_chatbot()
+
+    if request.n != 1 and request.top_k == 1:
+        request.top_k = request.n
 
     gen_params = await get_generation_parameters(
         request.model,
@@ -510,33 +519,40 @@ async def create_chat_completion(request: ChatCompletionRequest):
         return StreamingResponse(generator, media_type="text/event-stream")
 
     choices = []
-    chat_completions = []
-    for i in range(request.n):
-        content = asyncio.create_task(generate_completion(gen_params, chatbot))
-        chat_completions.append(content)
+    # chat_completions = []
+    # for i in range(request.n):
+    #     content = asyncio.create_task(generate_completion(gen_params, chatbot))
+    #     chat_completions.append(content)
+    # try:
+    #     all_tasks = await asyncio.gather(*chat_completions)
     try:
-        all_tasks = await asyncio.gather(*chat_completions)
+        content = await generate_completion(gen_params, chatbot)
     except Exception as e:
         return create_error_response(ApiErrorCode.INTERNAL_ERROR, str(e))
     usage = UsageInfo()
-    for i, content in enumerate(all_tasks):
-        if isinstance(content, str):
-            content = json.loads(content)
+    # for i, content in enumerate(all_tasks):
+    #     if isinstance(content, str):
+    #         content = json.loads(content)
 
-        if content["error_code"] != 0:
-            return create_error_response(content["error_code"], content["text"])
-        choices.append(
-            ChatCompletionResponseChoice(
-                index=i,
+    #     if content["error_code"] != 0:
+    #         return create_error_response(content["error_code"], content["text"])
+    #     choices.append(
+    #         ChatCompletionResponseChoice(
+    #             index=i,
+    #             message=ChatMessage(role="assistant", content=content["text"]),
+    #             finish_reason=content.get("finish_reason", "stop"),
+    #         )
+    #     )
+    #     if "usage" in content:
+    #         task_usage = UsageInfo.parse_obj(content["usage"])
+    #         for usage_key, usage_value in task_usage.dict().items():
+    #             setattr(usage, usage_key, getattr(usage, usage_key) + usage_value)
+
+    choices.append(ChatCompletionResponseChoice(
+                index=0,
                 message=ChatMessage(role="assistant", content=content["text"]),
                 finish_reason=content.get("finish_reason", "stop"),
-            )
-        )
-        if "usage" in content:
-            task_usage = UsageInfo.parse_obj(content["usage"])
-            for usage_key, usage_value in task_usage.dict().items():
-                setattr(usage, usage_key, getattr(usage, usage_key) + usage_value)
-
+            ))
     return ChatCompletionResponse(model=request.model, choices=choices, usage=usage)
 
 

--- a/intel_extension_for_transformers/neural_chat/utils/tracer.py
+++ b/intel_extension_for_transformers/neural_chat/utils/tracer.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from functools import wraps
 import time
 import inspect

--- a/intel_extension_for_transformers/neural_chat/utils/tracer.py
+++ b/intel_extension_for_transformers/neural_chat/utils/tracer.py
@@ -1,0 +1,96 @@
+from functools import wraps
+import time
+import inspect
+
+class TracerNode:
+    def __init__(self, id, func_name, next=[]):
+        # next: a list of TracerNode
+        self.id = id
+        self.func_name = func_name
+        self.next = next
+
+    def set_next(self, next_node):
+        self.next.append(next_node)
+
+    def set_time(self, time):
+        self.time = time
+
+class Tracer:
+
+    def __init__(self):
+        self.frame_to_tracer_node = {} # a mapping from the hashed frame to TracerNode
+        self.root = None
+
+    def _prepare_frame_tracer_nodes(self, func):
+        cur_func_name = func.__name__
+        cur_tracer_node = TracerNode(hash(func), cur_func_name, next=[])
+        is_root = False
+        if self.frame_to_tracer_node == {}:
+            is_root = True
+            self.root = cur_tracer_node
+
+        if self.frame_to_tracer_node != {}:
+            for i in inspect.stack()[1:]:
+                # for every parent (not including self) recursively, check whether has a TracerNode
+                # if there is a TracerNode, set its next to the current TracerNode, and break
+                # else, continue checking until the run_endpoint
+                # notice the frame should back to the wrapper which is on the stack of the callee func
+                if hash(i.frame.f_back) in self.frame_to_tracer_node:
+                    self.frame_to_tracer_node[hash(i.frame.f_back)].set_next(cur_tracer_node)
+                    # print("\n")
+                    # print(self.frame_to_tracer_node[hash(i.frame.f_back)].func_name)
+                    # print("=>")
+                    # print(self.frame_to_tracer_node[hash(i.frame.f_back)].next[0].func_name)
+                    # print("\n")
+                    break
+        # append the currentframe of wrapper => current TracerNode to the dict
+        cur_frame = hash(inspect.currentframe().f_back)
+
+        self.frame_to_tracer_node[cur_frame] = cur_tracer_node
+        return cur_tracer_node, is_root
+
+    def time_tracer(self, func):
+        if inspect.iscoroutinefunction(func):
+            @wraps(func)
+            async def wrapper(*args, **kwargs):
+                cur_tracer_node, is_root = self._prepare_frame_tracer_nodes(func)
+                start = time.time()
+                res = await func(*args, **kwargs)
+                # print unstructured time
+                # print(f'call {func.__name__}: {round(time.time() - start, 2)} seconds')
+                cur_tracer_node.set_time(round(time.time() - start, 2))
+                if is_root:
+                    self.print_time_trace(self.root)
+                    self.clearup()
+                return res
+        else:
+            @wraps(func)
+            def wrapper(*args, **kwargs):
+                cur_tracer_node, is_root = self._prepare_frame_tracer_nodes(func)
+                start = time.time()
+                res = func(*args, **kwargs)
+                # print unstructured time
+                # print(f'call {func.__name__}: {round(time.time() - start, 2)} seconds')
+                cur_tracer_node.set_time(round(time.time() - start, 2))
+                if is_root:
+                    self.print_time_trace(self.root)
+                    self.clearup()
+                return res
+
+        return wrapper
+
+    def print_time_trace(self, cur_node, depth=0):
+        if depth==0:
+            prefix = ""
+        else:
+            prefix = "|" + "-"*depth*5 + "> "
+        print(f'{prefix}{cur_node.func_name}: {cur_node.time} seconds')
+        for next_node in cur_node.next:
+            self.print_time_trace(next_node, depth+1)
+
+    def clearup(self):
+        self.frame_to_tracer_node = {}
+
+
+
+tracer = Tracer()


### PR DESCRIPTION
## Type of Change

feature

## Description

This is to mimic LangChain's LangSmith `View Trace` functionality.


That is, with one line simple decorator on one method, you can use this to

- [x] print the time that method use
- [x] print the caller and callee dependencies of all tracer nodes in a tree structure

To use it, simply decorate the method you want to trace with

```
@tracer.time_tracer
def your_func_here_xxx():
        .......
```

The benefit is that this will not involve a lot of redundant modification to the original code.

## Expected Behavior & Potential Risk

Expected: for example, by adding `@tracer` to the following four functions, here we can track the time used by those four with a structure:

```
create_chat_completion: 50.53 seconds
|-----> get_generation_parameters: 0.0 seconds
|-----> generate_completion: 50.46 seconds
|----------> predict: 50.46 seconds
```

Risk:

called methods using asyncio or independent threads will interfere the inspected call stack so the dependencies tree structure cannot be captured correctly, but time printing should still work.

Concurrent access to the same tracer instance may not work

## How has this PR been tested?

Current not added

## Dependency Change?

None