### PR TITLE
[NeuralChat] Fix finetuning unit test issue

### DIFF
--- a/intel_extension_for_transformers/neural_chat/cli/cli_commands.py
+++ b/intel_extension_for_transformers/neural_chat/cli/cli_commands.py
@@ -228,7 +228,7 @@ class FinetuingExecutor(BaseCommandExecutor):
         self.parser.add_argument(
             '--train_file', type=str, default=None, help='Specify train file path.')
         self.parser.add_argument(
-            '--max_steps', type=str, default=None, help='Specify max steps of finetuning.')
+            '--max_steps', type=int, default=None, help='Specify max steps of finetuning.')
 
     def execute(self, argv: List[str]) -> bool:
         """


### PR DESCRIPTION
## Type of Change

bug fix
API not changed

## Description

Fix finetuning unit test issue

2024-03-12 16:06:20,905 - intel_extension_for_transformers.llm.finetuning.finetuning - INFO - Using data collator of type DataCollatorForSeq2Seq
trainable params: 294,912 || all params: 125,534,208 || trainable%: 0.23492560689115113
2024-03-12 16:06:20,922 - root - ERROR - Exception: '>' not supported between instances of 'str' and 'int'
2024-03-12 16:06:20 [ERROR] neuralchat error: LORA finetuning failed

## Expected Behavior & Potential Risk

The finetuning unit test case will not raise any error.

## How has this PR been tested?

Local test and pre-CI test.

## Dependency Change?

None.
