### PR TITLE
Fix args.tasks type check issue

### DIFF
--- a/intel_extension_for_transformers/transformers/llm/evaluation/lm_eval/accuracy.py
+++ b/intel_extension_for_transformers/transformers/llm/evaluation/lm_eval/accuracy.py
@@ -89,7 +89,7 @@ def cli_evaluate(args) -> None:
     if args.tasks is None:
         eval_logger.error("Need to specify task to evaluate.")
         sys.exit()
-    elif args.tasks == "list":
+    elif isinstance(args.tasks, list):
         eval_logger.info(
             "Available Tasks:\n - {}".format("\n - ".join(task_manager.all_tasks))
         )


### PR DESCRIPTION
## Type of Change

bug fix


## Description
I believe that `elif args.tasks == "list":` here is a confusing typographical error, and it was originally intended to check if `args.tasks` is list type.

## Expected Behavior & Potential Risk

None

## How has this PR been tested?

None

## Dependency Change?

None
