### PR TITLE
[LLM] Support WOQ scheme asym

### DIFF
--- a/intel_extension_for_transformers/llm/quantization/autograd/functions.py
+++ b/intel_extension_for_transformers/llm/quantization/autograd/functions.py
@@ -155,7 +155,7 @@ class MatMulKBit(torch.autograd.Function):
                 None,
             )
 
-        req_gradA, _, _, req_gradBias, _, _, _ = ctx.needs_input_grad
+        req_gradA, _, _, req_gradBias, _, _, _, _ = ctx.needs_input_grad
         A, B = ctx.tensors
         grad_A, grad_B, grad_bias = None, None, None
 
@@ -177,7 +177,7 @@ class MatMulKBit(torch.autograd.Function):
         if req_gradA:
             grad_A = torch.matmul(grad_output, B.to(grad_output.dtype))
 
-        return grad_A, grad_B, None, grad_bias, None, None, None
+        return grad_A, grad_B, None, grad_bias, None, None, None, None
 
 
 def matmul_kbit(
@@ -191,9 +191,10 @@ def matmul_kbit(
     scheme,
     do_dequant=False,
 ):
+
     if do_dequant:
         return MatMulKBit.apply(
-            A, B, out, bias, compute_dtype, weight_dtype, scale_dtype
+            A, B, out, bias, compute_dtype, weight_dtype, scale_dtype, scheme
         )
     else:
         qbits_debug_flag = os.getenv('QBITS_DEBUG', 'NULL')

--- a/intel_extension_for_transformers/llm/quantization/autograd/functions.py
+++ b/intel_extension_for_transformers/llm/quantization/autograd/functions.py
@@ -76,6 +76,7 @@ class MatMulKBit(torch.autograd.Function):
         compute_dtype=None,
         weight_dtype=None,
         scale_dtype=None,
+        scheme=None,
     ):
         # # 1. Dequantize
         # B_dequant = torch.zeros(out.shape[-1], A.shape[-1], dtype=torch.float)
@@ -114,7 +115,7 @@ class MatMulKBit(torch.autograd.Function):
                 compute_dtype,
                 weight_dtype,
                 scale_dtype,
-                False,
+                False if scheme == "sym" else True,
             )
         else:
             out = qbits_woq_linear_ref_impl(
@@ -187,6 +188,7 @@ def matmul_kbit(
     compute_dtype,
     weight_dtype,
     scale_dtype,
+    scheme,
     do_dequant=False,
 ):
     if do_dequant:
@@ -206,7 +208,7 @@ def matmul_kbit(
                 compute_dtype,
                 weight_dtype,
                 scale_dtype,
-                False,
+                False if scheme == "sym" else True,
             )
         else:
             out = qbits_woq_linear_ref_impl(

--- a/intel_extension_for_transformers/llm/quantization/nn/modules.py
+++ b/intel_extension_for_transformers/llm/quantization/nn/modules.py
@@ -129,6 +129,7 @@ class QuantizedLinearQBits(torch.nn.Linear):
             self.compute_dtype if self.compute_dtype is not None else "fp32",
             self.weight_dtype,
             self.scale_dtype if self.scale_dtype is not None else "fp32",
+            self.scheme,
             do_dequant=self.training,
         )
         shape[-1] = self.out_features
@@ -146,7 +147,7 @@ class QuantizedLinearQBits(torch.nn.Linear):
             self.compute_dtype if self.compute_dtype is not None else "fp32",
             self.weight_dtype,
             self.scale_dtype if self.scale_dtype is not None else "fp32",
-            False,
+            False if self.scheme == "sym" else True,
         )
         self.weight = ParamsQBits(
             data=weight,
@@ -315,7 +316,7 @@ class QuantizedLoraLinearQBits(QuantizedLinearQBits, LoraLayer):
             self.compute_dtype,
             self.weight_dtype,
             self.scale_dtype,
-            False,
+            False if self.scheme == "sym" else True,
         )
 
         self.weight = ParamsQBits(
@@ -360,7 +361,7 @@ class QuantizedLoraLinearQBits(QuantizedLinearQBits, LoraLayer):
             self.compute_dtype,
             self.weight_dtype,
             self.scale_dtype,
-            False,
+            False if self.scheme == "sym" else True,
         )
 
         self.weight = ParamsQBits(

--- a/intel_extension_for_transformers/neural_chat/models/model_utils.py
+++ b/intel_extension_for_transformers/neural_chat/models/model_utils.py
@@ -556,7 +556,7 @@ def load_model(
                 tokenizer.padding_side = "left"
         if tokenizer.pad_token is None and tokenizer.pad_token_id is None:
             tokenizer.pad_token = tokenizer.eos_token
-        model = model.eval()
+        model.eval()
         MODELS[model_name]["model"] = model
         MODELS[model_name]["tokenizer"] = tokenizer
         logging.info("Optimized Model loaded.")

--- a/intel_extension_for_transformers/neural_chat/models/model_utils.py
+++ b/intel_extension_for_transformers/neural_chat/models/model_utils.py
@@ -556,7 +556,6 @@ def load_model(
                 tokenizer.padding_side = "left"
         if tokenizer.pad_token is None and tokenizer.pad_token_id is None:
             tokenizer.pad_token = tokenizer.eos_token
-        model.eval()
         MODELS[model_name]["model"] = model
         MODELS[model_name]["tokenizer"] = tokenizer
         logging.info("Optimized Model loaded.")

--- a/intel_extension_for_transformers/neural_chat/models/model_utils.py
+++ b/intel_extension_for_transformers/neural_chat/models/model_utils.py
@@ -556,6 +556,7 @@ def load_model(
                 tokenizer.padding_side = "left"
         if tokenizer.pad_token is None and tokenizer.pad_token_id is None:
             tokenizer.pad_token = tokenizer.eos_token
+        model = model.eval()
         MODELS[model_name]["model"] = model
         MODELS[model_name]["tokenizer"] = tokenizer
         logging.info("Optimized Model loaded.")

--- a/intel_extension_for_transformers/transformers/utils/config.py
+++ b/intel_extension_for_transformers/transformers/utils/config.py
@@ -142,6 +142,11 @@ class WeightOnlyQuantConfig(PretrainedConfig):
         if not isinstance(self.scheme, str):
             raise ValueError("scheme must be a string")
 
+        if self.scheme == "asym" and (self.compute_dtype == "int8" or \
+                         self.weight_dtype.startswith("fp") or self.scale_dtype != "fp32"):
+            raise ValueError("WeightOnlyQuantization doesn't support asym with \
+                                compute_dtype int8 or weight_dtype float or scale_dtype non-fp32 now, \
+                                please use sym scheme")
         self.use_llm_runtime = False
 
     def post_init_xpu(self):

--- a/intel_extension_for_transformers/transformers/utils/config.py
+++ b/intel_extension_for_transformers/transformers/utils/config.py
@@ -142,8 +142,8 @@ class WeightOnlyQuantConfig(PretrainedConfig):
         if not isinstance(self.scheme, str):
             raise ValueError("scheme must be a string")
 
-        if self.scheme == "asym" and (self.compute_dtype == "int8" or \
-                         self.weight_dtype.startswith("fp") or self.scale_dtype != "fp32"):
+        if self.scheme == "asym" and (self.compute_dtype == "int8" or self.weight_dtype.startswith("fp") \
+                                         or self.weight_dtype.startswith("nf") or self.scale_dtype != "fp32"):
             raise ValueError("WeightOnlyQuantization doesn't support asym with \
                                 compute_dtype int8 or weight_dtype float or scale_dtype non-fp32 now, \
                                 please use sym scheme")

--- a/tests/CI/test_quantization.py
+++ b/tests/CI/test_quantization.py
@@ -356,6 +356,7 @@ class TestQuantization(unittest.TestCase):
                                                     quantization_config=woq_config,
                                                     use_llm_runtime=False
                                                 )
+        woq_model.eval()
         output = woq_model(dummy_input)
         print("output:", float(output[0][0][0][0]))
         self.assertTrue(isclose(float(output[0][0][0][0]), 0.16387596726417542, rel_tol=1e-04))
@@ -368,6 +369,7 @@ class TestQuantization(unittest.TestCase):
                                                     quantization_config=woq_config,
                                                     use_llm_runtime=False
                                                 )
+        woq_model.eval()
         output = woq_model(dummy_input)
         print("output:", float(output[0][0][0][0]))
         self.assertTrue(isclose(float(output[0][0][0][0]), 0.17239853739738464, rel_tol=1e-04))
@@ -380,23 +382,25 @@ class TestQuantization(unittest.TestCase):
                                                     quantization_config=woq_config,
                                                     use_llm_runtime=False
                                                 )
+        woq_model.eval()
         output = woq_model(dummy_input)
-        # fp8
+        #fp8
         woq_config = WeightOnlyQuantConfig(weight_dtype="fp8_e5m2", scale_dtype="fp8_e8m0")
         woq_model = AutoModelForCausalLM.from_pretrained(
             model_name_or_path, quantization_config=woq_config, use_llm_runtime=False
         )
+        woq_model.eval()
         output = woq_model(dummy_input)
         self.assertTrue(
            isclose(float(output[0][0][0][0]), 0.16162332892417908, rel_tol=1e-04)
         )
-
         # amp
         amp_config = MixedPrecisionConfig()
         amp_model = AutoModelForCausalLM.from_pretrained(model_name_or_path,
                                                     quantization_config=amp_config,
                                                     use_llm_runtime=False
                                                 )
+        amp_model.eval()
         output = amp_model(dummy_input)
         self.assertTrue(isclose(float(output[0][0][0][0]), 0.1689453125, rel_tol=1e-04))
         # bitsandbytes, for cpu is fp32 model
@@ -410,6 +414,7 @@ class TestQuantization(unittest.TestCase):
                                                      load_in_4bit=True,
                                                      use_llm_runtime=False
                                                 )
+        bit4_model.eval()
         output = bit4_model(dummy_input)
         print("output:", float(output[0][0][0][0]))
         self.assertTrue(isclose(float(output[0][0][0][0]), 0.18726778030395508, rel_tol=1e-04))
@@ -420,6 +425,7 @@ class TestQuantization(unittest.TestCase):
                                                      use_llm_runtime=False,
                                                      device_map="cpu"
                                                 )
+        bit8_model.eval()
         output = bit8_model(dummy_input)
         print("output:", float(output[0][0][0][0]))
         self.assertTrue(isclose(float(output[0][0][0][0]), 0.1675747185945511, rel_tol=1e-04))
@@ -441,6 +447,7 @@ class TestQuantization(unittest.TestCase):
                                                     quantization_config=woq_config,
                                                     use_llm_runtime=False
                                                 )
+        woq_model.eval()
         output = woq_model(dummy_input)
         print("output:", float(output[0][0][0][0]))
         self.assertTrue(isclose(float(output[0][0][0][0]), 0.17126554250717163, rel_tol=1e-04))


### PR DESCRIPTION
## Type of Change

I add limitation in the python config.py due to kernel only supports asym in some cases( when enable asym , computer_dtype!=int8,weight-type is int, scale-type is fp32)
update other code to auto get scheme.

Here is the local test results.

rtn facebook/opt-1.3b sym
```
python run_generation.py --model facebook/opt-1.3b --woq --woq_weight_dtype "int4_clip" --woq_scheme "asym" --benchmark --batch_size 1
['Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun.\n\nOnce upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have']
['Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun.\n\nOnce upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have']

python run_generation.py --model facebook/opt-1.3b --woq --woq_weight_dtype "int4_clip" --woq_scheme "asym" --accuracy --batch_size 56
Running loglikelihood requests
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5151/5151 [09:32<00:00,  9.00it/s]
|     Task     |Version|Metric|Value |   |Stderr|
|--------------|------:|------|-----:|---|-----:|
|lambada_openai|      0|ppl   |8.1232|±  |0.2400|
|              |       |acc   |0.5420|±  |0.0069|

Accuracy for lambada_openai is: 0.5420143605666602
```
gptq facebook/opt-125m sym
```
python run_generation.py --model facebook/opt-125m --woq --woq_algo "GPTQ"  --gptq_pad_max_length 128 --gptq_use_max_length --gptq_block_size 16 --woq_weight_dtype "int4_clip" --output_dir "gptqq" --benchmark --batch_size 1
['Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun. She loved to travel. She loved to travel. She loved to travel. She loved to travel. She loved to travel. She loved to travel. She loved']
['Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun. She loved to travel. She loved to travel. She loved to travel. She loved to travel. She loved to travel. She loved to travel. She loved']

python run_generation.py --model facebook/opt-125m --woq --woq_algo "GPTQ" --gptq_pad_max_length 128 --gptq_use_max_length --gptq_block_size 16 --woq_weight_dtype "int4_clip" --output_dir "gptqq" --accuracy --batch_size 56
|     Task     |Version|Metric| Value |   |Stderr|
|--------------|------:|------|------:|---|-----:|
|lambada_openai|      0|ppl   |31.5093|±  |1.1838|
|              |       |acc   | 0.3588|±  |0.0067|

Accuracy for lambada_openai is: 0.35882010479332427
```
gptq facebook/opt-125m asym
```
python run_generation.py --model facebook/opt-125m --woq --woq_algo "GPTQ"  **--woq_algo "asym"** --gptq_pad_max_length 128 --gptq_use_max_length --gptq_block_size 16 --woq_weight_dtype "int4_clip" --output_dir "gptqq" --benchmark --batch_size 1

['Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun. She liked to go to the movies, and she liked to have fun. She liked to go to the beach, and she liked to have fun. She liked']
['Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun. She liked to go to the movies, and she liked to have fun. She liked to go to the beach, and she liked to have fun. She liked']

python run_generation.py --model facebook/opt-125m --woq --woq_algo "GPTQ" **--woq_algo "asym"** --gptq_pad_max_length 128 --gptq_use_max_length --gptq_block_size 16 --woq_weight_dtype "int4_clip" --output_dir "gptqq" --accuracy --batch_size 56
|     Task     |Version|Metric| Value |   |Stderr|
|--------------|------:|------|------:|---|-----:|
|lambada_openai|      0|ppl   |27.0044|±  |0.9937|
|              |       |acc   | 0.3755|±  |0.0067|

Accuracy for lambada_openai is: 0.3755094119930138
```
## Description

detail description 
JIRA ticket: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
