### PR TITLE
Fix typo at README.md

### DIFF
--- a/examples/huggingface/tensorflow/language-modeling/quantization/README.md
+++ b/examples/huggingface/tensorflow/language-modeling/quantization/README.md
@@ -31,7 +31,7 @@ pip install -r requirements.txt
 
 ```
 cd ptq
-bash run_tuning.sh  --topology=[topology]
+bash run_tuning.sh --topology=[topology]
 ```
 
 * To benchmark the int8 model
@@ -52,7 +52,7 @@ bash run_benchmark.sh --topology=[topology] --mode=benchmark --int8=true
 
 ```
 cd ptq
-bash run_tuning.sh  --topology=[topology]
+bash run_tuning.sh --topology=[topology]
 ```
 
 * To benchmark the int8 model


### PR DESCRIPTION
## Type of Change

Typo

## Description

Removed an extra space from two shell commands examples

## Expected Behavior & Potential Risk

Not applicable

## How has this PR been tested?

Not applicable

## Dependency Change?

Not applicable
