### PR TITLE
[NeuralChat] Fix chat history issue

### DIFF
--- a/intel_extension_for_transformers/neural_chat/server/restful/textchat_api.py
+++ b/intel_extension_for_transformers/neural_chat/server/restful/textchat_api.py
@@ -137,6 +137,7 @@ async def get_generation_parameters(
     best_of: Optional[int] = None,
     use_beam_search: Optional[bool] = None,
 ) -> Dict[str, Any]:
+    chatbot.conv_template.clear_messages()
     conv = chatbot.conv_template.conv
 
     if isinstance(messages, str):


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

Fix chat history issue, the chat history should be maintained by users. Users pass down all the chat history in 'messages', so neuralchat doesn't need to record all the chat history.

## Expected Behavior & Potential Risk

The chat history issue can be fixed.

## How has this PR been tested?

Local test and pre-CI test.

## Dependency Change?

None.
