### PR TITLE
[Transformers] Refine Model `from_pretrained` When `use_neural_speed`

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,14 +237,13 @@ You can also load the low-bit model quantized by GPTQ/AWQ/RTN/AutoRound algorith
 from transformers import AutoTokenizer
 from intel_extension_for_transformers.transformers import AutoModelForCausalLM, GPTQConfig
 
-# Download Hugging Face GPTQ/AWQ model or use local quantize model
-model_name = "PATH_TO_MODEL"  # local path to model
-woq_config = GPTQConfig(bits=4)   # use AwqConfig for AWQ models, and AutoRoundConfig for AutoRound models
+# Hugging Face GPTQ/AWQ model or use local quantize model
+model_name = "MODEL_NAME_OR_PATH"
 prompt = "Once upon a time, a little girl"
 
 tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
 inputs = tokenizer(prompt, return_tensors="pt").input_ids
-model = AutoModelForCausalLM.from_pretrained(model_name, quantization_config=woq_config, trust_remote_code=True) 
+model = AutoModelForCausalLM.from_pretrained(model_name, trust_remote_code=True)
 outputs = model.generate(inputs)
 ```
 

--- a/examples/huggingface/pytorch/text-generation/quantization/run_generation.py
+++ b/examples/huggingface/pytorch/text-generation/quantization/run_generation.py
@@ -540,19 +540,12 @@ if args.accuracy:
                   else user_model)
     args.model = (peft_config.base_model_name_or_path if args.peft_model_id else args.model)
     from intel_extension_for_transformers.transformers.llm.evaluation.lm_eval import evaluate
-    pretrained = ',pretrained=' + args.model
+    pretrained = ',pretrained=' + args.output_dir if args.woq_loading else ',pretrained=' + args.model
     args._commit_hash = "main" if args._commit_hash is None else args._commit_hash
     eval_args = "tokenizer=" + args.model + ",dtype=float32" + ",_commit_hash=" + \
                 args._commit_hash + ",trust_remote_code=" + str(args.trust_remote_code)
     if args.use_neural_speed:
         eval_args += pretrained
-        q_conf = user_model.config.quantization_config
-        if isinstance(q_conf, dict):
-            q_algo = q_conf.get("quant_method", None)
-        else:
-            q_algo = q_conf.quant_method.value
-        if q_algo.upper() in ["AWQ", "GPTQ", "AUTOROUND"]:
-            eval_args += ",use_gptq=True"
     results = evaluate(
         model="hf-causal",
         model_args=eval_args,

--- a/intel_extension_for_transformers/transformers/llm/evaluation/lm_eval/models/huggingface.py
+++ b/intel_extension_for_transformers/transformers/llm/evaluation/lm_eval/models/huggingface.py
@@ -620,18 +620,13 @@ class AutoCausalLM(HuggingFaceAutoLM):
         self.model_format = model_format
         if self.model_format == "neural_speed":
             from intel_extension_for_transformers.transformers import RtnConfig, AwqConfig, GPTQConfig, AutoRoundConfig
-            use_gptq = kwargs.pop("use_gptq", False)
-            if use_gptq:
-                self.woq_config = GPTQConfig(bits=4, compute_dtype="int8", weight_dtype="int4")
-            else:
-                self.woq_config = RtnConfig(bits=4, compute_dtype="int8", weight_dtype="int4")
         super().__init__(*args, pretrained=pretrained, model_format=model_format, **kwargs)
 
         if self.model_format == "neural_speed":
             from transformers import AutoTokenizer, TextStreamer
             from intel_extension_for_transformers.transformers import AutoModelForCausalLM
-            self.runtime_model = AutoModelForCausalLM.from_pretrained(pretrained, quantization_config=self.woq_config,
-                                        use_neural_speed=True, trust_remote_code=kwargs.get("trust_remote_code", False))
+            self.runtime_model = AutoModelForCausalLM.from_pretrained(pretrained, use_neural_speed=True,
+                                trust_remote_code=kwargs.get("trust_remote_code", False))
 
         if self.model_format == "onnx":
             if not os.path.exists(os.path.join(pretrained, "decoder_model.onnx")) and \

--- a/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
+++ b/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
@@ -422,26 +422,27 @@ class _BaseQBitsAutoModelClass:
                     quantization_config = ConfigInit[quantization_config["quant_method"]].from_dict(quantization_config)
                     logger.info("Loading Low Bits model by Neural Speed.")
                     quantization_config.post_init_runtime()
-                    from neural_speed import Model
 
-                    model = Model()
-                    model.init( # pylint: disable=E1123
-                        pretrained_model_name_or_path,
-                        weight_dtype=quantization_config.weight_dtype,
-                        alg=quantization_config.scheme,
-                        group_size=quantization_config.group_size,
-                        scale_dtype=quantization_config.scale_dtype,
-                        compute_dtype=quantization_config.compute_dtype,
-                        use_ggml=quantization_config.use_ggml,
-                        use_quant=True,
-                        use_gptq=quantization_config.quant_method.value == "gptq"
-                        or quantization_config.quant_method.value == "autoround"
-                        or quantization_config.quant_method.value == "rtn",
-                        use_awq=quantization_config.quant_method.value == "awq",
-                        model_hub=model_hub,
-                    )
-                    model.quantization_config = quantization_config
-                    return model
+                from neural_speed import Model
+
+                model = Model()
+                model.init( # pylint: disable=E1123
+                    pretrained_model_name_or_path,
+                    weight_dtype=quantization_config.weight_dtype,
+                    alg=quantization_config.scheme,
+                    group_size=quantization_config.group_size,
+                    scale_dtype=quantization_config.scale_dtype,
+                    compute_dtype=quantization_config.compute_dtype,
+                    use_ggml=quantization_config.use_ggml,
+                    use_quant=True,
+                    use_gptq=quantization_config.quant_method.value == "gptq"
+                    or quantization_config.quant_method.value == "autoround"
+                    or quantization_config.quant_method.value == "rtn",
+                    use_awq=quantization_config.quant_method.value == "awq",
+                    model_hub=model_hub,
+                )
+                model.quantization_config = quantization_config
+                return model
             else:
                 logger.info(
                     "quantization_config: {}".format(config.quantization_config)

--- a/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
+++ b/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
@@ -435,9 +435,9 @@ class _BaseQBitsAutoModelClass:
                         use_ggml=quantization_config.use_ggml,
                         use_quant=True,
                         use_gptq=quantization_config.quant_method.value == "gptq"
-                        or quantization_config.quant_method.value == "autoround",
-                        use_awq=quantization_config.quant_method.value == "awq"
+                        or quantization_config.quant_method.value == "autoround"
                         or quantization_config.quant_method.value == "rtn",
+                        use_awq=quantization_config.quant_method.value == "awq",
                         model_hub=model_hub,
                     )
                     model.quantization_config = quantization_config

--- a/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
+++ b/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
@@ -358,6 +358,7 @@ class _BaseQBitsAutoModelClass:
         config = kwargs.pop("config", None)
         model_hub = kwargs.pop("model_hub", "huggingface")
 
+        quantization_config = kwargs.pop("quantization_config", None)
         if not isinstance(config, PretrainedConfig):
             if model_hub == "modelscope":
                 import modelscope # pylint: disable=E0401
@@ -371,7 +372,6 @@ class _BaseQBitsAutoModelClass:
 
                 )
 
-        quantization_config = kwargs.pop("quantization_config", None)
         if kwargs.get("use_llm_runtime", None) is not None:
             use_neural_speed = kwargs.pop("use_llm_runtime", True) and not use_xpu
             logger.warning(

--- a/tests/Nightly/test_llm_runtime.py
+++ b/tests/Nightly/test_llm_runtime.py
@@ -53,8 +53,7 @@ class TestLLMRUNTIME(unittest.TestCase):
         print(tokenizer.decode(pt_generate_ids))
 
         # check output ids
-        woq_config = RtnConfig(use_quant=False)
-        itrex_model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, use_neural_speed=True, trust_remote_code=True)
+        itrex_model = AutoModel.from_pretrained(model_name, quantization_config=None, use_neural_speed=True, trust_remote_code=True)
         itrex_generate_ids = itrex_model.generate(inputs.input_ids, do_sample=False, max_new_tokens=100)[0]
         print(tokenizer.decode(itrex_generate_ids))
         for i in range(len(pt_generate_ids)):

--- a/tests/Nightly/test_neural_speed.py
+++ b/tests/Nightly/test_neural_speed.py
@@ -59,8 +59,7 @@ class TestLLMRUNTIME(unittest.TestCase):
         print(tokenizer.decode(pt_generate_ids))
 
         # check output ids
-        woq_config = RtnConfig(use_quant=False)
-        itrex_model = AutoModel.from_pretrained(model_name, quantization_config=woq_config, use_neural_speed=True, trust_remote_code=True)
+        itrex_model = AutoModel.from_pretrained(model_name, quantization_config=None, use_neural_speed=True, trust_remote_code=True)
         itrex_generate_ids = itrex_model.generate(inputs.input_ids, do_sample=False, max_new_tokens=100)[0]
         print(tokenizer.decode(itrex_generate_ids))
         for i in range(len(pt_generate_ids)):
@@ -68,7 +67,7 @@ class TestLLMRUNTIME(unittest.TestCase):
 
         # check diff of logits
         woq_configs = {
-            "fp32": RtnConfig(use_quant=False),
+            "fp32": None,
             # "ggml_int4": RtnConfig(compute_dtype="int8", weight_dtype="int4",use_ggml=True),
             "jblas_int4": RtnConfig(bits=8, compute_dtype="int8", weight_dtype="int4"),
             # "jblas_int8": RtnConfig(compute_dtype="bf16", weight_dtype="int8"),
@@ -118,9 +117,8 @@ class TestLLMRUNTIME(unittest.TestCase):
         pt_generate_ids = torch.load("/tf_dataset2/inc-ut/nlptoolkit_ut_model/beam_pt_generate_ids.pth").tolist()
 
         # llm runtime fp32
-        woq_config = RtnConfig(use_quant=False)
         itrex_model = AutoModelForCausalLM.from_pretrained(
-            model_name, quantization_config=woq_config, trust_remote_code=True)
+            model_name, quantization_config=None, trust_remote_code=True)
         itrex_generate_ids = itrex_model.generate(
             inputs.input_ids, num_beams=4, max_new_tokens=128, min_new_tokens=30, early_stopping=True, pad_token=pad_token)
         for i in range(len(itrex_generate_ids)):


### PR DESCRIPTION
## Type of Change

feature or bug fix or documentation or others
API changed or not

## Description

detail description 
JIRA ticket: xxx
- fp32 model in, fp32 dtype inference
   ```python
   itrex_model = AutoModelForCausalLM.from_pretrained(model_name, quantization_config=None, use_neural_speed=True, 
                              trust_remote_code=True)
   itrex_generate_ids = itrex_model.generate(inputs.input_ids, do_sample=False, max_new_tokens=100)[0]
   ```
- fp32 model in, low-bits dtype inference
  ```python
  woq_config=RtnConfig(compute_dtype="int8", weight_dtype="int4", group_size=128)
  itrex_model = AutoModelForCausalLM.from_pretrained(model_name, quantization_config=woq_config, use_neural_speed=True,  
   trust_remote_code=True)
  itrex_generate_ids = itrex_model.generate(inputs.input_ids, do_sample=False, max_new_tokens=100)[0]
  ```
- low-bits model in, low-bits dtype inference
  ```python
  model_name = "Intel/Mistral-7B-v0.1-int4-inc"
  itrex_model = AutoModelForCausalLM.from_pretrained(model_name, quantization_config=None, use_neural_speed=True, 
    trust_remote_code=True)
  itrex_generate_ids = itrex_model.generate(inputs.input_ids, do_sample=False, max_new_tokens=100)[0]
  ```

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
