### PR TITLE
Fix clm model with transformers 4.38.1

### DIFF
--- a/examples/huggingface/pytorch/language-modeling/quantization/requirements.txt
+++ b/examples/huggingface/pytorch/language-modeling/quantization/requirements.txt
@@ -8,6 +8,6 @@ pytest
 wandb
 einops
 neural-compressor
-pytest==8.0.1
+pytest==8.0.0
 git+https://github.com/EleutherAI/lm-evaluation-harness.git@83dbfbf6070324f3e5872f63e49d49ff7ef4c9b3
 git+https://github.com/huggingface/peft.git@6c44096c7b8d55a2ecf24be9bc68393467e1584a

--- a/examples/huggingface/pytorch/language-modeling/quantization/requirements.txt
+++ b/examples/huggingface/pytorch/language-modeling/quantization/requirements.txt
@@ -8,5 +8,6 @@ pytest
 wandb
 einops
 neural-compressor
+pytest==0.8.1
 git+https://github.com/EleutherAI/lm-evaluation-harness.git@83dbfbf6070324f3e5872f63e49d49ff7ef4c9b3
 git+https://github.com/huggingface/peft.git@6c44096c7b8d55a2ecf24be9bc68393467e1584a

--- a/examples/huggingface/pytorch/language-modeling/quantization/requirements.txt
+++ b/examples/huggingface/pytorch/language-modeling/quantization/requirements.txt
@@ -8,6 +8,6 @@ pytest
 wandb
 einops
 neural-compressor
-pytest==0.8.1
+pytest==8.0.1
 git+https://github.com/EleutherAI/lm-evaluation-harness.git@83dbfbf6070324f3e5872f63e49d49ff7ef4c9b3
 git+https://github.com/huggingface/peft.git@6c44096c7b8d55a2ecf24be9bc68393467e1584a


### PR DESCRIPTION
## Type of Change

ticket https://jira.devtools.intel.com/browse/NLPTOOLKIU-1241
transformers requests pytest 8.0.0 but lm-eval will auto request the latest 8.0.2 pytest to install, so fix the pytest version.
if transformers upgrades, we can try to remove the pytest version limit.


## Description

 the latest version of pytest (>= 8.0.1) have finally deprecated including import_path from _pytest.doctest to _pytest.pathlib, so this import path needs to be updated.
detail description 
JIRA ticket: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
