### PR TITLE
[Neural Speed] Add the model_type list for GPTQ

### DIFF
--- a/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
+++ b/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
@@ -372,7 +372,8 @@ class _BaseQBitsAutoModelClass:
                 exit(0)
 
             if config.model_type in cls.model_type_list and not use_xpu:
-                if isinstance(quantization_config, GPTQConfig) and config.model_type not in cls.model_type_list_for_gptq:
+                if isinstance(quantization_config,
+                              GPTQConfig) and config.model_type not in cls.model_type_list_for_gptq:
                     use_neural_speed = False
                 else:
                     use_neural_speed = True

--- a/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
+++ b/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
@@ -270,6 +270,19 @@ class _BaseQBitsAutoModelClass:
         "whisper",
     ]
 
+    model_type_list_for_gptq = [
+        "llama",
+        "gptj",
+        "mpt",
+        "falcon",
+        "chatglm2",
+        "chatglm",
+        "baichuan",
+        "mistral",
+        "qwen",
+        "phi",
+    ]
+
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, *model_args, **kwargs):
         # use for neuralspeed gguf
@@ -343,6 +356,7 @@ class _BaseQBitsAutoModelClass:
                 **kwargs,
             )
 
+        quantization_config = kwargs.pop("quantization_config", None)
         if kwargs.get("use_llm_runtime", None) is not None:
             use_neural_speed = kwargs.pop("use_llm_runtime", True) and not use_xpu
             logger.warning(
@@ -358,7 +372,10 @@ class _BaseQBitsAutoModelClass:
                 exit(0)
 
             if config.model_type in cls.model_type_list and not use_xpu:
-                use_neural_speed = True
+                if isinstance(quantization_config, GPTQConfig) and config.model_type not in cls.model_type_list_for_gptq:
+                    use_neural_speed = False
+                else:
+                    use_neural_speed = True
             else:
                 use_neural_speed = False
 
@@ -400,7 +417,6 @@ class _BaseQBitsAutoModelClass:
 
         load_in_8bit = kwargs.pop("load_in_8bit", False)
         load_in_4bit = kwargs.pop("load_in_4bit", False)
-        quantization_config = kwargs.pop("quantization_config", None)
 
         if isinstance(quantization_config, BitsAndBytesConfig):
             model = cls.ORIG_MODEL.from_pretrained(


### PR DESCRIPTION
## Type of Change

New feature.

## Description

Add the model_type list for GPTQ

## Expected Behavior & Potential Risk

N/A

## How has this PR been tested?

```python
from transformers import AutoTokenizer
from intel_extension_for_transformers.transformers import AutoModelForCausalLM, GPTQConfig

# Download Hugging Face GPTQ/AWQ model or use local quantize model
model_name = "/home/zhenzhong/model/Llama-2-7B-Chat-GPTQ"  # local path to model
woq_config = GPTQConfig(bits=4)   # use AwqConfig for AWQ models, and AutoRoundConfig for AutoRound models
prompt = "Once upon a time, a little girl"
tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
inputs = tokenizer(prompt, return_tensors="pt").input_ids
model = AutoModelForCausalLM.from_pretrained(model_name, quantization_config=woq_config, trust_remote_code=True)
outputs = model.generate(inputs)

print(tokenizer.decode(outputs[0]))
```

![image](https://github.com/intel/intel-extension-for-transformers/assets/109137058/8e0bd281-5886-4e41-8420-b25e035c965a)

## Dependency Change?

N/A
