### PR TITLE
adapt autoround release

### DIFF
--- a/examples/huggingface/pytorch/code-generation/quantization/requirements.txt
+++ b/examples/huggingface/pytorch/code-generation/quantization/requirements.txt
@@ -11,5 +11,5 @@ tiktoken #code_gen
 neural-compressor
 intel_extension_for_pytorch==2.3.0
 optimum-intel
-auto-round
+git+https://github.com/intel/auto-round.git@ecca5349981044e1278773a251b3fc5c0a11fe7b
 git+https://github.com/bigcode-project/bigcode-evaluation-harness@094c7cc197d13a53c19303865e2056f1c7488ac1

--- a/examples/huggingface/pytorch/text-generation/quantization/requirements_GPU.txt
+++ b/examples/huggingface/pytorch/text-generation/quantization/requirements_GPU.txt
@@ -12,6 +12,6 @@ bitsandbytes  #baichuan
 transformers_stream_generator
 tiktoken  #qwen
 einops  #qwen
-auto-round
+git+https://github.com/intel/auto-round.git@ecca5349981044e1278773a251b3fc5c0a11fe7b
 git+https://github.com/intel/neural-compressor.git
 lm-eval==0.4.2

--- a/examples/huggingface/pytorch/text-generation/quantization/requirements_cpu_woq.txt
+++ b/examples/huggingface/pytorch/text-generation/quantization/requirements_cpu_woq.txt
@@ -11,7 +11,7 @@ transformers_stream_generator
 tiktoken  #qwen
 einops  #qwen
 git+https://github.com/intel/neural-speed.git
-auto-round
+git+https://github.com/intel/auto-round.git@ecca5349981044e1278773a251b3fc5c0a11fe7b
 git+https://github.com/intel/neural-compressor.git
 lm-eval==0.4.2
 huggingface_hub

--- a/examples/huggingface/pytorch/text-generation/quantization/requirements_sq.txt
+++ b/examples/huggingface/pytorch/text-generation/quantization/requirements_sq.txt
@@ -13,7 +13,6 @@ bitsandbytes  #baichuan
 transformers_stream_generator
 tiktoken  #qwen
 einops  #qwen
-auto-round
 git+https://github.com/intel/neural-compressor.git
 lm-eval==0.4.2
 huggingface_hub

--- a/examples/huggingface/pytorch/text-generation/quantization/run_generation_cpu_woq.py
+++ b/examples/huggingface/pytorch/text-generation/quantization/run_generation_cpu_woq.py
@@ -392,9 +392,7 @@ if args.accuracy:
     if args.use_neural_speed:
         model_args += ",model_format=neural_speed"
     args = LMEvalParser(model = "hf", 
-                        model_args=model_args,
-                        #user_model=user_model,
-                        #tokenizer=tokenizer,
+                        model_args = model_args,
                         tasks = args.tasks,
                         device = "cpu",
                         batch_size = args.batch_size)

--- a/examples/huggingface/pytorch/text-generation/quantization/run_generation_cpu_woq.py
+++ b/examples/huggingface/pytorch/text-generation/quantization/run_generation_cpu_woq.py
@@ -149,7 +149,7 @@ parser.add_argument(
     help="minmax learning rate, if None,it will beset to be the same with lr",
 )
 parser.add_argument(
-    "--use_quant_input",
+    "--enable_quanted_input",
     action="store_true",
     help="whether to use the output of quantized block to tune the next block",
 )

--- a/examples/huggingface/pytorch/text-generation/quantization/run_generation_cpu_woq.py
+++ b/examples/huggingface/pytorch/text-generation/quantization/run_generation_cpu_woq.py
@@ -280,7 +280,7 @@ if args.woq:
             calib_len=args.calib_len,
             lr=args.lr,
             minmax_lr=args.minmax_lr,
-            use_quant_input=args.use_quant_input,
+            enable_quanted_input=args.enable_quanted_input,
             use_ipex=args.use_ipex,
         )
     else:

--- a/examples/huggingface/pytorch/text-generation/quantization/run_generation_cpu_woq.py
+++ b/examples/huggingface/pytorch/text-generation/quantization/run_generation_cpu_woq.py
@@ -276,7 +276,7 @@ if args.woq:
             compute_dtype=args.compute_dtype,
             scale_dtype=args.scale_dtype,
             weight_dtype=args.weight_dtype,
-            calib_iters=args.calib_iters,
+            iters=args.calib_iters,
             calib_len=args.calib_len,
             lr=args.lr,
             minmax_lr=args.minmax_lr,

--- a/intel_extension_for_transformers/transformers/llm/quantization/nn/modules.py
+++ b/intel_extension_for_transformers/transformers/llm/quantization/nn/modules.py
@@ -139,7 +139,7 @@ class QuantizedLinearQBits(torch.nn.Linear):
         shape = list(x.size())
         m = reduce(mul, shape[0:-1])
         out = torch.zeros(m, self.out_features, dtype=x.dtype)
-        bias = None if self.bias is None else self.bias.data
+        bias = None if self.bias is None else self.bias.data.float()
         if not x.is_contiguous():
             x = x.contiguous()
         out = matmul_kbit(

--- a/intel_extension_for_transformers/transformers/llm/quantization/utils.py
+++ b/intel_extension_for_transformers/transformers/llm/quantization/utils.py
@@ -389,7 +389,7 @@ def convert_to_quantized_model(model, config, device="cpu"):
 
     if config.quant_method.value == "autoround":
         from neural_compressor.adaptor.torch_utils.auto_round import get_dataloader
-        calib_dataloader = get_dataloader(config.tokenizer,
+        calib_dataloader = get_dataloader(config.tokenizer,  # pylint: disable=E1123
                                     seqlen=config.calib_len,
                                     dataset_name=config.dataset,
                                     seed=42,

--- a/intel_extension_for_transformers/transformers/llm/quantization/utils.py
+++ b/intel_extension_for_transformers/transformers/llm/quantization/utils.py
@@ -524,7 +524,7 @@ def convert_to_quantized_model(model, config, device="cpu"):
                 "autoround_args": {
                     "n_samples": config.nsamples,
                     "seqlen": config.calib_len,
-                    "iters": config.calib_iters,
+                    "iters": config.iters,
                     "scale_dtype": config.scale_dtype,
                     "enable_quanted_input": config.enable_quanted_input,
                     "lr": config.lr,

--- a/intel_extension_for_transformers/transformers/llm/quantization/utils.py
+++ b/intel_extension_for_transformers/transformers/llm/quantization/utils.py
@@ -388,9 +388,9 @@ def convert_to_quantized_model(model, config, device="cpu"):
     model_device = next(model.parameters()).device
 
     if config.quant_method.value == "autoround":
-        from neural_compressor.adaptor.torch_utils.auto_round import get_dataloader
+        from auto_round.calib_dataset import get_dataloader
         calib_dataloader = get_dataloader(config.tokenizer,
-                                    config.calib_len,
+                                    seqlen=config.calib_len,
                                     dataset_name=config.dataset,
                                     seed=42,
                                     bs=8,
@@ -523,7 +523,7 @@ def convert_to_quantized_model(model, config, device="cpu"):
             recipes = {
                 "autoround_args": {
                     "n_samples": config.nsamples,
-                    "seq_len": config.calib_len,
+                    "seqlen": config.calib_len,
                     "iters": config.calib_iters,
                     "scale_dtype": config.scale_dtype,
                     "enable_quanted_input": config.enable_quanted_input,

--- a/intel_extension_for_transformers/transformers/llm/quantization/utils.py
+++ b/intel_extension_for_transformers/transformers/llm/quantization/utils.py
@@ -388,7 +388,7 @@ def convert_to_quantized_model(model, config, device="cpu"):
     model_device = next(model.parameters()).device
 
     if config.quant_method.value == "autoround":
-        from auto_round.calib_dataset import get_dataloader
+        from neural_compressor.adaptor.torch_utils.auto_round import get_dataloader
         calib_dataloader = get_dataloader(config.tokenizer,
                                     seqlen=config.calib_len,
                                     dataset_name=config.dataset,

--- a/intel_extension_for_transformers/transformers/utils/config.py
+++ b/intel_extension_for_transformers/transformers/utils/config.py
@@ -1054,8 +1054,8 @@ class AutoRoundConfig(ITREXQuantizationConfigMixin):
         sym: bool = True,
         lr: float = 0.0025,
         minmax_lr: float = 0.0025,
-        use_quant_input: bool = True,
-        nsamples: int = 128,
+        enable_quanted_input: bool = True,
+        nsamples: int = 512,
         iters: int = 200,
         use_ggml: bool = False,
         use_neural_speed: bool = False,
@@ -1081,7 +1081,7 @@ class AutoRoundConfig(ITREXQuantizationConfigMixin):
         self.group_size = group_size
         self.lr = lr
         self.minmax_lr = minmax_lr
-        self.use_quant_input = use_quant_input
+        self.enable_quanted_input = enable_quanted_input
         self.iters = iters
         self.llm_int8_skip_modules = (
             llm_int8_skip_modules if llm_int8_skip_modules else []

--- a/intel_extension_for_transformers/transformers/utils/config.py
+++ b/intel_extension_for_transformers/transformers/utils/config.py
@@ -1042,18 +1042,18 @@ class TeqConfig(ITREXQuantizationConfigMixin):
 class AutoRoundConfig(ITREXQuantizationConfigMixin):
     def __init__(
         self,
-        bits: int = 8,
+        bits: int = 4,
         tokenizer: Any = None,
         dataset: str = "NeelNanda/pile-10k",
-        group_size: int = 32,
+        group_size: int = 128,
         compute_dtype: Any = None,
         weight_dtype: Any = None,
         scale_dtype: Any = None,
         use_double_quant=False,
         double_quant_scale_dtype=None,  # reserve for double quant
-        sym: bool = True,
-        lr: float = 0.0025,
-        minmax_lr: float = 0.0025,
+        sym: bool = False,
+        lr: float = None,
+        minmax_lr: float = None,
         enable_quanted_input: bool = True,
         nsamples: int = 512,
         iters: int = 200,
@@ -1090,7 +1090,7 @@ class AutoRoundConfig(ITREXQuantizationConfigMixin):
         self.use_neural_speed = use_neural_speed
         self.device = kwargs.get("device", "auto")
         self.calib_dataloader = kwargs.get("calib_dataloader", None)
-        self.calib_len = kwargs.get("calib_len", None)
+        self.calib_len = kwargs.get("calib_len", 2048)
         self.calib_func = kwargs.get("calib_func", None)
         self.calib_iters = kwargs.get("calib_iters", 100)
         self.scheme = "sym" if self.sym else "asym"

--- a/tests/CI/test_quantization.py
+++ b/tests/CI/test_quantization.py
@@ -518,7 +518,7 @@ class TestQuantization(unittest.TestCase):
         woq_model.eval()
         output = woq_model(dummy_input)
         if CpuInfo().bf16:
-            self.assertTrue(isclose(float(output[0][0][0][0]), 0.1709238588809967, rel_tol=1e-04))
+            self.assertTrue(isclose(float(output[0][0][0][0]), 0.171875, rel_tol=1e-04))
 
     def test_export(self):
         # test model with model_id

--- a/tests/CI/test_quantization.py
+++ b/tests/CI/test_quantization.py
@@ -508,7 +508,7 @@ class TestQuantization(unittest.TestCase):
                                     weight_dtype="int4_clip",
                                      nsamples=128,
                                      calib_len=32,
-                                     calib_iters=5,
+                                     iters=5,
                                      tokenizer=tokenizer
                                         )
         woq_model = AutoModelForCausalLM.from_pretrained(model_name_or_path,

--- a/tests/CI/test_quantization.py
+++ b/tests/CI/test_quantization.py
@@ -518,7 +518,7 @@ class TestQuantization(unittest.TestCase):
         woq_model.eval()
         output = woq_model(dummy_input)
         if CpuInfo().bf16:
-            self.assertTrue(isclose(float(output[0][0][0][0]), 0.171875, rel_tol=1e-04))
+            self.assertTrue(isclose(float(output[0][0][0][0]), 0.169921875, rel_tol=1e-04))
 
     def test_export(self):
         # test model with model_id

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,12 +1,12 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 accelerate
 auto-gptq
-auto-round
 bitsandbytes
 datasets==2.16.1
 einops
 evaluate
 gguf
+git+https://github.com/intel/auto-round.git@ecca5349981044e1278773a251b3fc5c0a11fe7b
 git+https://github.com/intel/neural-compressor.git
 git+https://github.com/intel/neural-speed.git
 intel-extension-for-pytorch==2.3.0


### PR DESCRIPTION
## Type of Change

```
external change:
autoroundconfig parameter, use_quant_input  -->  enable_quanted_input

internal change:
seq_len --> seqlen
autoround use autoround package get dataloader, not used with itrex bulit-in
```
please validate base the following message, @XuehaoSun 
INC PR: https://github.com/intel/neural-compressor/pull/1806
AutoRound main branch: https://github.com/intel/auto-round

## Description

detail description 
JIRA ticket: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
