### PR TITLE
resolve woq quantization error when running neuralchat

### DIFF
--- a/intel_extension_for_transformers/neural_chat/models/model_utils.py
+++ b/intel_extension_for_transformers/neural_chat/models/model_utils.py
@@ -1081,6 +1081,7 @@ def predict_stream(**params):
                                 **input_tokens,
                                 **generate_kwargs,
                                 streamer=streamer,
+                                pad_token_id=tokenizer.eos_token_id,
                                 generation_config=generation_config,
                                 return_dict_in_generate=True,
                             )
@@ -1109,6 +1110,7 @@ def predict_stream(**params):
                                     **input_tokens,
                                     **generate_kwargs,
                                     streamer=streamer,
+                                    pad_token_id=tokenizer.eos_token_id,
                                     generation_config=generation_config,
                                     return_dict_in_generate=True,
                                 )
@@ -1149,6 +1151,7 @@ def predict_stream(**params):
                         **input_tokens,
                         **generate_kwargs,
                         streamer=streamer,
+                        pad_token_id=tokenizer.eos_token_id,
                         generation_config=generation_config,
                         return_dict_in_generate=True,
                         output_scores=True,
@@ -1371,6 +1374,7 @@ def predict(**params):
                     generation_output = model.generate(
                             **input_tokens,
                             **generate_kwargs,
+                            pad_token_id=tokenizer.eos_token_id,
                             generation_config=generation_config,
                             return_dict_in_generate=True
                             )
@@ -1395,6 +1399,7 @@ def predict(**params):
                             generation_output = model.generate(
                                 **input_tokens,
                                 **generate_kwargs,
+                                pad_token_id=tokenizer.eos_token_id,
                                 generation_config=generation_config,
                                 return_dict_in_generate=True
                             )
@@ -1427,6 +1432,7 @@ def predict(**params):
                 generation_output = model.generate(
                     **input_tokens,
                     **generate_kwargs,
+                    pad_token_id=tokenizer.eos_token_id,
                     generation_config=generation_config,
                     return_dict_in_generate=True,
                     output_scores=True,

--- a/intel_extension_for_transformers/neural_chat/models/model_utils.py
+++ b/intel_extension_for_transformers/neural_chat/models/model_utils.py
@@ -1063,6 +1063,7 @@ def predict_stream(**params):
             num_beams=num_beams,
             use_cache=use_cache,
             num_return_sequences=num_return_sequences,
+            pad_token_id=tokenizer.eos_token_id
         )
 
         def generate_output():
@@ -1081,7 +1082,6 @@ def predict_stream(**params):
                                 **input_tokens,
                                 **generate_kwargs,
                                 streamer=streamer,
-                                pad_token_id=tokenizer.eos_token_id,
                                 generation_config=generation_config,
                                 return_dict_in_generate=True,
                             )
@@ -1110,7 +1110,6 @@ def predict_stream(**params):
                                     **input_tokens,
                                     **generate_kwargs,
                                     streamer=streamer,
-                                    pad_token_id=tokenizer.eos_token_id,
                                     generation_config=generation_config,
                                     return_dict_in_generate=True,
                                 )
@@ -1151,7 +1150,6 @@ def predict_stream(**params):
                         **input_tokens,
                         **generate_kwargs,
                         streamer=streamer,
-                        pad_token_id=tokenizer.eos_token_id,
                         generation_config=generation_config,
                         return_dict_in_generate=True,
                         output_scores=True,
@@ -1360,6 +1358,7 @@ def predict(**params):
             num_beams=num_beams,
             use_cache=use_cache,
             num_return_sequences=num_return_sequences,
+            pad_token_id=tokenizer.eos_token_id
         )
         dtype = model.dtype if hasattr(model, 'dtype') else torch.bfloat16
         try:
@@ -1374,7 +1373,6 @@ def predict(**params):
                     generation_output = model.generate(
                             **input_tokens,
                             **generate_kwargs,
-                            pad_token_id=tokenizer.eos_token_id,
                             generation_config=generation_config,
                             return_dict_in_generate=True
                             )
@@ -1399,7 +1397,6 @@ def predict(**params):
                             generation_output = model.generate(
                                 **input_tokens,
                                 **generate_kwargs,
-                                pad_token_id=tokenizer.eos_token_id,
                                 generation_config=generation_config,
                                 return_dict_in_generate=True
                             )
@@ -1432,7 +1429,6 @@ def predict(**params):
                 generation_output = model.generate(
                     **input_tokens,
                     **generate_kwargs,
-                    pad_token_id=tokenizer.eos_token_id,
                     generation_config=generation_config,
                     return_dict_in_generate=True,
                     output_scores=True,


### PR DESCRIPTION
## Type of Change

Bug fix

## Description

Resolves: #1267
Error seems to be caused by generation config
https://github.com/huggingface/transformers/issues/25353#issuecomment-1669339754

Setting `pad_token_id=tokenizer.eos_token_id` during the initial definition of `GenerationConfig()` resolves this bug


## Expected Behavior & Potential Risk

Quantized model using neuralchat functions should be able to run properly

## How has this PR been tested?

Run:
```
from intel_extension_for_transformers.neural_chat import build_chatbot, PipelineConfig
from intel_extension_for_transformers.transformers import WeightOnlyQuantConfig
from intel_extension_for_transformers.neural_chat.config import LoadingModelConfig
config = PipelineConfig(model_name_or_path="Intel/neural-chat-7b-v3-1",
                        optimization_config=WeightOnlyQuantConfig(compute_dtype="int8", weight_dtype="int4_fullrange"), 
                        loading_config=LoadingModelConfig(use_llm_runtime=False))
chatbot = build_chatbot(config)
response = chatbot.predict(query="Tell me about Intel Xeon Scalable Processors.")
print(response)
```
SPR:  `Intel(R) Xeon(R) Gold 6438Y+`

## Dependency Change?
N/A
