### PR TITLE
Add scale and weight dtype check for quantization config

### DIFF
--- a/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
+++ b/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
@@ -1742,7 +1742,7 @@ class _BaseQBitsAutoModelClass:
         if quantization_config.scale_dtype is None:
             quantization_config.scale_dtype = "fp32"
         if quantization_config.scale_dtype not in ["fp32", "fp16", "bf16"]:
-            logger.warning("scale_dtype only support fp32, bf16, fp16.")
+            logger.warning("scale_dtype only supports fp32, bf16, fp16.")
             quantization_config.scale_dtype = "fp32"
             logger.warning("fp32 scale_dtype is used, please change the config.json if you don't want to use it.")
 
@@ -1761,7 +1761,7 @@ class _BaseQBitsAutoModelClass:
                         quantization_config.weight_dtype)
                     )
             else:
-                logger.warning("bits number only support 4, 8.")
+                logger.warning("bits number only supports 4, 8.")
                 quantization_config.weight_dtype = "int4_clip"
                 logger.warning(
                     "int4_clip weight_dtype is used, please change the config.json if you don't want to use it.")

--- a/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
+++ b/intel_extension_for_transformers/transformers/modeling/modeling_auto.py
@@ -1738,8 +1738,13 @@ class _BaseQBitsAutoModelClass:
             if ((not CpuInfo().bf16 and quantization_config.compute_dtype == "bf16")
                     or (use_cpu and quantization_config.compute_dtype == "fp16")):
                 quantization_config.compute_dtype = "fp32"
+
         if quantization_config.scale_dtype is None:
             quantization_config.scale_dtype = "fp32"
+        if quantization_config.scale_dtype not in ["fp32", "fp16", "bf16"]:
+            logger.warning("scale_dtype only support fp32, bf16, fp16.")
+            quantization_config.scale_dtype = "fp32"
+            logger.warning("fp32 scale_dtype is used, please change the config.json if you don't want to use it.")
         if quantization_config.weight_dtype is None:
             quantization_config.weight_dtype = "int4_clip"
 


### PR DESCRIPTION
## Type of Change

bug fix:
add scale dtype and weight dtype check for quantization config when loading.
no API changed 

## Description
scale dtype: we only support [fp32, bf16, fp16], if the scale_dtype doesn't in the support list, we will report the warning log and then use the fp32 as the default scale_dtype.
weight dtype: when bits and weight dtype both in config.json, we higher priority to choice weight_dtype as inference weight datatype.

detail description 
JIRA ticket: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
