### PR TITLE
limit setuptools version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 py-cpuinfo
-setuptools>=65
+setuptools==69.5.1
 setuptools_scm[toml]>=6.2


### PR DESCRIPTION
## Type of Change

set setuptools==69.5.1

## Description

To avoid `ImportError: cannot import name 'packaging' from 'pkg_resources'` when use setuptools>=70

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
