### PR TITLE
WOQ support autoround algo on cpu device

### DIFF
--- a/examples/huggingface/pytorch/code-generation/quantization/requirements.txt
+++ b/examples/huggingface/pytorch/code-generation/quantization/requirements.txt
@@ -12,4 +12,7 @@ neural-compressor
 intel_extension_for_pytorch==2.2.0
 optimum-intel
 git+https://github.com/bigcode-project/bigcode-evaluation-harness@00967d12093ef614de7bdad0772aed8e4118f1fd
+git+https://github.com/intel/auto-round.git@a868c805de4be271cfe7403309a64d9bf03a0ecf
+
+
 

--- a/examples/huggingface/pytorch/code-generation/quantization/run_generation.py
+++ b/examples/huggingface/pytorch/code-generation/quantization/run_generation.py
@@ -68,7 +68,7 @@ parser.add_argument("--woq", action="store_true")
 parser.add_argument(
     "--woq_algo",
     default="RTN",
-    choices=["RTN", "AWQ", "TEQ", "GPTQ"],
+    choices=["RTN", "AWQ", "TEQ", "GPTQ", "AUTOROUND"],
     help="Weight-only parameter.",
 )
 parser.add_argument(
@@ -133,6 +133,18 @@ parser.add_argument(
     help="Calibration dataset sequence max length, this should align with your model config",
 )
 parser.add_argument('--gptq_static_groups', action='store_true', help='Use determined group to do quantization')
+# ============AUTOROUND configs==============
+parser.add_argument(
+    "--autoround_nsamples",
+    type=int, default=128,
+    help="Number of calibration data samples.",
+)
+parser.add_argument(
+    "--autoround_seq_len",
+    type=int,
+    default=2048,
+    help="Calibration dataset sequence max length, this should align with your model config",
+)
 # ============Harness configs============
 parser.add_argument("--tasks", default=None, help="Evaluation tasks")
 parser.add_argument(
@@ -269,6 +281,26 @@ elif args.woq:
             "use_max_length": args.gptq_use_max_length,
             "pad_max_length": args.gptq_pad_max_length,
             "static_groups": args.gptq_static_groups,
+        }
+        quantization_config = WeightOnlyQuantConfig(
+            compute_dtype=args.woq_compute_dtype,
+            scale_dtype=args.woq_scale_dtype,
+            weight_dtype=args.woq_weight_dtype,
+            scheme=args.woq_scheme,
+            group_size=args.woq_group_size,
+            algorithm=args.woq_algo,
+            tokenizer=tokenizer,
+            algorithm_args=algorithm_args,
+            calib_dataset=args.dataset
+        )
+    elif args.woq_algo == "AUTOROUND":
+        algorithm_args = {
+            "n_samples": args.autoround_nsamples,
+            "amp": False,
+            "seq_len": args.autoround_seq_len,
+            "iters": args.calib_iters,
+            "scale_dtype": "fp32",
+            "device": "cpu",
         }
         quantization_config = WeightOnlyQuantConfig(
             compute_dtype=args.woq_compute_dtype,

--- a/examples/huggingface/pytorch/text-generation/quantization/requirements.txt
+++ b/examples/huggingface/pytorch/text-generation/quantization/requirements.txt
@@ -14,3 +14,4 @@ tiktoken  #qwen
 einops  #qwen
 git+https://github.com/intel/neural-compressor.git
 git+https://github.com/EleutherAI/lm-evaluation-harness.git@cc9778fbe4fa1a709be2abed9deb6180fd40e7e2
+git+https://github.com/intel/auto-round.git@a868c805de4be271cfe7403309a64d9bf03a0ecf

--- a/examples/huggingface/pytorch/text-generation/quantization/run_generation.py
+++ b/examples/huggingface/pytorch/text-generation/quantization/run_generation.py
@@ -95,7 +95,7 @@ parser.add_argument("--woq", action="store_true")
 parser.add_argument(
     "--woq_algo",
     default="RTN",
-    choices=["RTN", "AWQ", "TEQ", "GPTQ"],
+    choices=["RTN", "AWQ", "TEQ", "GPTQ", "AUTOROUND"],
     help="Weight-only parameter.",
 )
 parser.add_argument(
@@ -159,6 +159,18 @@ parser.add_argument(
     help="Calibration dataset sequence max length, this should align with your model config",
 )
 parser.add_argument('--gptq_static_groups', action='store_true', help='Use determined group to do quantization')
+# ============AUTOROUND configs==============
+parser.add_argument(
+    "--autoround_nsamples",
+    type=int, default=128,
+    help="Number of calibration data samples.",
+)
+parser.add_argument(
+    "--autoround_seq_len",
+    type=int,
+    default=2048,
+    help="Calibration dataset sequence max length, this should align with your model config",
+)
 # ============BitsAndBytes configs==============
 parser.add_argument("--bitsandbytes", action="store_true")
 # ============AutoModel parameters==============
@@ -291,6 +303,26 @@ elif args.woq:
             algorithm=args.woq_algo,
             tokenizer=tokenizer,
             algorithm_args=algorithm_args,
+        )
+    elif args.woq_algo == "AUTOROUND":
+        algorithm_args = {
+            "n_samples": args.autoround_nsamples,
+            "amp": False,
+            "seq_len": args.autoround_seq_len,
+            "iters": args.calib_iters,
+            "scale_dtype": "fp32",
+            "device": "cpu",
+        }
+        quantization_config = WeightOnlyQuantConfig(
+            compute_dtype=args.woq_compute_dtype,
+            scale_dtype=args.woq_scale_dtype,
+            weight_dtype=args.woq_weight_dtype,
+            scheme=args.woq_scheme,
+            group_size=args.woq_group_size,
+            algorithm=args.woq_algo,
+            tokenizer=tokenizer,
+            algorithm_args=algorithm_args,
+            calib_dataset=args.dataset
         )
     else:
         quantization_config = WeightOnlyQuantConfig(

--- a/intel_extension_for_transformers/llm/quantization/utils.py
+++ b/intel_extension_for_transformers/llm/quantization/utils.py
@@ -173,7 +173,7 @@ def _replace_linear(
                     model._modules[name].requires_grad_(False)
                 if device == "cpu" or device == torch.device("cpu") or device == "auto":
                     if not empty_weights:
-                        if quantization_config.algorithm == "GPTQ":
+                        if quantization_config.algorithm == "GPTQ" or quantization_config.algorithm == "AUTOROUND":
                             from .gptq_utils import unpack_weight
                             int_weight, gptq_scales, gptq_zeros = unpack_weight(
                                 module.qweight,
@@ -237,7 +237,7 @@ def convert_to_quantized_model(model, config, device="cpu"):
     calib_func = config.calib_func
     calib_iters = config.calib_iters
     model_device = next(model.parameters()).device
-    if calib_dataloader is None and config.algorithm in ["TEQ", "AWQ", "GPTQ"]:
+    if calib_dataloader is None and config.algorithm in ["TEQ", "AWQ", "GPTQ", "AUTOROUND"]:
         from datasets import load_dataset
         from torch.utils.data import DataLoader
 
@@ -320,7 +320,8 @@ def convert_to_quantized_model(model, config, device="cpu"):
             },
             "awq_args": config.algorithm_args.update({"enable_mse_search": config.mse_range})
                 if config.algorithm == "AWQ" and config.algorithm_args is not None else {},
-            "gptq_args": config.algorithm_args if config.algorithm == "GPTQ" else None
+            "gptq_args": config.algorithm_args if config.algorithm == "GPTQ" else None,
+            "autoround_args": config.algorithm_args if config.algorithm == "AUTOROUND" else None
         }
         conf = PostTrainingQuantConfig(
             approach="weight_only",
@@ -346,7 +347,7 @@ def convert_to_quantized_model(model, config, device="cpu"):
         )
         # TEQ: set calib_func=None, use default training func as calib_func
         # RTN: doesn't need calib_func
-        if config.algorithm in ["TEQ", "RTN", "GPTQ"]:
+        if config.algorithm in ["TEQ", "RTN", "GPTQ", "AUTOROUND"]:
             calib_func = None
 
         orig_dtype = torch.float32
@@ -360,6 +361,7 @@ def convert_to_quantized_model(model, config, device="cpu"):
                                      conf,
                                      calib_func=calib_func,
                                      calib_dataloader=calib_dataloader)
+
         if device == "xpu" or device == torch.device("xpu"):
             model = inc_model.export_compressed_model(compression_dtype=torch.int8,
                                                       compression_dim=0,
@@ -374,12 +376,26 @@ def convert_to_quantized_model(model, config, device="cpu"):
             if config.algorithm == "GPTQ":
                 inc_model = inc_model.export_compressed_model(use_optimum_format=True)
                 inc_model.eval()
-
                 quantize_config = {
                     "bits": bits,
                     "group_size": config.group_size,
                     "damp_percent": config.algorithm_args["percdamp"],
                     "desc_act": config.algorithm_args["act_order"],
+                    "sym": True if config.scheme == "sym" else False,
+                    "true_sequential": True,
+                    "model_name_or_path": "null",
+                    "model_file_base_name": "model",
+                }
+
+                setattr(config, "gptq_quantize_config", quantize_config)
+                q_model = replace_linear(inc_model, None, None, config, device=device)
+            elif config.algorithm == "AUTOROUND":
+                inc_model = inc_model.export_compressed_model(use_optimum_format=True)
+                inc_model.eval()
+                quantize_config = {
+                    "bits": bits,
+                    "group_size": config.group_size,
+                    "desc_act": False,
                     "sym": True if config.scheme == "sym" else False,
                     "true_sequential": True,
                     "model_name_or_path": "null",

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -26,3 +26,4 @@ transformers==4.36.2
 transformers_stream_generator
 tyro
 wget
+git+https://github.com/intel/auto-round.git@a868c805de4be271cfe7403309a64d9bf03a0ecf

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,6 +5,7 @@ datasets==2.14.7
 einops
 evaluate
 gguf
+git+https://github.com/intel/auto-round.git@a868c805de4be271cfe7403309a64d9bf03a0ecf
 git+https://github.com/intel/neural-compressor.git
 intel-extension-for-pytorch==2.2.0
 intel-tensorflow==2.14.0
@@ -26,4 +27,3 @@ transformers==4.36.2
 transformers_stream_generator
 tyro
 wget
-git+https://github.com/intel/auto-round.git@a868c805de4be271cfe7403309a64d9bf03a0ecf


### PR DESCRIPTION
## Type of Change

```
python run_generation.py --model facebook/opt-125m --woq --woq_algo "AUTOROUND" --woq_weight_dtype "int4_clip" --calib_iters 20 --benchmark --batch_size 1
['Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun. When she was a little girl, she liked to go to the movies. She liked to go to the movies. She liked to go to the movies. She']
['Once upon a time, there existed a little girl, who liked to have adventures. She wanted to go to places and meet new people, and have fun. When she was a little girl, she liked to go to the movies. She liked to go to the movies. She liked to go to the movies. She']
```
```
python run_generation.py --model facebook/opt-125m --woq --woq_algo "AUTOROUND" --woq_weight_dtype "int4_clip" --calib_iters 20 --accuracy --batch_size 56

two, maybe three, miles away,” Tom said and smiled at', ' Carlos')[0]
, Req_loglikelihood('“Carlos Rafael Wilson.”\nThe man smiled at him. Carlos didn’t have a clue what was going on. He looked to his manager.\n“Tom here’s just moved into the house at the bottom of the hill.”\n“Oh right.”\n“About two, maybe three, miles away,” Tom said and smiled at', ' Carlos')[1]
)
Running loglikelihood requests
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5151/5151 [00:47<00:00, 108.50it/s]
|     Task     |Version|Metric| Value |   |Stderr|
|--------------|------:|------|------:|---|-----:|
|lambada_openai|      0|ppl   |42.2816|±  |1.5480|
|              |       |acc   | 0.2971|±  |0.0064|

Accuracy for lambada_openai is: 0.297108480496798
```
## Description

detail description 
JIRA ticket: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
