### PR TITLE
improve lm_eval get chatglm2 tokenizer from local saved files

### DIFF
--- a/intel_extension_for_transformers/transformers/llm/evaluation/lm_eval/models/huggingface.py
+++ b/intel_extension_for_transformers/transformers/llm/evaluation/lm_eval/models/huggingface.py
@@ -838,12 +838,20 @@ class HFLM(TemplateLM):
             else:
                 # get the HF hub name via accessor on model
                 model_name = self.model.name_or_path
-            self.tokenizer = transformers.AutoTokenizer.from_pretrained(
-                model_name,
-                revision=revision,
-                trust_remote_code=trust_remote_code,
-                use_fast=use_fast_tokenizer,
-            )
+
+            # chatglm2 tokenizer doesn't support loading from local.
+            if  hasattr(self.model, "config") and hasattr(self.model.config, "auto_map") and \
+                "chatglm2" in self.model.config.auto_map["AutoConfig"]:
+                self.tokenizer = transformers.AutoTokenizer.from_pretrained(
+                    "THUDM/chatglm2-6b", trust_remote_code=True
+                    )
+            else:
+                self.tokenizer = transformers.AutoTokenizer.from_pretrained(
+                    model_name,
+                    revision=revision,
+                    trust_remote_code=trust_remote_code,
+                    use_fast=use_fast_tokenizer,
+                )
         return None
 
     def _detect_batch_size(self, requests=None, pos: int = 0):


### PR DESCRIPTION
## Type of Change
ticket https://jira.devtools.intel.com/browse/NLPTOOLKIU-1383
improve the tokenizer loading like the following code.
```
    tokenizer = AutoTokenizer.from_pretrained(
        "THUDM/chatglm2-6b", trust_remote_code=args.trust_remote_code
    )
    # save
    tokenizer.saved_pretrained("saved_results")
```
```
# load tokenizer
    tokenizer = AutoTokenizer.from_pretrained(
        args.model, trust_remote_code=args.trust_remote_code
    )
```
if args.model == "THUDM/chatglm2-6b", it works.
if args.model == "saved_results", it fails.

## Description

detail description 
JIRA ticket: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
