### PR TITLE
disable qbits lib import when using gpu version itrex

### DIFF
--- a/intel_extension_for_transformers/qbits/__init__.py
+++ b/intel_extension_for_transformers/qbits/__init__.py
@@ -16,4 +16,5 @@
 # limitations under the License.
 
 import torch
-from intel_extension_for_transformers.qbits_py import * # pylint: disable=E0401, E0611
+if not torch.xpu._is_compiled():
+    from intel_extension_for_transformers.qbits_py import * # pylint: disable=E0401, E0611


### PR DESCRIPTION
## Type of Change

feature or bug fix or documentation or others: bug fix
API changed or not: no

## Description

detail description 

GPU version itrex will not build qbits.so but try to import it in qbits/__init__.py, this pr target to fix this bug.

JIRA ticket: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed: NO
