### PR TITLE
Removed fallback for lm_head op

### DIFF
--- a/intel_extension_for_transformers/transformers/llm/quantization/utils.py
+++ b/intel_extension_for_transformers/transformers/llm/quantization/utils.py
@@ -108,10 +108,6 @@ def replace_linear(
     device="cpu",
     empty_weights=False,
 ):
-    if modules_to_not_convert is None:
-        # output_layer is chatglm last layer name
-        # embed_out is dolly_v2 last layer name
-        modules_to_not_convert = ["lm_head", "output_layer", "embed_out"]
     if quantization_config.llm_int8_skip_modules:
         modules_to_not_convert = modules_to_not_convert.extend(
             quantization_config.llm_int8_skip_modules
@@ -515,17 +511,6 @@ def convert_to_quantized_model(model, config, device="cpu"):
                         "scheme": config.scheme,
                         "algorithm": algorithm,
                     },
-                },
-            },
-            op_name_dict={
-                ".*lm_head": {  # re.match
-                    "weight": {"dtype": "fp32"},
-                },
-                ".*output_layer": {  # re.match
-                    "weight": {"dtype": "fp32"},
-                },
-                ".*embed_out": {  # re.match
-                    "weight": {"dtype": "fp32"},
                 },
             },
             recipes=recipes,


### PR DESCRIPTION
## Type of Change

feature
No API changed

## Description

Removed fallback of lm_head op for WOQ

## Expected Behavior & Potential Risk

Don't fallback lm_head when weight-only quantization.

## How has this PR been tested?

Local tested

