### PR TITLE
fix xpu version itrex detect

### DIFF
--- a/.github/workflows/script/install_binary.sh
+++ b/.github/workflows/script/install_binary.sh
@@ -4,6 +4,7 @@ source /intel-extension-for-transformers/.github/workflows/script/change_color.s
 cd /intel-extension-for-transformers
 export CMAKE_ARGS="-DNE_DNNL_CACHE_DIR=/cache"
 pip install -U pip
+pip install -r requirements.txt
 $BOLD_YELLOW && echo "---------------- git submodule update --init --recursive -------------" && $RESET
 git config --global --add safe.directory "*"
 git submodule update --init --recursive

--- a/.github/workflows/script/unitTest/env_setup.sh
+++ b/.github/workflows/script/unitTest/env_setup.sh
@@ -1,4 +1,5 @@
 pip list
+pip install setuptools==69.5.1
 
 inc=$(pip list | grep -c 'neural-compressor') || true # Prevent from exiting when 'inc' not found
 if [ ${inc} != 0 ]; then

--- a/.github/workflows/script/unitTest/env_setup.sh
+++ b/.github/workflows/script/unitTest/env_setup.sh
@@ -1,5 +1,4 @@
 pip list
-pip install setuptools==69.5.1
 
 inc=$(pip list | grep -c 'neural-compressor') || true # Prevent from exiting when 'inc' not found
 if [ ${inc} != 0 ]; then

--- a/intel_extension_for_transformers/qbits/__init__.py
+++ b/intel_extension_for_transformers/qbits/__init__.py
@@ -17,5 +17,5 @@
 
 import torch
 import intel_extension_for_transformers
-if "gpu" in intel_extension_for_transformers.__version__:
+if "gpu" not in intel_extension_for_transformers.__version__:
     from intel_extension_for_transformers.qbits_py import *  # pylint: disable=E0401, E0611

--- a/intel_extension_for_transformers/qbits/__init__.py
+++ b/intel_extension_for_transformers/qbits/__init__.py
@@ -16,5 +16,6 @@
 # limitations under the License.
 
 import torch
-if not torch.xpu._is_compiled():
-    from intel_extension_for_transformers.qbits_py import * # pylint: disable=E0401, E0611
+import intel_extension_for_transformers
+if "gpu" in intel_extension_for_transformers.__version__:
+    from intel_extension_for_transformers.qbits_py import *  # pylint: disable=E0401, E0611

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,11 @@ from io import open
 from pathlib import Path
 from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext
+from setuptools_scm import get_version
 
 result = subprocess.Popen("pip install -r requirements.txt", shell=True)
 result.wait()
+
 
 def is_intel_gpu_available():
     import torch
@@ -286,6 +288,9 @@ if __name__ == '__main__':
                            "intel_extension_for_transformers/transformers/runtime/"),
         ])
     cmdclass = {'build_ext': CMakeBuild}
+    itrex_version = get_version()
+    if IS_INTEL_GPU:
+        itrex_version = itrex_version + "-gpu"
 
     setup(
         name="intel-extension-for-transformers",
@@ -324,4 +329,5 @@ if __name__ == '__main__':
         ],
         setup_requires=['setuptools_scm'],
         use_scm_version=True,
+        version=itrex_version
     )


### PR DESCRIPTION
## Type of Change

feature or bug fix or documentation or others: bug fix
API changed or not: no

## Description

detail description 
JIRA ticket: https://jira.devtools.intel.com/browse/NLPTOOLKIU-1399
as there is no `xpu._is_compiled()` function in 2.2.0 torch, append GPU postfix to `itrex.__version__`  for multi-torch-version xpu available checking. 

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR: xpu detection works well on multi-version torch

## How has this PR been tested?

how to reproduce the test (including hardware information) 64-core emr

## Dependency Change?

any library dependency introduced or removed: no
