### PR TITLE
Fix Qwen neural speed

### DIFF
--- a/examples/huggingface/neural_speed/requirements.txt
+++ b/examples/huggingface/neural_speed/requirements.txt
@@ -1,12 +1,11 @@
 intel_extension_for_transformers
 neural-speed
-lm-eval
+lm-eval==0.4.2
 sentencepiece
 gguf
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==2.3.0+cpu
 transformers
-intel_extension_for_pytorch==2.3.0
 tiktoken
 transformers_stream_generator
 zipfile38


### PR DESCRIPTION
## Type of Change

bug fix
https://jira.devtools.intel.com/browse/NLPTOOLKIU-1400
neuralspeed doesn't depend on ipex and ipex changed qwen model behavior, so remove it.

## Description

detail description 
JIRA ticket: xxx

## Expected Behavior & Potential Risk

the expected behavior that triggered by this PR 

## How has this PR been tested?

how to reproduce the test (including hardware information)

## Dependency Change?

any library dependency introduced or removed
