### PR TITLE
support qwen and baichuan with neuralchat ns=False

### DIFF
--- a/intel_extension_for_transformers/neural_chat/chatbot.py
+++ b/intel_extension_for_transformers/neural_chat/chatbot.py
@@ -169,6 +169,7 @@ def build_chatbot(config: PipelineConfig=None):
             "magicoder" in config.model_name_or_path.lower() or \
             "mixtral" in config.model_name_or_path.lower() or \
             "phi-2" in config.model_name_or_path.lower() or \
+            "qwen" in config.model_name_or_path.lower() or \
             "sqlcoder" in config.model_name_or_path.lower():
             from .models.base_model import BaseModel
             adapter = BaseModel(config.model_name_or_path, config.task)

--- a/intel_extension_for_transformers/neural_chat/chatbot.py
+++ b/intel_extension_for_transformers/neural_chat/chatbot.py
@@ -169,7 +169,7 @@ def build_chatbot(config: PipelineConfig=None):
             "magicoder" in config.model_name_or_path.lower() or \
             "mixtral" in config.model_name_or_path.lower() or \
             "phi-2" in config.model_name_or_path.lower() or \
-            "qwen" in config.model_name_or_path.lower() or \
+            "baichuan" in config.model_name_or_path.lower() or \
             "sqlcoder" in config.model_name_or_path.lower():
             from .models.base_model import BaseModel
             adapter = BaseModel(config.model_name_or_path, config.task)

--- a/intel_extension_for_transformers/neural_chat/models/model_utils.py
+++ b/intel_extension_for_transformers/neural_chat/models/model_utils.py
@@ -578,6 +578,12 @@ def load_model(
                 tokenizer.padding_side = "left"
         if tokenizer.pad_token is None and tokenizer.pad_token_id is None:
             tokenizer.pad_token = tokenizer.eos_token
+        if re.search("qwen", model.config.architectures[0], re.IGNORECASE):
+            tokenizer.pad_token = '<|extra_0|>'
+            model.config.pad_token_id = tokenizer.pad_token_id
+            model.generation_config.pad_token_id = tokenizer.pad_token_id
+            from .qwen_model import prepare_inputs_for_generation
+            model.prepare_inputs_for_generation = prepare_inputs_for_generation
         MODELS[model_name]["model"] = model
         MODELS[model_name]["tokenizer"] = tokenizer
         logging.info("Optimized Model loaded.")

--- a/intel_extension_for_transformers/neural_chat/models/model_utils.py
+++ b/intel_extension_for_transformers/neural_chat/models/model_utils.py
@@ -514,6 +514,7 @@ def load_model(
         else:
             config = AutoConfig.from_pretrained(model_name, use_auth_token=hf_access_token, trust_remote_code=True \
                                                 if (re.search("chatglm", model_name, re.IGNORECASE) or \
+                                                re.search("baichuan", model_name, re.IGNORECASE) or \
                                                 re.search("qwen", model_name, re.IGNORECASE) or \
                                                 re.search("deci", model_name, re.IGNORECASE)) else False)
     except ValueError as e:
@@ -548,6 +549,7 @@ def load_model(
                     or re.search("neural-chat-7b-v2", model_name, re.IGNORECASE)) else True,
                 use_auth_token=hf_access_token,
                 trust_remote_code=True if (re.search("qwen", model_name, re.IGNORECASE) or \
+                        re.search("baichuan", model_name, re.IGNORECASE) or \
                     re.search("chatglm", model_name, re.IGNORECASE) or gguf_model_path) else False,
             )
     except EnvironmentError as e:

--- a/intel_extension_for_transformers/transformers/llm/quantization/optimization.py
+++ b/intel_extension_for_transformers/transformers/llm/quantization/optimization.py
@@ -64,7 +64,7 @@ class Optimization:
             or re.search("magicoder", model_name, re.IGNORECASE)
             or re.search("solar", model_name, re.IGNORECASE)
             or re.search("qwen", model_name, re.IGNORECASE)
-            ot re.search("baichuan", model_name, re.IGNORECASE)
+            or re.search("baichuan", model_name, re.IGNORECASE)
         ):
             from intel_extension_for_transformers.transformers import AutoModelForCausalLM
             optimized_model = AutoModelForCausalLM.from_pretrained(

--- a/intel_extension_for_transformers/transformers/llm/quantization/optimization.py
+++ b/intel_extension_for_transformers/transformers/llm/quantization/optimization.py
@@ -63,6 +63,8 @@ class Optimization:
             or re.search("mistral", model_name, re.IGNORECASE)
             or re.search("magicoder", model_name, re.IGNORECASE)
             or re.search("solar", model_name, re.IGNORECASE)
+            or re.search("qwen", model_name, re.IGNORECASE)
+            ot re.search("baichuan", model_name, re.IGNORECASE)
         ):
             from intel_extension_for_transformers.transformers import AutoModelForCausalLM
             optimized_model = AutoModelForCausalLM.from_pretrained(


### PR DESCRIPTION
## Type of Change

support hackathon

## Description

detail description 
JIRA ticket: xxx
```
# Build chatbot with INT4 weight-only quantization, computations in AMX INT8
from intel_extension_for_transformers.neural_chat import build_chatbot, PipelineConfig
from intel_extension_for_transformers.transformers import RtnConfig
from intel_extension_for_transformers.neural_chat.config import LoadingModelConfig
config = PipelineConfig(model_name_or_path="baichuan-inc/Baichuan2-7B-Chat",
                        optimization_config=RtnConfig(bits=4, compute_dtype="int8", weight_dtype="int4_fullrange"),
                        loading_config=LoadingModelConfig(use_neural_speed=False))
chatbot = build_chatbot(config)

# Perform inference/generate a response
response = chatbot.predict(query="Tell me about Intel Xeon Scalable Processors.")
print(response)
```
offline validation pass.
## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
