### PR TITLE
Add a dependency for  Neural_chat on CPU device

### DIFF
--- a/intel_extension_for_transformers/neural_chat/requirements_cpu.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements_cpu.txt
@@ -1,3 +1,4 @@
+--extra-index-url https://pytorch-extension.intel.com/release-whl/stable/cpu/us/
 accelerate==0.28.0
 cchardet
 einops
@@ -10,6 +11,7 @@ lm-eval
 neural-compressor
 neural_speed==1.0a0
 numpy==1.23.5
+oneccl_bind_pt
 optimum
 optimum-intel
 peft==0.6.2
@@ -27,5 +29,3 @@ transformers>=4.35.2
 transformers_stream_generator
 uvicorn
 yacs
---extra-index-url https://pytorch-extension.intel.com/release-whl/stable/cpu/us/
-oneccl_bind_pt

--- a/intel_extension_for_transformers/neural_chat/requirements_cpu.txt
+++ b/intel_extension_for_transformers/neural_chat/requirements_cpu.txt
@@ -27,3 +27,5 @@ transformers>=4.35.2
 transformers_stream_generator
 uvicorn
 yacs
+--extra-index-url https://pytorch-extension.intel.com/release-whl/stable/cpu/us/
+oneccl_bind_pt


### PR DESCRIPTION
## Type of Change

bug fix
No API changed

## Description

Add a dependency "oneccl_bind_pt" for  Neural_chat on CPU device
Issue report:
https://github.com/intel/intel-extension-for-transformers/issues/1574

## Expected Behavior & Potential Risk

Run Neural_chat on the CPU device successfully with IPEX.

## How has this PR been tested?

Local tested