### PR TITLE
[NeuralChat] Fix IPEX version mismatch with Pytorch issue

### DIFF
--- a/intel_extension_for_transformers/neural_chat/requirements.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements.txt
@@ -6,7 +6,7 @@ fastapi==0.103.2
 fschat==0.2.35
 git+https://github.com/EleutherAI/lm-evaluation-harness.git@cc9778fbe4fa1a709be2abed9deb6180fd40e7e2
 huggingface_hub
-intel_extension_for_pytorch
+intel_extension_for_pytorch==2.1.0
 neural-compressor
 neural_speed
 numpy==1.23.5


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

Fix IPEX version mismatch with Pytorch issue

## Expected Behavior & Potential Risk

ERROR! Intel® Extension for PyTorch* needs to work with PyTorch 2.2.*, but PyTorch 2.1.0+cu121 is found. Please switch to the matching version and run again.

The above issue can be fixed.

## How has this PR been tested?

Local test and pre-CI test.

## Dependency Change?

None.
